### PR TITLE
Add structured data health report

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,6 +647,7 @@ projects/
                                           #   anchor analysis, page_link_counts
       external_links.json                 # outbound profile, broken links
       linkbuilding.json                   # site-level link health, anchor audit, anchor scatter
+      structured_data.json                # schema.org JSON-LD coverage, validity, type mix
       header_analysis.json                # H1-H6 structure, drifty headers, keyword freq
       header_scatter.json                 # header UMAP coordinates
       paragraph_clusters.json             # paragraph topic clusters

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,11 @@ dependencies = [
   "umap-learn>=0.5.5",
 ]
 
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.0.0",
+]
+
 [project.urls]
 Homepage = "https://github.com/vzeman/site-audit"
 Source   = "https://github.com/vzeman/site-audit"

--- a/site_audit/compare.py
+++ b/site_audit/compare.py
@@ -44,6 +44,7 @@ class _Project:
     external_links: dict
     linkbuilding: dict
     header_analysis: dict
+    structured_data: dict
     embeddings: Optional[np.ndarray]    # aligned with pages
     embedded_pages: list[dict]          # subset of pages that have an embedding
 
@@ -93,6 +94,7 @@ def _load_project(domain: str, projects_root: Path) -> Optional[_Project]:
     external_links = _load_json(report / "external_links.json", {})
     linkbuilding = _load_json(report / "linkbuilding.json", {})
     header_analysis = _load_json(report / "header_analysis.json", {})
+    structured_data = _load_json(report / "structured_data.json", {})
 
     page_link_counts = (linkgraph.get("page_link_counts") or []) if isinstance(linkgraph, dict) else []
     model = metrics.get("model", "Alibaba-NLP/gte-multilingual-base")
@@ -120,6 +122,7 @@ def _load_project(domain: str, projects_root: Path) -> Optional[_Project]:
         external_links=external_links,
         linkbuilding=linkbuilding,
         header_analysis=header_analysis,
+        structured_data=structured_data,
         embeddings=embed_array,
         embedded_pages=embedded_pages,
     )
@@ -224,6 +227,7 @@ def _leaderboard_row(proj: _Project) -> dict:
     ext_summary = (proj.external_links or {}).get("citation_density_summary", {}) or {}
     lb = (proj.linkbuilding or {}).get("summary", {}) or {}
     ha = (proj.header_analysis or {}).get("summary", {}) or {}
+    sd = (proj.structured_data or {}).get("summary", {}) or {}
 
     n_pages = len(proj.page_link_counts) or m.get("page_count") or len(proj.pages) or 0
     orphan_share = (sum(1 for r in proj.page_link_counts if r.get("in_degree") == 0) / n_pages) if n_pages else 0.0
@@ -255,6 +259,10 @@ def _leaderboard_row(proj: _Project) -> dict:
         "zero_link_paragraph_share": float(pd_summary.get("zero_link_share", 0.0)),
         # External citation
         "citation_density_median": float(ext_summary.get("median", 0.0)),
+        "schema_coverage": float(sd.get("schema_coverage", 0.0)),
+        "invalid_jsonld_blocks": int(sd.get("invalid_jsonld_blocks", 0)),
+        "schema_type_count": int(sd.get("schema_type_count", 0)),
+        "pages_missing_schema": int(sd.get("pages_missing_schema", 0)),
         # Action plan
         "recommendations_total": int((proj.recommendations or {}).get("total", 0)),
         "rec_high": int(rec_pri.get("high", 0)),

--- a/site_audit/extractor.py
+++ b/site_audit/extractor.py
@@ -48,6 +48,7 @@ class ExtractedPage:
     list_count: int = 0
     table_count: int = 0
     schema_types: list[str] = field(default_factory=list)  # JSON-LD @type values
+    schema_blocks: list[dict] = field(default_factory=list)  # parsed JSON-LD diagnostics
     external_link_count: int = 0
     has_dates: bool = False
     stat_count: int = 0  # numbers with units / percentages
