### PR TITLE
Add SERP metadata quality audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,6 +648,7 @@ projects/
       external_links.json                 # outbound profile, broken links
       linkbuilding.json                   # site-level link health, anchor audit, anchor scatter
       structured_data.json                # schema.org JSON-LD coverage, validity, type mix
+      metadata_quality.json               # SERP title/description/canonical/social metadata health
       header_analysis.json                # H1-H6 structure, drifty headers, keyword freq
       header_scatter.json                 # header UMAP coordinates
       paragraph_clusters.json             # paragraph topic clusters

--- a/site_audit/compare.py
+++ b/site_audit/compare.py
@@ -45,6 +45,7 @@ class _Project:
     linkbuilding: dict
     header_analysis: dict
     structured_data: dict
+    metadata_quality: dict
     embeddings: Optional[np.ndarray]    # aligned with pages
     embedded_pages: list[dict]          # subset of pages that have an embedding
 
@@ -95,6 +96,7 @@ def _load_project(domain: str, projects_root: Path) -> Optional[_Project]:
     linkbuilding = _load_json(report / "linkbuilding.json", {})
     header_analysis = _load_json(report / "header_analysis.json", {})
     structured_data = _load_json(report / "structured_data.json", {})
+    metadata_quality = _load_json(report / "metadata_quality.json", {})
 
     page_link_counts = (linkgraph.get("page_link_counts") or []) if isinstance(linkgraph, dict) else []
     model = metrics.get("model", "Alibaba-NLP/gte-multilingual-base")
@@ -123,6 +125,7 @@ def _load_project(domain: str, projects_root: Path) -> Optional[_Project]:
         linkbuilding=linkbuilding,
         header_analysis=header_analysis,
         structured_data=structured_data,
+        metadata_quality=metadata_quality,
         embeddings=embed_array,
         embedded_pages=embedded_pages,
     )
@@ -228,6 +231,7 @@ def _leaderboard_row(proj: _Project) -> dict:
     lb = (proj.linkbuilding or {}).get("summary", {}) or {}
     ha = (proj.header_analysis or {}).get("summary", {}) or {}
     sd = (proj.structured_data or {}).get("summary", {}) or {}
+    mq = (proj.metadata_quality or {}).get("summary", {}) or {}
 
     n_pages = len(proj.page_link_counts) or m.get("page_count") or len(proj.pages) or 0
     orphan_share = (sum(1 for r in proj.page_link_counts if r.get("in_degree") == 0) / n_pages) if n_pages else 0.0
@@ -263,6 +267,11 @@ def _leaderboard_row(proj: _Project) -> dict:
         "invalid_jsonld_blocks": int(sd.get("invalid_jsonld_blocks", 0)),
         "schema_type_count": int(sd.get("schema_type_count", 0)),
         "pages_missing_schema": int(sd.get("pages_missing_schema", 0)),
+        "metadata_issue_share": float(mq.get("issue_share", 0.0)),
+        "missing_description": int(mq.get("missing_description", 0)),
+        "duplicate_title_pages": int(mq.get("duplicate_title_pages", 0)),
+        "missing_canonical": int(mq.get("missing_canonical", 0)),
+        "incomplete_open_graph": int(mq.get("incomplete_open_graph", 0)),
         # Action plan
         "recommendations_total": int((proj.recommendations or {}).get("total", 0)),
         "rec_high": int(rec_pri.get("high", 0)),

--- a/site_audit/extractor.py
+++ b/site_audit/extractor.py
@@ -41,6 +41,14 @@ class ExtractedPage:
     body: str
     word_count: int
     language: Optional[str]
+    canonical_url: str = ""
+    robots_content: str = ""
+    og_title: str = ""
+    og_description: str = ""
+    og_image: str = ""
+    twitter_card: str = ""
+    twitter_title: str = ""
+    twitter_description: str = ""
     headings: list[str] = field(default_factory=list)  # H2 + H3 text, in order (kept for backwards compat)
     h1: str = ""
     h1_count: int = 0                         # number of <h1> elements on the page
@@ -94,6 +102,21 @@ def _title_from_html(soup: BeautifulSoup) -> str:
     if h1:
         return _clean(h1.get_text(" "))
     return ""