@@ -172,33 +173,73 @@ def _extract_paragraphs(
     return blocks, counts
 
 
-def _extract_schema_types(soup: BeautifulSoup) -> list[str]:
+def _schema_type_values(value) -> list[str]:
+    if isinstance(value, list):
+        return [str(x) for x in value if x]
+    if value:
+        return [str(value)]
+    return []
+
+
+def _schema_types_from_item(item) -> list[str]:
     types: list[str] = []
+    if isinstance(item, dict):
+        types.extend(_schema_type_values(item.get("@type")))
+        graph = item.get("@graph")
+        if isinstance(graph, list):
+            for graph_item in graph:
+                types.extend(_schema_types_from_item(graph_item))
+    elif isinstance(item, list):
+        for child in item:
+            types.extend(_schema_types_from_item(child))
+    return types
+
+
+def _schema_keys_from_item(item) -> list[str]:
+    keys: set[str] = set()
+    if isinstance(item, dict):
+        keys.update(str(k) for k in item.keys())
+        graph = item.get("@graph")
+        if isinstance(graph, list):
+            for graph_item in graph:
+                keys.update(_schema_keys_from_item(graph_item))
+    elif isinstance(item, list):
+        for child in item:
+            keys.update(_schema_keys_from_item(child))
+    return sorted(keys)
+
+
+def _extract_schema_data(soup: BeautifulSoup) -> tuple[list[str], list[dict]]:
+    types: list[str] = []
+    blocks: list[dict] = []
     for tag in soup.find_all("script", attrs={"type": "application/ld+json"}):
         raw = tag.string or tag.get_text() or ""
         if not raw.strip():
             continue
         try:
             data = json.loads(raw)
-        except Exception:
-            # malformed JSON-LD blocks are common; ignore them
+        except Exception as exc:
+            blocks.append({
+                "format": "json-ld",
+                "valid": False,
+                "types": [],
+                "error": str(exc),
+            })
             continue
-        for item in (data if isinstance(data, list) else [data]):
-            if isinstance(item, dict):
-                t = item.get("@type")
-                if isinstance(t, list):
-                    types.extend(str(x) for x in t)
-                elif t:
-                    types.append(str(t))
-                graph = item.get("@graph")
-                if isinstance(graph, list):
-                    for g in graph:
-                        if isinstance(g, dict):
-                            t = g.get("@type")
-                            if isinstance(t, list):
-                                types.extend(str(x) for x in t)
-                            elif t:
-                                types.append(str(t))
+        block_types = _schema_types_from_item(data)
+        types.extend(block_types)
+        blocks.append({
+            "format": "json-ld",
+            "valid": True,
+            "types": sorted(set(block_types)),
+            "keys": _schema_keys_from_item(data),
+            "error": "",
+        })
+    return sorted(set(types)), blocks
+
+
+def _extract_schema_types(soup: BeautifulSoup) -> list[str]:
+    types, _ = _extract_schema_data(soup)
     return types
 
 
@@ -423,7 +464,7 @@ def extract(
     h1, headings, headers_rich, h1_count = _extract_headings(soup)
     list_count = len(soup.find_all(["ul", "ol"]))
     table_count = len(soup.find_all("table"))
-    schema_types = _extract_schema_types(soup)
+    schema_types, schema_blocks = _extract_schema_data(soup)
     external_link_count = _count_external_links(soup, url)
     has_dates = bool(_DATE_RE.search(body_text))
     stat_count = len(_STAT_RE.findall(body_text))
@@ -444,6 +485,7 @@ def extract(
         list_count=list_count,
         table_count=table_count,
         schema_types=schema_types,
+        schema_blocks=schema_blocks,
         external_link_count=external_link_count,
         has_dates=has_dates,
         stat_count=stat_count,

--- a/site_audit/html_report.py
+++ b/site_audit/html_report.py
@@ -42,6 +42,7 @@ _PLACEHOLDERS = {
     "__HEADER_ANALYSIS_JSON__": "header_analysis",
     "__HEADER_SCATTER_JSON__": "header_scatter",
     "__LINKBUILDING_JSON__": "linkbuilding",
+    "__STRUCTURED_DATA_JSON__": "structured_data",
 }
 
 
@@ -230,6 +231,7 @@ def write_html_report(
     header_analysis: Optional[dict] = None,
     header_scatter: Optional[dict] = None,
     linkbuilding: Optional[dict] = None,
+    structured_data: Optional[dict] = None,
 ) -> Path:
     template = template_path.read_text(encoding="utf-8")
 
@@ -258,6 +260,7 @@ def write_html_report(
         "header_analysis": header_analysis or {},
         "header_scatter": header_scatter or {},
         "linkbuilding": linkbuilding or {},
+        "structured_data": structured_data or {},
     }
 
     rendered = template

--- a/site_audit/pipeline.py
+++ b/site_audit/pipeline.py
@@ -77,6 +77,8 @@ from .recommendations import synthesize as synthesize_recommendations
 from .recommendations import to_payload as recommendations_payload
 from .report import build_duplicate_rows, build_outlier_rows, write_all
 from .scatter import project
+from .structured_data import analyze as analyze_structured_data
+from .structured_data import to_payload as structured_data_payload
 
 LOG = logging.getLogger(__name__)
 
@@ -292,6 +294,15 @@ def run(config: PipelineConfig) -> dict:
     if config.enable_answerability:
         ans_payload = answerability_payload(score_answerability(extracted_pages))
         LOG.info("  scored %d pages for answerability", len(ans_payload))
+
+    structured_data_data = structured_data_payload(analyze_structured_data(extracted_pages))
+    sd_summary = structured_data_data.get("summary", {}) or {}
+    LOG.info(
+        "  structured data: %.0f%% coverage · %d invalid JSON-LD blocks · %d schema types",
+        (sd_summary.get("schema_coverage", 0.0) or 0.0) * 100,
+        sd_summary.get("invalid_jsonld_blocks", 0),
+        sd_summary.get("schema_type_count", 0),
+    )
 
     # 9) Link graph + recommendations
     link_payload: dict = {}
@@ -611,6 +622,7 @@ def run(config: PipelineConfig) -> dict:
         header_analysis=header_analysis_data,
         header_scatter=header_scatter_data,
         linkbuilding=linkbuilding_data,
+        structured_data=structured_data_data,
     )
 
     template_path = Path(__file__).resolve().parent.parent / "ui" / "index.html"
@@ -643,6 +655,7 @@ def run(config: PipelineConfig) -> dict:
             header_analysis=header_analysis_data,
             header_scatter=header_scatter_data,
             linkbuilding=linkbuilding_data,
+            structured_data=structured_data_data,
         )
         LOG.info("  HTML report: %s", html_path)
 

--- a/site_audit/report.py
+++ b/site_audit/report.py
@@ -291,6 +291,7 @@ def write_all(
     header_analysis: Optional[dict] = None,
     header_scatter: Optional[dict] = None,
     linkbuilding: Optional[dict] = None,
+    structured_data: Optional[dict] = None,
 ) -> dict:
     output_dir.mkdir(parents=True, exist_ok=True)
     write_site_metrics(output_dir / "site_metrics.json", result, model_name, domain)
@@ -338,4 +339,6 @@ def write_all(
         _write_json(output_dir / "header_scatter.json", header_scatter)
     if linkbuilding is not None:
         _write_json(output_dir / "linkbuilding.json", linkbuilding)
+    if structured_data is not None:
+        _write_json(output_dir / "structured_data.json", structured_data)
     return {"outliers": len(outliers), "duplicates": len(result.duplicate_pairs)}

--- a/site_audit/structured_data.py
+++ b/site_audit/structured_data.py
@@ -1,0 +1,143 @@
+"""Structured-data health analysis.
+
+The extractor keeps lightweight JSON-LD diagnostics per page. This module
+turns those page-level signals into a report payload and comparison metrics:
+coverage, invalid blocks, type mix, and common missing recommended fields.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from typing import Iterable
+
+from .extractor import ExtractedPage
+
+
+_RECOMMENDED_PROPS: dict[str, set[str]] = {
+    "Article": {"headline", "datePublished", "author"},
+    "NewsArticle": {"headline", "datePublished", "author"},
+    "BlogPosting": {"headline", "datePublished", "author"},
+    "FAQPage": {"mainEntity"},
+    "QAPage": {"mainEntity"},
+    "HowTo": {"name", "step"},
+    "Product": {"name"},
+    "Organization": {"name", "url"},
+    "LocalBusiness": {"name", "address"},
+    "BreadcrumbList": {"itemListElement"},
+    "VideoObject": {"name", "uploadDate"},
+}
+
+
+@dataclass
+class StructuredDataReport:
+    summary: dict
+    top_types: list[dict]
+    invalid_blocks: list[dict]
+    missing_recommended: list[dict]
+    per_page: list[dict]
+
+
+def _top_level_keys(block: dict) -> set[str]:
+    if not isinstance(block, dict):
+        return set()
+    return set(block.get("keys") or [])
+
+
+def _missing_recommended(types: list[str], keys: set[str]) -> list[dict]:
+    missing: list[dict] = []
+    for schema_type in types:
+        wanted = _RECOMMENDED_PROPS.get(schema_type)
+        if not wanted:
+            continue
+        absent = sorted(prop for prop in wanted if prop not in keys)
+        if absent:
+            missing.append({"type": schema_type, "missing": absent})
+    return missing
+
+
+def analyze(pages: Iterable[ExtractedPage]) -> StructuredDataReport:
+    page_list = list(pages)
+    type_counts: Counter[str] = Counter()
+    invalid_blocks: list[dict] = []
+    missing_rows: list[dict] = []
+    per_page: list[dict] = []
+    pages_with_schema = 0
+    pages_with_invalid = 0
+    valid_blocks = 0
+    invalid_count = 0
+
+    for page in page_list:
+        blocks = list(page.schema_blocks or [])
+        types = sorted(set(page.schema_types or []))
+        valid_page_blocks = [block for block in blocks if block.get("valid")]
+        invalid_page_blocks = [block for block in blocks if not block.get("valid")]
+        if types or valid_page_blocks:
+            pages_with_schema += 1
+        if invalid_page_blocks:
+            pages_with_invalid += 1
+        valid_blocks += len(valid_page_blocks)
+        invalid_count += len(invalid_page_blocks)
+        type_counts.update(types)
+
+        keys: set[str] = set()
+        for block in valid_page_blocks:
+            keys.update(_top_level_keys(block))
+        missing = _missing_recommended(types, keys)
+        if missing:
+            missing_rows.append({
+                "url": page.url,
+                "title": page.title,
+                "types": types,
+                "missing": missing,
+            })
+        for block in invalid_page_blocks:
+            invalid_blocks.append({
+                "url": page.url,
+                "title": page.title,
+                "format": block.get("format", "json-ld"),
+                "error": block.get("error", ""),
+            })
+
+        per_page.append({
+            "url": page.url,
+            "title": page.title,
+            "types": types,
+            "valid_blocks": len(valid_page_blocks),
+            "invalid_blocks": len(invalid_page_blocks),
+            "missing_recommended": missing,
+        })
+
+    total_pages = len(page_list)
+    summary = {
+        "total_pages": total_pages,
+        "pages_with_schema": pages_with_schema,
+        "schema_coverage": pages_with_schema / total_pages if total_pages else 0.0,
+        "valid_jsonld_blocks": valid_blocks,
+        "invalid_jsonld_blocks": invalid_count,
+        "pages_with_invalid_jsonld": pages_with_invalid,
+        "schema_type_count": len(type_counts),
+        "pages_missing_schema": max(0, total_pages - pages_with_schema),
+    }
+    top_types = [
+        {"type": schema_type, "pages": count}
+        for schema_type, count in type_counts.most_common()
+    ]
+    per_page.sort(key=lambda row: (-row["invalid_blocks"], not row["missing_recommended"], row["url"]))
+    return StructuredDataReport(
+        summary=summary,
+        top_types=top_types,
+        invalid_blocks=invalid_blocks[:200],
+        missing_recommended=missing_rows[:200],
+        per_page=per_page,
+    )
+
+
+def to_payload(report: StructuredDataReport) -> dict:
+    return {
+        "summary": report.summary,
+        "top_types": report.top_types,
+        "invalid_blocks": report.invalid_blocks,
+        "missing_recommended": report.missing_recommended,
+        "per_page": report.per_page,
+    }

--- a/tests/test_structured_data.py
+++ b/tests/test_structured_data.py
@@ -1,0 +1,120 @@
+from pathlib import Path
+
+from site_audit.compare import build_payload
+from site_audit.extractor import ExtractedPage, extract
+from site_audit.structured_data import analyze, to_payload
+
+
+def _page(url: str, schema_types=None, schema_blocks=None) -> ExtractedPage:
+    return ExtractedPage(
+        url=url,
+        title=url.rsplit("/", 1)[-1] or "Home",
+        description="",
+        body="Useful content for testing structured data.",
+        word_count=120,
+        language="en",
+        schema_types=schema_types or [],
+        schema_blocks=schema_blocks or [],
+    )
+
+
+def test_extract_jsonld_blocks_with_graph_and_invalid_json() -> None:
+    html = """
+    <html><head>
+      <title>Schema test</title>
+      <script type="application/ld+json">
+        {"@context":"https://schema.org","@graph":[
+          {"@type":"Organization","name":"Acme","url":"https://example.com"},
+          {"@type":["FAQPage","WebPage"],"mainEntity":[]}
+        ]}
+      </script>
+      <script type="application/ld+json">{"@type":"Article",</script>
+    </head><body>
+      <h1>Schema test</h1>
+      <p>This page has enough body copy for the extractor fallback to keep it.
+      It discusses structured data, JSON LD, organizations, questions, and
+      search result eligibility in enough detail to pass the minimum body
+      threshold used by the audit extractor during tests.</p>
+    </body></html>
+    """
+
+    page = extract("https://example.com/schema", html, max_chars=2000)
+
+    assert page is not None
+    assert page.schema_types == ["FAQPage", "Organization", "WebPage"]
+    assert len(page.schema_blocks) == 2
+    assert page.schema_blocks[0]["valid"] is True
+    assert page.schema_blocks[0]["types"] == ["FAQPage", "Organization", "WebPage"]
+    assert "mainEntity" in page.schema_blocks[0]["keys"]
+    assert page.schema_blocks[1]["valid"] is False
+    assert page.schema_blocks[1]["error"]
+
+
+def test_structured_data_payload_summarizes_coverage_and_missing_properties() -> None:
+    report = to_payload(analyze([
+        _page(
+            "https://example.com/blog/post",
+            schema_types=["Article"],
+            schema_blocks=[{
+                "format": "json-ld",
+                "valid": True,
+                "types": ["Article"],
+                "keys": ["@type", "headline", "datePublished"],
+                "error": "",
+            }],
+        ),
+        _page(
+            "https://example.com/bad",
+            schema_blocks=[{
+                "format": "json-ld",
+                "valid": False,
+                "types": [],
+                "keys": [],
+                "error": "Expecting property name",
+            }],
+        ),
+        _page("https://example.com/no-schema"),
+    ]))
+
+    assert report["summary"]["total_pages"] == 3
+    assert report["summary"]["pages_with_schema"] == 1
+    assert report["summary"]["schema_coverage"] == 1 / 3
+    assert report["summary"]["invalid_jsonld_blocks"] == 1
+    assert report["summary"]["pages_with_invalid_jsonld"] == 1
+    assert report["top_types"] == [{"type": "Article", "pages": 1}]
+    assert report["invalid_blocks"][0]["url"] == "https://example.com/bad"
+    assert report["missing_recommended"][0]["missing"] == [
+        {"type": "Article", "missing": ["author"]}
+    ]
+
+
+def test_compare_leaderboard_includes_structured_data_metrics(tmp_path: Path) -> None:
+    for domain, coverage, invalid in [
+        ("a.example", 0.75, 1),
+        ("b.example", 0.25, 3),
+    ]:
+        report_dir = tmp_path / domain / "report"
+        report_dir.mkdir(parents=True)
+        (report_dir / "site_metrics.json").write_text(
+            '{"domain":"%s","model":"test-model","page_count":4}' % domain,
+            encoding="utf-8",
+        )
+        (report_dir / "pages.json").write_text("[]", encoding="utf-8")
+        (report_dir / "structured_data.json").write_text(
+            (
+                '{"summary":{"schema_coverage":%s,'
+                '"invalid_jsonld_blocks":%d,'
+                '"schema_type_count":2,'
+                '"pages_missing_schema":1}}'
+            ) % (coverage, invalid),
+            encoding="utf-8",
+        )
+
+    payload = build_payload(["a.example", "b.example"], tmp_path)
+
+    rows = {row["domain"]: row for row in payload["leaderboard"]}
+    assert rows["a.example"]["schema_coverage"] == 0.75
+    assert rows["a.example"]["invalid_jsonld_blocks"] == 1
+    assert rows["a.example"]["schema_type_count"] == 2
+    assert rows["b.example"]["schema_coverage"] == 0.25
+    assert rows["b.example"]["invalid_jsonld_blocks"] == 3

--- a/ui/compare.html
+++ b/ui/compare.html
@@ -147,6 +147,9 @@
       { key: 'answerability_p90',     label: 'GEO p90',   better: 'high', fmt: '0.0' },
       { key: 'answerability_below_4_share', label: 'GEO < 4 share', better: 'low', fmt: 'pct' },
       { key: 'citation_density_median', label: 'Citation density', better: 'high', fmt: '0.0' },
+      { key: 'schema_coverage',       label: 'Schema coverage', better: 'high', fmt: 'pct' },
+      { key: 'invalid_jsonld_blocks', label: 'Invalid JSON-LD', better: 'low', fmt: 'int' },
+      { key: 'schema_type_count',     label: 'Schema types', better: 'high', fmt: 'int' },
     ],
     linking: [
       { key: 'pages',             label: 'Pages',        better: 'na',   fmt: 'int' },

--- a/ui/index.html
+++ b/ui/index.html
@@ -337,6 +337,32 @@
       </div>
     </div>
 
+    <!-- Structured data -->
+    <div class="bg-white border border-gray-200 rounded-lg shadow-sm p-5 mb-8" id="structured-data-block">
+      <div class="mb-3">
+        <h3 class="text-lg font-semibold">Structured data health</h3>
+        <p class="text-xs text-gray-500 mt-1">
+          JSON-LD coverage and validity across crawled pages. Invalid blocks are ignored by search engines and answer engines;
+          missing recommended properties make schema less useful even when the type is present.
+        </p>
+      </div>
+      <div id="audit-structured-summary" class="grid sm:grid-cols-3 lg:grid-cols-5 gap-3 text-sm mb-5"></div>
+      <div class="grid lg:grid-cols-3 gap-5 text-xs">
+        <div>
+          <h4 class="font-semibold mb-2">Top schema types</h4>
+          <div id="audit-structured-types" class="max-h-72 overflow-y-auto"></div>
+        </div>
+        <div>
+          <h4 class="font-semibold mb-2">Invalid JSON-LD</h4>
+          <div id="audit-structured-invalid" class="max-h-72 overflow-y-auto"></div>
+        </div>
+        <div>
+          <h4 class="font-semibold mb-2">Missing recommended properties</h4>
+          <div id="audit-structured-missing" class="max-h-72 overflow-y-auto"></div>
+        </div>
+      </div>
+    </div>
+
     <!-- Answerability -->
     <div class="bg-white border border-gray-200 rounded-lg shadow-sm p-5 mb-8" id="answerability-block">
       <div class="mb-3">
@@ -719,6 +745,7 @@
 <script type="application/json" id="data-header-analysis">__HEADER_ANALYSIS_JSON__</script>
 <script type="application/json" id="data-header-scatter">__HEADER_SCATTER_JSON__</script>
 <script type="application/json" id="data-linkbuilding">__LINKBUILDING_JSON__</script>
+<script type="application/json" id="data-structured-data">__STRUCTURED_DATA_JSON__</script>
 <script>
 (function() {
   const basePath = '/data';
@@ -799,8 +826,9 @@
       const inlinedHeaderAnalysis = readInlined('data-header-analysis');
       const inlinedHeaderScatter = readInlined('data-header-scatter');
       const inlinedLinkbuilding = readInlined('data-linkbuilding');
+      const inlinedStructuredData = readInlined('data-structured-data');
 
-      let scatter, metrics, sections, outliers, duplicates, clusters, coverage, answerability, linkgraph, external, paraLinks, clusterOverlap, paraClusters, paraScatter, fanout, titleMismatch, wrongHome, improvement, competitive, recommendations, paraDensity, headerAnalysis, headerScatter, linkbuilding;
+      let scatter, metrics, sections, outliers, duplicates, clusters, coverage, answerability, linkgraph, external, paraLinks, clusterOverlap, paraClusters, paraScatter, fanout, titleMismatch, wrongHome, improvement, competitive, recommendations, paraDensity, headerAnalysis, headerScatter, linkbuilding, structuredData;
       if (inlinedMetrics) {
         scatter = inlinedScatter;
         metrics = inlinedMetrics;
@@ -826,8 +854,9 @@
         headerAnalysis = inlinedHeaderAnalysis || {};
         headerScatter = inlinedHeaderScatter || {};
         linkbuilding = inlinedLinkbuilding || {};
+        structuredData = inlinedStructuredData || {};
       } else {
-        [scatter, metrics, sections, outliers, duplicates, clusters, coverage, answerability, linkgraph, external, paraLinks, clusterOverlap, paraClusters, paraScatter, fanout, titleMismatch, wrongHome, improvement, competitive, recommendations, paraDensity, headerAnalysis, headerScatter, linkbuilding] = await Promise.all([
+        [scatter, metrics, sections, outliers, duplicates, clusters, coverage, answerability, linkgraph, external, paraLinks, clusterOverlap, paraClusters, paraScatter, fanout, titleMismatch, wrongHome, improvement, competitive, recommendations, paraDensity, headerAnalysis, headerScatter, linkbuilding, structuredData] = await Promise.all([
           loadJSON('scatterplot.json').catch(() => null),
           loadJSON('site_metrics.json'),
           loadJSON('section_report.json').catch(() => []),
@@ -852,6 +881,7 @@
           loadJSON('header_analysis.json').catch(() => ({})),
           loadJSON('header_scatter.json').catch(() => ({})),
           loadJSON('linkbuilding.json').catch(() => ({})),
+          loadJSON('structured_data.json').catch(() => ({})),
         ]);
       }
       state.scatter = scatter;
@@ -881,6 +911,7 @@
       state.headerAnalysis = headerAnalysis || {};
       state.headerScatter = headerScatter || {};
       state.linkbuilding = linkbuilding || {};
+      state.structuredData = structuredData || {};
       state.linkCountMode = 'hist';
       document.getElementById('header-domain').textContent =
         `${metrics.domain || ''} · ${metrics.page_count || 0} pages · model ${metrics.model || ''}`;
@@ -900,6 +931,7 @@
       renderTreemap();
       renderHeatmap();
       renderCoverage('all');
+      renderStructuredData();
       renderAnswerability();
       renderLinkgraph();
       renderLinkbuilding();
@@ -1851,6 +1883,53 @@
         </div>`;
     }).join('');
     el.innerHTML = summary + rows;
+  }
+
+  function renderStructuredData() {
+    const block = document.getElementById('structured-data-block');
+    const data = state.structuredData || {};
+    const summary = data.summary || {};
+    if (!summary.total_pages) {
+      block.style.display = 'none';
+      return;
+    }
+    document.getElementById('audit-structured-summary').innerHTML =
+      card('Coverage', `${((summary.schema_coverage || 0) * 100).toFixed(0)}%`,
+        `${summary.pages_with_schema || 0} / ${summary.total_pages || 0} pages have schema`,
+        (summary.schema_coverage || 0) >= 0.7 ? 'text-green-600' : 'text-orange-600') +
+      card('Valid JSON-LD', (summary.valid_jsonld_blocks || 0).toLocaleString(),
+        'parseable structured-data blocks') +
+      card('Invalid JSON-LD', (summary.invalid_jsonld_blocks || 0).toLocaleString(),
+        'blocks search engines will ignore',
+        summary.invalid_jsonld_blocks ? 'text-red-600' : 'text-green-600') +
+      card('Schema types', (summary.schema_type_count || 0).toLocaleString(),
+        'distinct @type values') +
+      card('Missing schema', (summary.pages_missing_schema || 0).toLocaleString(),
+        'pages with no valid schema');
+
+    document.getElementById('audit-structured-types').innerHTML =
+      (data.top_types || []).slice(0, 40).map(r => `
+        <div class="flex justify-between gap-3 border-b border-gray-100 py-1">
+          <span>${escapeHtml(r.type)}</span>
+          <span class="font-mono text-gray-600">${Number(r.pages || 0).toLocaleString()}</span>
+        </div>`).join('') || '<div class="text-gray-500">No schema types found.</div>';
+
+    document.getElementById('audit-structured-invalid').innerHTML =
+      (data.invalid_blocks || []).slice(0, 60).map(r => `
+        <div class="border-b border-gray-100 py-2">
+          <a class="text-blue-600 hover:underline break-all" href="${escapeHtml(r.url)}" target="_blank" rel="noopener">${escapeHtml(r.url)}</a>
+          <div class="text-red-700 mt-1">${escapeHtml(r.error || 'Invalid JSON-LD')}</div>
+        </div>`).join('') || '<div class="text-gray-500">No invalid JSON-LD blocks.</div>';
+
+    document.getElementById('audit-structured-missing').innerHTML =
+      (data.missing_recommended || []).slice(0, 60).map(r => {
+        const bits = (r.missing || []).map(m => `${escapeHtml(m.type)}: ${(m.missing || []).map(escapeHtml).join(', ')}`).join(' · ');
+        return `
+          <div class="border-b border-gray-100 py-2">
+            <a class="text-blue-600 hover:underline break-all" href="${escapeHtml(r.url)}" target="_blank" rel="noopener">${escapeHtml(r.url)}</a>
+            <div class="text-gray-700 mt-1">${bits}</div>
+          </div>`;
+      }).join('') || '<div class="text-gray-500">No recommended schema properties missing.</div>';
   }
 
   function renderLinkgraph() {


### PR DESCRIPTION
## Summary
- closes #1
- add JSON-LD diagnostics to extraction, including invalid block errors and @graph type coverage
- add structured_data.json report payload with coverage, validity, type mix, and missing recommended properties
- surface schema metrics in the domain report and comparison leaderboard
- add pytest dev extra and focused unit tests

## Tests
- ./.venv/bin/python -m pytest
- ./.venv/bin/python -m compileall site_audit