+
+
+def _canonical_url(soup: BeautifulSoup) -> str:
+    tag = soup.find("link", rel=lambda value: value and "canonical" in [str(v).lower() for v in (value if isinstance(value, list) else [value])])
+    href = (tag.get("href") or "").strip() if tag else ""
+    return _clean(html.unescape(href))
+
+
+def _robots_content(soup: BeautifulSoup) -> str:
+    values: list[str] = []
+    for tag in soup.find_all("meta"):
+        name = (tag.get("name") or tag.get("http-equiv") or "").strip().lower()
+        if name in _INDEX_BOTS and tag.get("content"):
+            values.append(_clean(html.unescape(tag["content"])))
+    return ", ".join(values)
 
 
 def _strip_to_text(html_body: str) -> str:
@@ -432,6 +455,14 @@ def extract(
     is_noindex, noindex_source = _detect_noindex(soup, x_robots_tag)
     title = _title_from_html(soup)
     description = _meta(soup, "description") or _meta(soup, "og:description")
+    canonical_url = _canonical_url(soup)
+    robots_content = _robots_content(soup)
+    og_title = _meta(soup, "og:title")
+    og_description = _meta(soup, "og:description")
+    og_image = _meta(soup, "og:image")
+    twitter_card = _meta(soup, "twitter:card")
+    twitter_title = _meta(soup, "twitter:title")
+    twitter_description = _meta(soup, "twitter:description")
     lang_attr = soup.find("html")
     language = lang_attr.get("lang") if lang_attr and lang_attr.has_attr("lang") else None
 
@@ -478,6 +509,14 @@ def extract(
         body=truncated,
         word_count=word_count,
         language=language,
+        canonical_url=canonical_url,
+        robots_content=robots_content,
+        og_title=og_title,
+        og_description=og_description,
+        og_image=og_image,
+        twitter_card=twitter_card,
+        twitter_title=twitter_title,
+        twitter_description=twitter_description,
         headings=headings,
         h1=h1,
         h1_count=h1_count,

--- a/site_audit/html_report.py
+++ b/site_audit/html_report.py
@@ -43,6 +43,7 @@ _PLACEHOLDERS = {
     "__HEADER_SCATTER_JSON__": "header_scatter",
     "__LINKBUILDING_JSON__": "linkbuilding",
     "__STRUCTURED_DATA_JSON__": "structured_data",
+    "__METADATA_QUALITY_JSON__": "metadata_quality",
 }
 
 
@@ -232,6 +233,7 @@ def write_html_report(
     header_scatter: Optional[dict] = None,
     linkbuilding: Optional[dict] = None,
     structured_data: Optional[dict] = None,
+    metadata_quality: Optional[dict] = None,
 ) -> Path:
     template = template_path.read_text(encoding="utf-8")
 
@@ -261,6 +263,7 @@ def write_html_report(
         "header_scatter": header_scatter or {},
         "linkbuilding": linkbuilding or {},
         "structured_data": structured_data or {},
+        "metadata_quality": metadata_quality or {},
     }
 
     rendered = template

--- a/site_audit/metadata_quality.py
+++ b/site_audit/metadata_quality.py
@@ -1,0 +1,127 @@
+"""SERP metadata quality analysis."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from typing import Iterable
+from urllib.parse import urlparse
+
+from .extractor import ExtractedPage
+
+
+@dataclass
+class MetadataQualityReport:
+    summary: dict
+    issues_by_type: dict[str, int]
+    per_page: list[dict]
+
+
+def _norm(value: str) -> str:
+    return " ".join((value or "").strip().lower().split())
+
+
+def _same_host(url: str, canonical_url: str) -> bool:
+    if not canonical_url:
+        return True
+    parsed = urlparse(url)
+    canonical = urlparse(canonical_url)
+    if not canonical.netloc:
+        return True
+    left = parsed.netloc.lower().removeprefix("www.")
+    right = canonical.netloc.lower().removeprefix("www.")
+    return left == right
+
+
+def _title_issue(title: str) -> str:
+    length = len(title or "")
+    if length == 0:
+        return "missing_title"
+    if length < 20:
+        return "short_title"
+    if length > 65:
+        return "long_title"
+    return ""
+
+
+def _description_issue(description: str) -> str:
+    length = len(description or "")
+    if length == 0:
+        return "missing_description"
+    if length < 50:
+        return "short_description"
+    if length > 160:
+        return "long_description"
+    return ""
+
+
+def analyze(pages: Iterable[ExtractedPage]) -> MetadataQualityReport:
+    page_list = list(pages)
+    title_counts = Counter(_norm(page.title) for page in page_list if _norm(page.title))
+    desc_counts = Counter(_norm(page.description) for page in page_list if _norm(page.description))
+    issues_by_type: Counter[str] = Counter()
+    rows: list[dict] = []
+
+    for page in page_list:
+        issues: list[str] = []
+        for issue in (_title_issue(page.title), _description_issue(page.description)):
+            if issue:
+                issues.append(issue)
+        if title_counts[_norm(page.title)] > 1:
+            issues.append("duplicate_title")
+        if desc_counts[_norm(page.description)] > 1:
+            issues.append("duplicate_description")
+        if not page.canonical_url:
+            issues.append("missing_canonical")
+        elif not _same_host(page.url, page.canonical_url):
+            issues.append("canonical_external_host")
+        if not page.og_title or not page.og_description:
+            issues.append("incomplete_open_graph")
+        if not page.twitter_card:
+            issues.append("missing_twitter_card")
+        if page.noindex:
+            issues.append("noindex")
+
+        issues_by_type.update(issues)
+        rows.append({
+            "url": page.url,
+            "title": page.title,
+            "title_length": len(page.title or ""),
+            "description": page.description,
+            "description_length": len(page.description or ""),
+            "canonical_url": page.canonical_url,
+            "robots_content": page.robots_content,
+            "og_complete": bool(page.og_title and page.og_description),
+            "twitter_card": page.twitter_card,
+            "issues": issues,
+        })
+
+    total = len(page_list)
+    issue_pages = sum(1 for row in rows if row["issues"])
+    summary = {
+        "total_pages": total,
+        "pages_with_issues": issue_pages,
+        "issue_share": issue_pages / total if total else 0.0,
+        "missing_title": issues_by_type.get("missing_title", 0),
+        "missing_description": issues_by_type.get("missing_description", 0),
+        "duplicate_title_pages": issues_by_type.get("duplicate_title", 0),
+        "duplicate_description_pages": issues_by_type.get("duplicate_description", 0),
+        "missing_canonical": issues_by_type.get("missing_canonical", 0),
+        "canonical_external_host": issues_by_type.get("canonical_external_host", 0),
+        "incomplete_open_graph": issues_by_type.get("incomplete_open_graph", 0),
+        "missing_twitter_card": issues_by_type.get("missing_twitter_card", 0),
+    }
+    rows.sort(key=lambda row: (-len(row["issues"]), row["url"]))
+    return MetadataQualityReport(
+        summary=summary,
+        issues_by_type=dict(issues_by_type),
+        per_page=rows,
+    )
+
+
+def to_payload(report: MetadataQualityReport) -> dict:
+    return {
+        "summary": report.summary,
+        "issues_by_type": report.issues_by_type,
+        "per_page": report.per_page,
+    }

--- a/site_audit/pipeline.py
+++ b/site_audit/pipeline.py
@@ -68,6 +68,8 @@ from .keyword_coverage import (
 )
 from .linkgraph import analyze as analyze_linkgraph
 from .linkgraph import to_payload as linkgraph_payload
+from .metadata_quality import analyze as analyze_metadata_quality
+from .metadata_quality import to_payload as metadata_quality_payload
 from .paragraph_density import compute_rows as compute_paragraph_density_rows
 from .paragraph_density import density_lookup as paragraph_density_lookup
 from .paragraph_density import to_payload as paragraph_density_payload
@@ -302,6 +304,15 @@ def run(config: PipelineConfig) -> dict:
         (sd_summary.get("schema_coverage", 0.0) or 0.0) * 100,
         sd_summary.get("invalid_jsonld_blocks", 0),
         sd_summary.get("schema_type_count", 0),
+    )
+
+    metadata_quality_data = metadata_quality_payload(analyze_metadata_quality(extracted_pages))
+    mq_summary = metadata_quality_data.get("summary", {}) or {}
+    LOG.info(
+        "  metadata quality: %.0f%% pages with issues · %d missing descriptions · %d missing canonicals",
+        (mq_summary.get("issue_share", 0.0) or 0.0) * 100,
+        mq_summary.get("missing_description", 0),
+        mq_summary.get("missing_canonical", 0),
     )
 
     # 9) Link graph + recommendations
@@ -623,6 +634,7 @@ def run(config: PipelineConfig) -> dict:
         header_scatter=header_scatter_data,
         linkbuilding=linkbuilding_data,
         structured_data=structured_data_data,
+        metadata_quality=metadata_quality_data,
     )
 
     template_path = Path(__file__).resolve().parent.parent / "ui" / "index.html"
@@ -656,6 +668,7 @@ def run(config: PipelineConfig) -> dict:
             header_scatter=header_scatter_data,
             linkbuilding=linkbuilding_data,
             structured_data=structured_data_data,
+            metadata_quality=metadata_quality_data,
         )
         LOG.info("  HTML report: %s", html_path)
 

--- a/site_audit/report.py
+++ b/site_audit/report.py
@@ -292,6 +292,7 @@ def write_all(
     header_scatter: Optional[dict] = None,
     linkbuilding: Optional[dict] = None,
     structured_data: Optional[dict] = None,
+    metadata_quality: Optional[dict] = None,
 ) -> dict:
     output_dir.mkdir(parents=True, exist_ok=True)
     write_site_metrics(output_dir / "site_metrics.json", result, model_name, domain)
@@ -341,4 +342,6 @@ def write_all(
         _write_json(output_dir / "linkbuilding.json", linkbuilding)
     if structured_data is not None:
         _write_json(output_dir / "structured_data.json", structured_data)
+    if metadata_quality is not None:
+        _write_json(output_dir / "metadata_quality.json", metadata_quality)
     return {"outliers": len(outliers), "duplicates": len(result.duplicate_pairs)}

--- a/tests/test_metadata_quality.py
+++ b/tests/test_metadata_quality.py
@@ -1,0 +1,116 @@
+from pathlib import Path
+
+from site_audit.compare import build_payload
+from site_audit.extractor import ExtractedPage, extract
+from site_audit.metadata_quality import analyze, to_payload
+
+
+def _page(
+    url: str,
+    title: str = "Useful Search Title",
+    description: str = "This description is long enough to be useful in search results.",
+    canonical_url: str = "https://example.com/page",
+    og_title: str = "OG title",
+    og_description: str = "OG description",
+    twitter_card: str = "summary",
+) -> ExtractedPage:
+    return ExtractedPage(
+        url=url,
+        title=title,
+        description=description,
+        body="Useful content for testing metadata quality.",
+        word_count=120,
+        language="en",
+        canonical_url=canonical_url,
+        og_title=og_title,
+        og_description=og_description,
+        twitter_card=twitter_card,
+    )
+
+
+def test_extract_serp_metadata_fields() -> None:
+    html = """
+    <html><head>
+      <title>Complete metadata example</title>
+      <meta name="description" content="A complete description for search result snippets and previews.">
+      <link rel="canonical" href="https://example.com/canonical">
+      <meta name="robots" content="index,follow">
+      <meta property="og:title" content="Open graph title">
+      <meta property="og:description" content="Open graph description">
+      <meta property="og:image" content="https://example.com/image.png">
+      <meta name="twitter:card" content="summary_large_image">
+      <meta name="twitter:title" content="Twitter title">
+      <meta name="twitter:description" content="Twitter description">
+    </head><body>
+      <h1>Complete metadata example</h1>
+      <p>This page has enough body copy for the extractor fallback to keep it.
+      It discusses titles, descriptions, canonical URLs, robots directives,
+      Open Graph data, and Twitter cards in enough detail to pass the minimum
+      body threshold during extraction tests.</p>
+    </body></html>
+    """
+
+    page = extract("https://example.com/page", html, max_chars=2000)
+
+    assert page is not None
+    assert page.description == "A complete description for search result snippets and previews."
+    assert page.canonical_url == "https://example.com/canonical"
+    assert page.robots_content == "index,follow"
+    assert page.og_title == "Open graph title"
+    assert page.og_description == "Open graph description"
+    assert page.og_image == "https://example.com/image.png"
+    assert page.twitter_card == "summary_large_image"
+    assert page.twitter_title == "Twitter title"
+    assert page.twitter_description == "Twitter description"
+
+
+def test_metadata_quality_payload_flags_duplicates_and_missing_fields() -> None:
+    report = to_payload(analyze([
+        _page("https://example.com/a", title="Same title", description=""),
+        _page("https://example.com/b", title="Same title", canonical_url="", og_description=""),
+        _page("https://example.com/c", canonical_url="https://other.example/c", twitter_card=""),
+    ]))
+
+    assert report["summary"]["total_pages"] == 3
+    assert report["summary"]["pages_with_issues"] == 3
+    assert report["summary"]["missing_description"] == 1
+    assert report["summary"]["duplicate_title_pages"] == 2
+    assert report["summary"]["missing_canonical"] == 1
+    assert report["summary"]["canonical_external_host"] == 1
+    assert report["summary"]["incomplete_open_graph"] == 1
+    assert report["summary"]["missing_twitter_card"] == 1
+    assert report["issues_by_type"]["duplicate_title"] == 2
+    assert any("missing_description" in row["issues"] for row in report["per_page"])
+
+
+def test_compare_leaderboard_includes_metadata_quality_metrics(tmp_path: Path) -> None:
+    for domain, issue_share, missing_description in [
+        ("a.example", 0.25, 1),
+        ("b.example", 0.75, 3),
+    ]:
+        report_dir = tmp_path / domain / "report"
+        report_dir.mkdir(parents=True)
+        (report_dir / "site_metrics.json").write_text(
+            '{"domain":"%s","model":"test-model","page_count":4}' % domain,
+            encoding="utf-8",
+        )
+        (report_dir / "pages.json").write_text("[]", encoding="utf-8")
+        (report_dir / "metadata_quality.json").write_text(
+            (
+                '{"summary":{"issue_share":%s,'
+                '"missing_description":%d,'
+                '"duplicate_title_pages":2,'
+                '"missing_canonical":1,'
+                '"incomplete_open_graph":4}}'
+            ) % (issue_share, missing_description),
+            encoding="utf-8",
+        )
+
+    payload = build_payload(["a.example", "b.example"], tmp_path)
+
+    rows = {row["domain"]: row for row in payload["leaderboard"]}
+    assert rows["a.example"]["metadata_issue_share"] == 0.25
+    assert rows["a.example"]["missing_description"] == 1
+    assert rows["a.example"]["duplicate_title_pages"] == 2
+    assert rows["b.example"]["metadata_issue_share"] == 0.75
+    assert rows["b.example"]["missing_description"] == 3

--- a/ui/compare.html
+++ b/ui/compare.html
@@ -34,6 +34,7 @@
           <button data-group="overview"  class="lb-group px-2 py-1 rounded border border-gray-300 bg-white">Overview</button>
           <button data-group="topic"     class="lb-group px-2 py-1 rounded border border-gray-300 bg-white">Topic shape</button>
           <button data-group="geo"       class="lb-group px-2 py-1 rounded border border-gray-300 bg-white">GEO answer-ability</button>
+          <button data-group="metadata"  class="lb-group px-2 py-1 rounded border border-gray-300 bg-white">Metadata</button>
           <button data-group="linking"   class="lb-group px-2 py-1 rounded border border-gray-300 bg-white">Internal linking</button>
           <button data-group="linkbuilding" class="lb-group px-2 py-1 rounded border border-gray-300 bg-white">Linkbuilding</button>
           <button data-group="headers"   class="lb-group px-2 py-1 rounded border border-gray-300 bg-white">Headers</button>
@@ -157,6 +158,14 @@
       { key: 'p90_in_degree',     label: 'In-degree p90',    better: 'high', fmt: '0' },
       { key: 'median_out_degree', label: 'Out-degree median',better: 'high', fmt: '0' },
       { key: 'orphan_share',      label: 'Orphan share', better: 'low',  fmt: 'pct' },
+    ],
+    metadata: [
+      { key: 'pages',                   label: 'Pages', better: 'na', fmt: 'int' },
+      { key: 'metadata_issue_share',    label: 'Pages with issues', better: 'low', fmt: 'pct' },
+      { key: 'missing_description',     label: 'Missing desc', better: 'low', fmt: 'int' },
+      { key: 'duplicate_title_pages',   label: 'Duplicate titles', better: 'low', fmt: 'int' },
+      { key: 'missing_canonical',       label: 'Missing canonical', better: 'low', fmt: 'int' },
+      { key: 'incomplete_open_graph',   label: 'Incomplete OG', better: 'low', fmt: 'int' },
     ],
     density: [
       { key: 'pages',                       label: 'Pages',          better: 'na',   fmt: 'int' },

--- a/ui/index.html
+++ b/ui/index.html
@@ -363,6 +363,18 @@
       </div>
     </div>
 
+    <!-- SERP metadata -->
+    <div class="bg-white border border-gray-200 rounded-lg shadow-sm p-5 mb-8" id="metadata-quality-block">
+      <div class="mb-3">
+        <h3 class="text-lg font-semibold">SERP metadata quality</h3>
+        <p class="text-xs text-gray-500 mt-1">
+          Title, description, canonical, robots, Open Graph, and Twitter card signals that shape search snippets and sharing previews.
+        </p>
+      </div>
+      <div id="audit-metadata-summary" class="grid sm:grid-cols-3 lg:grid-cols-5 gap-3 text-sm mb-5"></div>
+      <div id="audit-metadata-pages" class="text-xs max-h-96 overflow-y-auto"></div>
+    </div>
+
     <!-- Answerability -->
     <div class="bg-white border border-gray-200 rounded-lg shadow-sm p-5 mb-8" id="answerability-block">
       <div class="mb-3">
@@ -746,6 +758,7 @@
 <script type="application/json" id="data-header-scatter">__HEADER_SCATTER_JSON__</script>
 <script type="application/json" id="data-linkbuilding">__LINKBUILDING_JSON__</script>
 <script type="application/json" id="data-structured-data">__STRUCTURED_DATA_JSON__</script>
+<script type="application/json" id="data-metadata-quality">__METADATA_QUALITY_JSON__</script>
 <script>
 (function() {
   const basePath = '/data';
@@ -827,8 +840,9 @@
       const inlinedHeaderScatter = readInlined('data-header-scatter');
       const inlinedLinkbuilding = readInlined('data-linkbuilding');
       const inlinedStructuredData = readInlined('data-structured-data');
+      const inlinedMetadataQuality = readInlined('data-metadata-quality');
 
-      let scatter, metrics, sections, outliers, duplicates, clusters, coverage, answerability, linkgraph, external, paraLinks, clusterOverlap, paraClusters, paraScatter, fanout, titleMismatch, wrongHome, improvement, competitive, recommendations, paraDensity, headerAnalysis, headerScatter, linkbuilding, structuredData;
+      let scatter, metrics, sections, outliers, duplicates, clusters, coverage, answerability, linkgraph, external, paraLinks, clusterOverlap, paraClusters, paraScatter, fanout, titleMismatch, wrongHome, improvement, competitive, recommendations, paraDensity, headerAnalysis, headerScatter, linkbuilding, structuredData, metadataQuality;
       if (inlinedMetrics) {
         scatter = inlinedScatter;
         metrics = inlinedMetrics;
@@ -855,8 +869,9 @@
         headerScatter = inlinedHeaderScatter || {};
         linkbuilding = inlinedLinkbuilding || {};
         structuredData = inlinedStructuredData || {};
+        metadataQuality = inlinedMetadataQuality || {};
       } else {
-        [scatter, metrics, sections, outliers, duplicates, clusters, coverage, answerability, linkgraph, external, paraLinks, clusterOverlap, paraClusters, paraScatter, fanout, titleMismatch, wrongHome, improvement, competitive, recommendations, paraDensity, headerAnalysis, headerScatter, linkbuilding, structuredData] = await Promise.all([
+        [scatter, metrics, sections, outliers, duplicates, clusters, coverage, answerability, linkgraph, external, paraLinks, clusterOverlap, paraClusters, paraScatter, fanout, titleMismatch, wrongHome, improvement, competitive, recommendations, paraDensity, headerAnalysis, headerScatter, linkbuilding, structuredData, metadataQuality] = await Promise.all([
           loadJSON('scatterplot.json').catch(() => null),
           loadJSON('site_metrics.json'),
           loadJSON('section_report.json').catch(() => []),
@@ -882,6 +897,7 @@
           loadJSON('header_scatter.json').catch(() => ({})),
           loadJSON('linkbuilding.json').catch(() => ({})),
           loadJSON('structured_data.json').catch(() => ({})),
+          loadJSON('metadata_quality.json').catch(() => ({})),
         ]);
       }
       state.scatter = scatter;
@@ -912,6 +928,7 @@
       state.headerScatter = headerScatter || {};
       state.linkbuilding = linkbuilding || {};
       state.structuredData = structuredData || {};
+      state.metadataQuality = metadataQuality || {};
       state.linkCountMode = 'hist';
       document.getElementById('header-domain').textContent =
         `${metrics.domain || ''} · ${metrics.page_count || 0} pages · model ${metrics.model || ''}`;
@@ -932,6 +949,7 @@
       renderHeatmap();
       renderCoverage('all');
       renderStructuredData();
+      renderMetadataQuality();
       renderAnswerability();
       renderLinkgraph();
       renderLinkbuilding();
@@ -1930,6 +1948,41 @@
             <div class="text-gray-700 mt-1">${bits}</div>
           </div>`;
       }).join('') || '<div class="text-gray-500">No recommended schema properties missing.</div>';
+  }
+
+  function renderMetadataQuality() {
+    const block = document.getElementById('metadata-quality-block');
+    const data = state.metadataQuality || {};
+    const summary = data.summary || {};
+    if (!summary.total_pages) {
+      block.style.display = 'none';
+      return;
+    }
+    document.getElementById('audit-metadata-summary').innerHTML =
+      card('Pages with issues', `${((summary.issue_share || 0) * 100).toFixed(0)}%`,
+        `${summary.pages_with_issues || 0} / ${summary.total_pages || 0} pages flagged`,
+        summary.pages_with_issues ? 'text-orange-600' : 'text-green-600') +
+      card('Missing descriptions', (summary.missing_description || 0).toLocaleString(),
+        'pages without meta descriptions') +
+      card('Duplicate titles', (summary.duplicate_title_pages || 0).toLocaleString(),
+        'pages sharing title text') +
+      card('Missing canonical', (summary.missing_canonical || 0).toLocaleString(),
+        'pages without rel=canonical') +
+      card('Incomplete OG', (summary.incomplete_open_graph || 0).toLocaleString(),
+        'missing og:title or og:description');
+
+    document.getElementById('audit-metadata-pages').innerHTML =
+      (data.per_page || []).filter(r => (r.issues || []).length).slice(0, 200).map(r => {
+        const issues = (r.issues || []).map(issue =>
+          `<span class="inline-block bg-gray-100 text-gray-700 px-1.5 py-0.5 rounded mr-1 mb-1">${escapeHtml(issue.replaceAll('_', ' '))}</span>`
+        ).join('');
+        return `
+          <div class="border-b border-gray-100 py-2">
+            <a class="text-blue-600 hover:underline break-all" href="${escapeHtml(r.url)}" target="_blank" rel="noopener">${escapeHtml(r.url)}</a>
+            <div class="mt-1">${issues}</div>
+            <div class="text-gray-500 mt-1">title ${r.title_length || 0} chars · description ${r.description_length || 0} chars · canonical ${escapeHtml(r.canonical_url || 'missing')}</div>
+          </div>`;
+      }).join('') || '<div class="text-gray-500">No metadata issues found.</div>';
   }
 
   function renderLinkgraph() {


### PR DESCRIPTION
## Summary
- closes #5
- extract canonical, robots, Open Graph, and Twitter metadata
- add metadata_quality.json with title/description/canonical/social issue summaries and per-page rows
- add metadata metrics to the comparison leaderboard
- add report UI section and focused unit tests

## Tests
- ./.venv/bin/python -m pytest
- ./.venv/bin/python -m compileall site_audit