### PR TITLE
Add extended domain audit reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,8 +647,15 @@ projects/
                                           #   anchor analysis, page_link_counts
       external_links.json                 # outbound profile, broken links
       linkbuilding.json                   # site-level link health, anchor audit, anchor scatter
+      indexability.json                   # crawl-to-analysis funnel + skipped/noindex pages
       structured_data.json                # schema.org JSON-LD coverage, validity, type mix
       metadata_quality.json               # SERP title/description/canonical/social metadata health
+      media_accessibility.json            # image alt/caption/transcript/embed accessibility signals
+      page_types.json                     # page type and template-family classifications
+      entities.json                       # entity coverage, reuse, organizations, topical authority
+      freshness.json                      # date coverage, stale pages, missing/future dates
+      conversion.json                     # CTA, form, contact, and lead-capture signals
+      performance.json                    # offline HTML/resource weight and render-blocking signals
       header_analysis.json                # H1-H6 structure, drifty headers, keyword freq
       header_scatter.json                 # header UMAP coordinates
       paragraph_clusters.json             # paragraph topic clusters

--- a/site_audit/compare.py
+++ b/site_audit/compare.py
@@ -46,6 +46,13 @@ class _Project:
     header_analysis: dict
     structured_data: dict
     metadata_quality: dict
+    media_accessibility: dict
+    page_types: dict
+    entities: dict
+    freshness: dict
+    conversion: dict
+    indexability: dict
+    performance: dict
     embeddings: Optional[np.ndarray]    # aligned with pages
     embedded_pages: list[dict]          # subset of pages that have an embedding
 
@@ -97,6 +104,13 @@ def _load_project(domain: str, projects_root: Path) -> Optional[_Project]:
     header_analysis = _load_json(report / "header_analysis.json", {})
     structured_data = _load_json(report / "structured_data.json", {})
     metadata_quality = _load_json(report / "metadata_quality.json", {})
+    media_accessibility = _load_json(report / "media_accessibility.json", {})
+    page_types = _load_json(report / "page_types.json", {})
+    entities = _load_json(report / "entities.json", {})
+    freshness = _load_json(report / "freshness.json", {})
+    conversion = _load_json(report / "conversion.json", {})
+    indexability = _load_json(report / "indexability.json", {})
+    performance = _load_json(report / "performance.json", {})
 
     page_link_counts = (linkgraph.get("page_link_counts") or []) if isinstance(linkgraph, dict) else []
     model = metrics.get("model", "Alibaba-NLP/gte-multilingual-base")
@@ -126,6 +140,13 @@ def _load_project(domain: str, projects_root: Path) -> Optional[_Project]:
         header_analysis=header_analysis,
         structured_data=structured_data,
         metadata_quality=metadata_quality,
+        media_accessibility=media_accessibility,
+        page_types=page_types,
+        entities=entities,
+        freshness=freshness,
+        conversion=conversion,
+        indexability=indexability,
+        performance=performance,
         embeddings=embed_array,
         embedded_pages=embedded_pages,
     )
@@ -232,6 +253,13 @@ def _leaderboard_row(proj: _Project) -> dict:
     ha = (proj.header_analysis or {}).get("summary", {}) or {}
     sd = (proj.structured_data or {}).get("summary", {}) or {}
     mq = (proj.metadata_quality or {}).get("summary", {}) or {}
+    ma = (proj.media_accessibility or {}).get("summary", {}) or {}
+    pt = (proj.page_types or {}).get("summary", {}) or {}
+    ent = (proj.entities or {}).get("summary", {}) or {}
+    fr = (proj.freshness or {}).get("summary", {}) or {}
+    cv = (proj.conversion or {}).get("summary", {}) or {}
+    ix = (proj.indexability or {}).get("summary", {}) or {}
+    pf = (proj.performance or {}).get("summary", {}) or {}
 
     n_pages = len(proj.page_link_counts) or m.get("page_count") or len(proj.pages) or 0
     orphan_share = (sum(1 for r in proj.page_link_counts if r.get("in_degree") == 0) / n_pages) if n_pages else 0.0
@@ -272,6 +300,46 @@ def _leaderboard_row(proj: _Project) -> dict:
         "duplicate_title_pages": int(mq.get("duplicate_title_pages", 0)),
         "missing_canonical": int(mq.get("missing_canonical", 0)),
         "incomplete_open_graph": int(mq.get("incomplete_open_graph", 0)),
+        "media_accessibility_issue_share": float(ma.get("issue_share", 0.0)),
+        "images_missing_alt": int(ma.get("images_missing_alt", 0)),
+        "linked_images_empty_alt": int(ma.get("linked_images_empty_alt", 0)),
+        "videos_missing_captions": int(ma.get("videos_missing_captions", 0)),
+        "iframes_missing_title": int(ma.get("iframes_missing_title", 0)),
+        "page_type_count": int(pt.get("page_type_count", 0)),
+        "template_family_count": int(pt.get("template_family_count", 0)),
+        "template_signature_count": int(pt.get("template_signature_count", 0)),
+        "dominant_page_type": str(pt.get("dominant_page_type", "")),
+        "dominant_template_family": str(pt.get("dominant_template_family", "")),
+        "freshness_date_coverage": float(fr.get("date_coverage", 0.0)),
+        "freshness_stale_share": float(fr.get("stale_share", 0.0)),
+        "freshness_missing_dates": int(fr.get("missing_dates", 0)),
+        "freshness_very_stale_pages": int(fr.get("pages_very_stale", 0)),
+        "freshness_median_age_days": int(fr.get("median_age_days") or 0),
+        "entity_coverage": float(ent.get("entity_coverage", 0.0)),
+        "unique_entities": int(ent.get("unique_entities", 0)),
+        "avg_entities_per_page": float(ent.get("avg_entities_per_page", 0.0)),
+        "entity_reuse_share": float(ent.get("entity_reuse_share", 0.0)),
+        "organization_count": int(ent.get("organization_count", 0)),
+        "organization_coverage": float(ent.get("organization_coverage", 0.0)),
+        "topical_depth_share": float(ent.get("topical_depth_share", 0.0)),
+        "topical_authority_score": float(ent.get("topical_authority_score", 0.0)),
+        "cta_coverage": float(cv.get("cta_coverage", 0.0)),
+        "primary_cta_coverage": float(cv.get("primary_cta_coverage", 0.0)),
+        "form_coverage": float(cv.get("form_coverage", 0.0)),
+        "avg_ctas_per_page": float(cv.get("avg_ctas_per_page", 0.0)),
+        "lead_pages_without_capture": int(cv.get("lead_pages_without_capture", 0)),
+        "cta_overload_pages": int(cv.get("cta_overload_pages", 0)),
+        "indexable_share": float(ix.get("indexable_share", 0.0)),
+        "noindex_share": float(ix.get("noindex_share", 0.0)),
+        "skipped_pages": int(ix.get("skipped_pages", 0)),
+        "median_html_weight_bytes": int(pf.get("median_html_weight_bytes", 0)),
+        "p90_estimated_weight_bytes": int(pf.get("p90_estimated_weight_bytes", 0)),
+        "avg_resource_tags_per_page": float(pf.get("avg_resource_tags_per_page", 0.0)),
+        "render_blocking_share": float(pf.get("render_blocking_share", 0.0)),
+        "heavy_page_share": float(pf.get("heavy_page_share", 0.0)),
+        "total_images": int(pf.get("total_images", 0)),
+        "total_scripts": int(pf.get("total_scripts", 0)),
+        "total_stylesheets": int(pf.get("total_stylesheets", 0)),
         # Action plan
         "recommendations_total": int((proj.recommendations or {}).get("total", 0)),
         "rec_high": int(rec_pri.get("high", 0)),

--- a/site_audit/conversion.py
+++ b/site_audit/conversion.py
@@ -1,0 +1,165 @@
+"""Conversion and CTA signal analysis."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from typing import Iterable
+from urllib.parse import urlparse
+
+from .extractor import ExtractedPage
+
+
+_LEAD_PATH_TERMS = (
+    "contact",
+    "demo",
+    "quote",
+    "estimate",
+    "pricing",
+    "signup",
+    "register",
+    "book",
+    "consult",
+    "apply",
+)
+_GENERIC_CTA_TEXT = {
+    "learn more",
+    "read more",
+    "click here",
+    "more",
+    "details",
+}
+
+
+@dataclass
+class ConversionReport:
+    summary: dict
+    issues_by_type: dict[str, int]
+    top_ctas: list[dict]
+    per_page: list[dict]
+
+
+def _is_lead_page(url: str, title: str) -> bool:
+    parsed = urlparse(url)
+    haystack = f"{parsed.path} {title}".lower().replace("-", " ")
+    return any(term in haystack for term in _LEAD_PATH_TERMS)
+
+
+def _generic_cta_count(ctas: list[dict]) -> int:
+    return sum(1 for cta in ctas if (cta.get("text") or "").strip().lower() in _GENERIC_CTA_TEXT)
+
+
+def analyze(pages: Iterable[ExtractedPage]) -> ConversionReport:
+    page_list = list(pages)
+    issues_by_type: Counter[str] = Counter()
+    cta_text_counts: Counter[str] = Counter()
+    rows: list[dict] = []
+
+    total_ctas = 0
+    total_primary_ctas = 0
+    total_forms = 0
+    total_form_fields = 0
+    pages_with_cta = 0
+    pages_with_primary_cta = 0
+    pages_with_forms = 0
+    pages_with_contact_link = 0
+
+    for page in page_list:
+        signals = page.conversion_signals or {}
+        ctas = list(signals.get("ctas") or [])
+        forms = list(signals.get("forms") or [])
+        cta_count = int(signals.get("cta_count") or len(ctas))
+        primary_cta_count = int(signals.get("primary_cta_count") or sum(1 for cta in ctas if cta.get("primary")))
+        form_count = int(signals.get("form_count") or len(forms))
+        form_field_count = int(signals.get("form_field_count") or sum(int(form.get("field_count") or 0) for form in forms))
+        contact_link_count = int(signals.get("contact_link_count") or 0)
+        generic_ctas = _generic_cta_count(ctas)
+        lead_page = _is_lead_page(page.url, page.title)
+        forms_without_submit = sum(1 for form in forms if not form.get("has_submit"))
+
+        total_ctas += cta_count
+        total_primary_ctas += primary_cta_count
+        total_forms += form_count
+        total_form_fields += form_field_count
+        if cta_count:
+            pages_with_cta += 1
+        if primary_cta_count:
+            pages_with_primary_cta += 1
+        if form_count:
+            pages_with_forms += 1
+        if contact_link_count:
+            pages_with_contact_link += 1
+        cta_text_counts.update((cta.get("text") or "").strip() for cta in ctas if (cta.get("text") or "").strip())
+
+        issues: list[str] = []
+        if not cta_count:
+            issues.append("no_cta")
+        if not primary_cta_count:
+            issues.append("no_primary_cta")
+        if lead_page and not form_count and not contact_link_count:
+            issues.append("lead_page_without_capture")
+        if cta_count > 8:
+            issues.append("cta_overload")
+        if generic_ctas and generic_ctas == cta_count:
+            issues.append("only_generic_ctas")
+        if forms_without_submit:
+            issues.append("form_without_submit")
+
+        issues_by_type.update(issues)
+        rows.append({
+            "url": page.url,
+            "title": page.title,
+            "cta_count": cta_count,
+            "primary_cta_count": primary_cta_count,
+            "form_count": form_count,
+            "form_field_count": form_field_count,
+            "contact_link_count": contact_link_count,
+            "lead_page": lead_page,
+            "generic_cta_count": generic_ctas,
+            "forms_without_submit": forms_without_submit,
+            "top_ctas": ctas[:8],
+            "issues": issues,
+        })
+
+    total_pages = len(page_list)
+    summary = {
+        "total_pages": total_pages,
+        "total_ctas": total_ctas,
+        "total_primary_ctas": total_primary_ctas,
+        "total_forms": total_forms,
+        "total_form_fields": total_form_fields,
+        "pages_with_cta": pages_with_cta,
+        "cta_coverage": pages_with_cta / total_pages if total_pages else 0.0,
+        "pages_with_primary_cta": pages_with_primary_cta,
+        "primary_cta_coverage": pages_with_primary_cta / total_pages if total_pages else 0.0,
+        "pages_with_forms": pages_with_forms,
+        "form_coverage": pages_with_forms / total_pages if total_pages else 0.0,
+        "pages_with_contact_link": pages_with_contact_link,
+        "contact_link_coverage": pages_with_contact_link / total_pages if total_pages else 0.0,
+        "avg_ctas_per_page": total_ctas / total_pages if total_pages else 0.0,
+        "pages_without_cta": issues_by_type.get("no_cta", 0),
+        "pages_without_primary_cta": issues_by_type.get("no_primary_cta", 0),
+        "lead_pages_without_capture": issues_by_type.get("lead_page_without_capture", 0),
+        "cta_overload_pages": issues_by_type.get("cta_overload", 0),
+        "forms_without_submit_pages": issues_by_type.get("form_without_submit", 0),
+    }
+    top_ctas = [
+        {"text": text, "count": count}
+        for text, count in cta_text_counts.most_common(50)
+    ]
+    rows.sort(key=lambda row: (-len(row["issues"]), -int(row["lead_page"]), row["url"]))
+    return ConversionReport(
+        summary=summary,
+        issues_by_type=dict(issues_by_type),
+        top_ctas=top_ctas,
+        per_page=rows,
+    )
+
+
+def to_payload(report: ConversionReport) -> dict:
+    return {
+        "summary": report.summary,
+        "issues_by_type": report.issues_by_type,
+        "top_ctas": report.top_ctas,
+        "per_page": report.per_page,
+    }

--- a/site_audit/crawler.py
+++ b/site_audit/crawler.py
@@ -128,6 +128,7 @@ class FetchResult:
     body: str
     content_type: str
     from_cache: bool
+    content_length_bytes: int = 0
     x_robots_tag: str = ""                               # raw X-Robots-Tag header (lowercased)
     outlinks: list = field(default_factory=list)         # same-site (target_url, anchor_text)
     external_links: list = field(default_factory=list)   # cross-site (target_url, anchor_text)
@@ -529,6 +530,7 @@ class Crawler:
                     body=cached.text,
                     content_type=(cached.content_type or "").lower(),
                     from_cache=True,
+                    content_length_bytes=len(cached.body or b""),
                     x_robots_tag=xrt,
                 )
 
@@ -567,5 +569,6 @@ class Crawler:
             body=text,
             content_type=ctype,
             from_cache=False,
+            content_length_bytes=len(body_bytes or b""),
             x_robots_tag=(r.headers.get("X-Robots-Tag", "") or "").lower(),
         )

--- a/site_audit/entities.py
+++ b/site_audit/entities.py
@@ -1,0 +1,250 @@
+"""Entity and topical-authority analysis.
+
+This module stays deliberately offline and heuristic: it extracts capitalized
+entity-like phrases from metadata, headings, body copy, and lightweight schema
+diagnostics, then rolls them into page/site coverage signals.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from statistics import median
+from typing import Iterable
+
+from .extractor import ExtractedPage
+
+
+@dataclass
+class EntityReport:
+    summary: dict
+    top_entities: list[dict]
+    organizations: list[dict]
+    per_page: list[dict]
+
+
+_ENTITY_RE = re.compile(
+    r"\b(?:[A-Z][\wÀ-ÖØ-Þà-öø-ÿ'’-]+|[A-Z]{2,})"
+    r"(?:\s+(?:&|and|of|for|the|[A-Z][\wÀ-ÖØ-Þà-öø-ÿ'’-]+|[A-Z]{2,})){0,5}"
+)
+_ORG_SUFFIX_RE = re.compile(
+    r"\b(?:Inc\.?|LLC|Ltd\.?|Limited|Corp\.?|Corporation|Company|Co\.?|Group|Agency|"
+    r"Studio|Labs?|University|Institute|Foundation|Association|Partners|GmbH|AG|S\.r\.o\.|a\.s\.)\b",
+    re.I,
+)
+_STOPWORDS = {
+    "About", "All", "And", "Article", "Blog", "Browse", "Careers", "Contact",
+    "Copyright", "Cookie", "Email", "Facebook", "Faq", "Home", "Instagram",
+    "Learn", "Linkedin", "Login", "Menu", "News", "Next", "Our", "Page",
+    "Previous", "Privacy", "Read", "Resources", "Search", "Services", "Share",
+    "Terms", "The", "This", "Twitter", "Welcome", "You", "Your",
+}
+
+
+def _clean_entity(value: str) -> str:
+    value = re.sub(r"\s+", " ", value or "").strip(" -–—:;,.()[]{}\"'")
+    value = re.sub(r"^(?:The|A|An)\s+", "", value)
+    value = re.sub(r"\s+(?:and|of|for|the)$", "", value, flags=re.I)
+    return value.strip()
+
+
+def _is_entity(value: str) -> bool:
+    if not value or value in _STOPWORDS:
+        return False
+    if len(value) < 3 or len(value) > 90:
+        return False
+    words = value.split()
+    if len(words) == 1 and value not in value.upper() and value in _STOPWORDS:
+        return False
+    if value.lower() in {word.lower() for word in _STOPWORDS}:
+        return False
+    if re.fullmatch(r"\d+", value):
+        return False
+    return any(ch.isupper() for ch in value)
+
+
+def extract_entities_from_text(text: str) -> list[str]:
+    """Return normalized capitalized entity-like phrases from text."""
+    entities: list[str] = []
+    seen: set[str] = set()
+    for match in _ENTITY_RE.finditer(text or ""):
+        entity = _clean_entity(match.group(0))
+        if not _is_entity(entity):
+            continue
+        key = entity.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        entities.append(entity)
+    return entities
+
+
+def _schema_entity_names(page: ExtractedPage) -> list[str]:
+    names: list[str] = []
+    for block in page.schema_blocks or []:
+        for name in block.get("names") or []:
+            clean = _clean_entity(str(name))
+            if _is_entity(clean):
+                names.append(clean)
+    return names
+
+
+def _text_sources(page: ExtractedPage) -> dict[str, str]:
+    heading_text = " ".join(
+        str(h.get("text", "")) for h in (page.headers_rich or []) if h.get("text")
+    ) or " ".join(page.headings or [])
+    metadata = " ".join(
+        part for part in (
+            page.title, page.description, page.og_title, page.og_description,
+            page.twitter_title, page.twitter_description,
+        ) if part
+    )
+    return {
+        "schema": " ".join(_schema_entity_names(page)),
+        "metadata": metadata,
+        "heading": " ".join(part for part in (page.h1, heading_text) if part),
+        "body": page.body or "",
+    }
+
+
+def _is_organization(entity: str, schema_orgs: set[str]) -> bool:
+    if entity in schema_orgs:
+        return True
+    return bool(_ORG_SUFFIX_RE.search(entity))
+
+
+def analyze(pages: Iterable[ExtractedPage]) -> EntityReport:
+    page_list = list(pages)
+    entity_mentions: Counter[str] = Counter()
+    entity_pages: dict[str, set[str]] = defaultdict(set)
+    entity_sources: dict[str, set[str]] = defaultdict(set)
+    organization_mentions: Counter[str] = Counter()
+    organization_pages: dict[str, set[str]] = defaultdict(set)
+    per_page: list[dict] = []
+
+    for page in page_list:
+        source_entities: dict[str, list[str]] = {
+            source: extract_entities_from_text(text)
+            for source, text in _text_sources(page).items()
+            if text
+        }
+        schema_orgs = set(source_entities.get("schema", []))
+        page_counter: Counter[str] = Counter()
+        source_map: dict[str, set[str]] = defaultdict(set)
+        for source, entities in source_entities.items():
+            for entity in entities:
+                page_counter[entity] += 1
+                source_map[entity].add(source)
+
+        organizations = sorted(
+            entity for entity in page_counter
+            if _is_organization(entity, schema_orgs)
+        )
+        for entity, mentions in page_counter.items():
+            entity_mentions[entity] += mentions
+            entity_pages[entity].add(page.url)
+            entity_sources[entity].update(source_map[entity])
+        for organization in organizations:
+            organization_mentions[organization] += page_counter[organization]
+            organization_pages[organization].add(page.url)
+
+        distinct = len(page_counter)
+        mentions = sum(page_counter.values())
+        depth_score = min(1.0, (distinct / 8.0) * 0.6 + (mentions / 16.0) * 0.4)
+        signals: list[str] = []
+        if source_entities.get("schema"):
+            signals.append("schema_entities")
+        if source_entities.get("heading"):
+            signals.append("heading_entities")
+        if distinct >= 8:
+            signals.append("entity_rich")
+        if organizations:
+            signals.append("organization_mentions")
+        per_page.append({
+            "url": page.url,
+            "title": page.title,
+            "entity_count": distinct,
+            "entity_mentions": mentions,
+            "organization_count": len(organizations),
+            "top_entities": [
+                {"entity": entity, "mentions": count}
+                for entity, count in page_counter.most_common(8)
+            ],
+            "organizations": organizations[:8],
+            "topical_depth_score": round(depth_score, 3),
+            "signals": signals,
+        })
+
+    total_pages = len(page_list)
+    entity_counts = [row["entity_count"] for row in per_page]
+    mention_counts = [row["entity_mentions"] for row in per_page]
+    pages_with_entities = sum(1 for count in entity_counts if count > 0)
+    depth_pages = sum(1 for row in per_page if row["entity_count"] >= 5 and row["entity_mentions"] >= 8)
+    thin_pages = sum(1 for row in per_page if row["entity_count"] < 3)
+    reused_entities = sum(1 for entity, urls in entity_pages.items() if len(urls) >= 2)
+    unique_entities = len(entity_mentions)
+    unique_orgs = len(organization_mentions)
+    entity_coverage = pages_with_entities / total_pages if total_pages else 0.0
+    depth_share = depth_pages / total_pages if total_pages else 0.0
+    reuse_share = reused_entities / unique_entities if unique_entities else 0.0
+    org_coverage = (sum(1 for row in per_page if row["organization_count"] > 0) / total_pages) if total_pages else 0.0
+    topical_authority_score = round(
+        100.0 * (entity_coverage * 0.3 + depth_share * 0.3 + reuse_share * 0.25 + org_coverage * 0.15),
+        1,
+    )
+
+    top_entities = [
+        {
+            "entity": entity,
+            "mentions": mentions,
+            "pages": len(entity_pages[entity]),
+            "coverage": len(entity_pages[entity]) / total_pages if total_pages else 0.0,
+            "sources": sorted(entity_sources[entity]),
+        }
+        for entity, mentions in entity_mentions.most_common(100)
+    ]
+    organizations = [
+        {
+            "organization": organization,
+            "mentions": mentions,
+            "pages": len(organization_pages[organization]),
+            "coverage": len(organization_pages[organization]) / total_pages if total_pages else 0.0,
+        }
+        for organization, mentions in organization_mentions.most_common(50)
+    ]
+    per_page.sort(key=lambda row: (row["entity_count"], row["entity_mentions"], row["url"]))
+
+    summary = {
+        "total_pages": total_pages,
+        "pages_with_entities": pages_with_entities,
+        "entity_coverage": entity_coverage,
+        "unique_entities": unique_entities,
+        "total_entity_mentions": sum(entity_mentions.values()),
+        "avg_entities_per_page": (sum(entity_counts) / total_pages) if total_pages else 0.0,
+        "median_entities_per_page": float(median(entity_counts)) if entity_counts else 0.0,
+        "avg_entity_mentions_per_page": (sum(mention_counts) / total_pages) if total_pages else 0.0,
+        "entities_reused_across_pages": reused_entities,
+        "entity_reuse_share": reuse_share,
+        "organization_count": unique_orgs,
+        "organization_coverage": org_coverage,
+        "topical_depth_pages": depth_pages,
+        "topical_depth_share": depth_share,
+        "thin_entity_pages": thin_pages,
+        "topical_authority_score": topical_authority_score,
+    }
+    return EntityReport(
+        summary=summary,
+        top_entities=top_entities,
+        organizations=organizations,
+        per_page=per_page,
+    )
+
+
+def to_payload(report: EntityReport) -> dict:
+    return {
+        "summary": report.summary,
+        "top_entities": report.top_entities,
+        "organizations": report.organizations,
+        "per_page": report.per_page,
+    }

--- a/site_audit/extractor.py
+++ b/site_audit/extractor.py
@@ -59,6 +59,9 @@ class ExtractedPage:
     schema_blocks: list[dict] = field(default_factory=list)  # parsed JSON-LD diagnostics
     external_link_count: int = 0
     has_dates: bool = False
+    date_published: str = ""
+    date_modified: str = ""
+    date_candidates: list[dict] = field(default_factory=list)
     stat_count: int = 0  # numbers with units / percentages
     paragraphs: list[str] = field(default_factory=list)  # body broken into clean paragraph blocks
     paragraph_link_counts: list[tuple[int, int]] = field(default_factory=list)  # (internal, external) per paragraph, aligned with .paragraphs
@@ -66,6 +69,8 @@ class ExtractedPage:
     noindex_source: str = ""  # "meta" | "header" | "" — diagnostic only
     link_quality: dict = field(default_factory=dict)  # per-page link quality counters (total, has_text, has_title, image_only, empty, …)
     link_audit_rows: list[dict] = field(default_factory=list)  # one row per <a href>: anchor + flags, used for site-level aggregation
+    media_items: list[dict] = field(default_factory=list)  # images/video/audio/iframes with accessibility-relevant attributes
+    conversion_signals: dict = field(default_factory=dict)  # CTA/form/contact signals for conversion analysis
 
 
 _WHITESPACE_RE = re.compile(r"\s+")
@@ -75,6 +80,7 @@ _DATE_RE = re.compile(
     r"|\b\d{1,2}/\d{1,2}/\d{4}\b",
     re.I,
 )
+_ISO_DATE_PREFIX_RE = re.compile(r"^\d{4}-\d{2}-\d{2}")
 _STAT_RE = re.compile(
     r"\b\d+(?:[,.]\d+)*\s*(?:%|percent|million|billion|thousand|users?|customers?|clients?|"
     r"\$|€|£|kg|kilograms?|grams?|hours?|minutes?|days?|weeks?|months?|years?)\b",
@@ -93,6 +99,115 @@ def _meta(soup: BeautifulSoup, name: str) -> str:
     if tag and tag.get("content"):
         return _clean(html.unescape(tag["content"]))
     return ""
+
+
+def _jsonld_date_values(item, keys: set[str]) -> list[tuple[str, str]]:
+    values: list[tuple[str, str]] = []
+    if isinstance(item, dict):
+        for key, value in item.items():
+            key_str = str(key)
+            if key_str in keys:
+                if isinstance(value, str):
+                    values.append((key_str, value))
+                elif isinstance(value, list):
+                    values.extend((key_str, str(v)) for v in value if v)
+            if key_str == "@graph" and isinstance(value, list):
+                for child in value:
+                    values.extend(_jsonld_date_values(child, keys))
+    elif isinstance(item, list):
+        for child in item:
+            values.extend(_jsonld_date_values(child, keys))
+    return values
+
+
+def _date_candidate(value: str, source: str, kind: str) -> dict | None:
+    clean_value = _clean(html.unescape(value or ""))
+    if not clean_value:
+        return None
+    if _ISO_DATE_PREFIX_RE.match(clean_value):
+        date_value = clean_value[:10]
+    else:
+        match = _DATE_RE.search(clean_value)
+        if not match:
+            return None
+        date_value = match.group(0)
+    return {"date": date_value, "source": source, "kind": kind}
+
+
+def _extract_date_candidates(soup: BeautifulSoup, body_text: str) -> tuple[str, str, list[dict]]:
+    """Collect publication/update date hints from metadata, schema, and body text.
+
+    Values are intentionally kept as short strings; the freshness analyzer owns
+    parsing and ageing so tests can pass a deterministic ``today`` date.
+    """
+    candidates: list[dict] = []
+    published_names = {
+        "article:published_time",
+        "date",
+        "datepublished",
+        "dc.date",
+        "dc.date.issued",
+        "pubdate",
+        "publishdate",
+    }
+    modified_names = {
+        "article:modified_time",
+        "last-modified",
+        "lastmod",
+        "datemodified",
+        "dc.date.modified",
+        "updated_time",
+    }
+
+    for tag in soup.find_all("meta"):
+        name = (tag.get("name") or tag.get("property") or tag.get("itemprop") or "").strip().lower()
+        content = tag.get("content") or ""
+        if name in published_names:
+            candidate = _date_candidate(content, f"meta:{name}", "published")
+            if candidate:
+                candidates.append(candidate)
+        elif name in modified_names:
+            candidate = _date_candidate(content, f"meta:{name}", "modified")
+            if candidate:
+                candidates.append(candidate)
+
+    for time_tag in soup.find_all("time"):
+        raw = time_tag.get("datetime") or time_tag.get_text(" ")
+        candidate = _date_candidate(raw, "time", "visible")
+        if candidate:
+            candidates.append(candidate)
+
+    for tag in soup.find_all("script", attrs={"type": "application/ld+json"}):
+        raw = tag.string or tag.get_text() or ""
+        if not raw.strip():
+            continue
+        try:
+            data = json.loads(raw)
+        except Exception:
+            continue
+        for key, value in _jsonld_date_values(data, {"datePublished", "dateModified", "dateCreated", "uploadDate"}):
+            kind = "modified" if key == "dateModified" else "published"
+            candidate = _date_candidate(value, f"jsonld:{key}", kind)
+            if candidate:
+                candidates.append(candidate)
+
+    for match in _DATE_RE.finditer(body_text or ""):
+        candidates.append({"date": match.group(0), "source": "body", "kind": "visible"})
+        if len(candidates) >= 25:
+            break
+
+    deduped: list[dict] = []
+    seen: set[tuple[str, str, str]] = set()
+    for candidate in candidates:
+        key = (candidate["date"], candidate["source"], candidate["kind"])
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(candidate)
+
+    date_published = next((c["date"] for c in deduped if c["kind"] == "published"), "")
+    date_modified = next((c["date"] for c in deduped if c["kind"] == "modified"), "")
+    return date_published, date_modified, deduped
 
 
 def _title_from_html(soup: BeautifulSoup) -> str:
@@ -232,6 +347,27 @@ def _schema_keys_from_item(item) -> list[str]:
     return sorted(keys)
 
 
+def _schema_names_from_item(item) -> list[str]:
+    names: list[str] = []
+    if isinstance(item, dict):
+        item_types = set(_schema_type_values(item.get("@type")))
+        if item_types & {"Organization", "LocalBusiness", "Corporation", "NGO", "EducationalOrganization"}:
+            for key in ("name", "legalName", "alternateName"):
+                value = item.get(key)
+                if isinstance(value, str) and value.strip():
+                    names.append(value.strip())
+                elif isinstance(value, list):
+                    names.extend(str(v).strip() for v in value if str(v).strip())
+        graph = item.get("@graph")
+        if isinstance(graph, list):
+            for graph_item in graph:
+                names.extend(_schema_names_from_item(graph_item))
+    elif isinstance(item, list):
+        for child in item:
+            names.extend(_schema_names_from_item(child))
+    return names
+
+
 def _extract_schema_data(soup: BeautifulSoup) -> tuple[list[str], list[dict]]:
     types: list[str] = []
     blocks: list[dict] = []
@@ -256,6 +392,7 @@ def _extract_schema_data(soup: BeautifulSoup) -> tuple[list[str], list[dict]]:
             "valid": True,
             "types": sorted(set(block_types)),
             "keys": _schema_keys_from_item(data),
+            "names": sorted(set(_schema_names_from_item(data))),
             "error": "",
         })
     return sorted(set(types)), blocks
@@ -414,6 +551,170 @@ def _link_quality(soup: BeautifulSoup, page_url: str) -> tuple[dict, list[dict]]
     return counters, rows
 
 
+def _media_items(soup: BeautifulSoup) -> list[dict]:
+    """Extract lightweight media accessibility signals from HTML."""
+    items: list[dict] = []
+
+    for img in soup.find_all("img"):
+        parent_link = img.find_parent("a")
+        link_text = _clean(parent_link.get_text(" ")) if parent_link else ""
+        items.append({
+            "type": "image",
+            "src": _clean(html.unescape(img.get("src") or img.get("data-src") or "")),
+            "alt": _clean(html.unescape(img.get("alt") or "")),
+            "alt_present": img.has_attr("alt"),
+            "title": _clean(html.unescape(img.get("title") or "")),
+            "aria_label": _clean(html.unescape(img.get("aria-label") or "")),
+            "role": _clean(img.get("role") or "").lower(),
+            "aria_hidden": str(img.get("aria-hidden") or "").lower() == "true",
+            "in_link": parent_link is not None,
+            "link_text": link_text,
+            "link_title": _clean(html.unescape(parent_link.get("title") or "")) if parent_link else "",
+            "link_aria_label": _clean(html.unescape(parent_link.get("aria-label") or "")) if parent_link else "",
+        })
+
+    for video in soup.find_all("video"):
+        tracks = [
+            _clean(track.get("kind") or "").lower()
+            for track in video.find_all("track")
+            if _clean(track.get("kind") or "")
+        ]
+        items.append({
+            "type": "video",
+            "src": _clean(html.unescape(video.get("src") or "")),
+            "title": _clean(html.unescape(video.get("title") or "")),
+            "aria_label": _clean(html.unescape(video.get("aria-label") or "")),
+            "track_kinds": tracks,
+            "has_captions": any(kind in {"captions", "subtitles"} for kind in tracks),
+        })
+
+    for audio in soup.find_all("audio"):
+        parent = audio.parent
+        nearby_text = _clean(parent.get_text(" "))[:500].lower() if parent else ""
+        items.append({
+            "type": "audio",
+            "src": _clean(html.unescape(audio.get("src") or "")),
+            "title": _clean(html.unescape(audio.get("title") or "")),
+            "aria_label": _clean(html.unescape(audio.get("aria-label") or "")),
+            "has_transcript_hint": "transcript" in nearby_text,
+        })
+
+    for iframe in soup.find_all("iframe"):
+        items.append({
+            "type": "iframe",
+            "src": _clean(html.unescape(iframe.get("src") or "")),
+            "title": _clean(html.unescape(iframe.get("title") or "")),
+            "aria_label": _clean(html.unescape(iframe.get("aria-label") or "")),
+        })
+
+    return items
+
+
+_CTA_RE = re.compile(
+    r"\b("
+    r"buy|order|checkout|cart|pricing|price|quote|estimate|demo|book|schedule|"
+    r"contact|call|start|signup|sign\s*up|register|subscribe|download|apply|"
+    r"request|consultation|get\s+started|learn\s+more"
+    r")\b",
+    re.I,
+)
+_PRIMARY_CTA_RE = re.compile(
+    r"\b("
+    r"buy|order|checkout|quote|estimate|demo|book|schedule|contact|call|"
+    r"signup|sign\s*up|subscribe|apply|get\s+started"
+    r")\b",
+    re.I,
+)
+
+
+def _conversion_signals(soup: BeautifulSoup, page_url: str) -> dict:
+    """Extract lightweight CTA, form, and direct-contact signals."""
+    try:
+        host = urlparse(page_url).netloc.lower()
+    except Exception:
+        host = ""
+    host_root = host[4:] if host.startswith("www.") else host
+
+    ctas: list[dict] = []
+    seen: set[tuple[str, str]] = set()
+    for tag in soup.find_all(["a", "button", "input"]):
+        tag_name = tag.name or ""
+        input_type = (tag.get("type") or "").strip().lower()
+        if tag_name == "input" and input_type not in {"button", "submit", "image"}:
+            continue
+        href = (tag.get("href") or "").strip()
+        if href.startswith(("javascript:", "#")):
+            continue
+        text = _clean(tag.get_text(" ") or tag.get("value") or tag.get("aria-label") or tag.get("title") or "")
+        if not text and href.startswith(("tel:", "mailto:")):
+            text = href.split(":", 1)[0]
+        if not text:
+            continue
+        text = text[:120]
+        is_primary = bool(_PRIMARY_CTA_RE.search(text) or href.startswith(("tel:", "mailto:")))
+        is_cta = is_primary or bool(_CTA_RE.search(text))
+        if not is_cta:
+            continue
+        key = (text.lower(), href)
+        if key in seen:
+            continue
+        seen.add(key)
+        destination = "internal"
+        if href.startswith(("http://", "https://")):
+            other = urlparse(href).netloc.lower()
+            other_root = other[4:] if other.startswith("www.") else other
+            destination = "internal" if host_root and other_root == host_root else "external"
+        elif href.startswith("mailto:"):
+            destination = "email"
+        elif href.startswith("tel:"):
+            destination = "phone"
+        ctas.append({
+            "text": text,
+            "element": tag_name,
+            "href": href,
+            "destination": destination,
+            "primary": is_primary,
+        })
+
+    forms: list[dict] = []
+    for form in soup.find_all("form"):
+        fields = []
+        for field in form.find_all(["input", "select", "textarea"]):
+            field_type = (field.get("type") or field.name or "").strip().lower()
+            if field_type in {"hidden", "submit", "button", "reset", "image"}:
+                continue
+            label = field.get("name") or field.get("id") or field.get("placeholder") or field_type
+            fields.append(_clean(str(label))[:80])
+        submit = form.find(["button", "input"], attrs={"type": re.compile(r"submit|button", re.I)})
+        if submit is None:
+            submit = form.find("button")
+        submit_text = _clean(submit.get_text(" ") or submit.get("value") or submit.get("aria-label") or "") if submit else ""
+        forms.append({
+            "action": (form.get("action") or "").strip(),
+            "method": (form.get("method") or "get").strip().lower(),
+            "field_count": len(fields),
+            "fields": fields[:20],
+            "has_submit": bool(submit),
+            "submit_text": submit_text[:120],
+        })
+
+    contact_links = [
+        (a.get("href") or "").strip()
+        for a in soup.find_all("a", href=True)
+        if (a.get("href") or "").strip().startswith(("tel:", "mailto:"))
+    ]
+    return {
+        "cta_count": len(ctas),
+        "primary_cta_count": sum(1 for cta in ctas if cta["primary"]),
+        "ctas": ctas[:50],
+        "form_count": len(forms),
+        "form_field_count": sum(form["field_count"] for form in forms),
+        "forms": forms[:20],
+        "contact_link_count": len(contact_links),
+        "contact_links": contact_links[:20],
+    }
+
+
 def _count_external_links(soup: BeautifulSoup, page_url: str) -> int:
     try:
         host = urlparse(page_url).netloc.lower()
@@ -497,10 +798,13 @@ def extract(
     table_count = len(soup.find_all("table"))
     schema_types, schema_blocks = _extract_schema_data(soup)
     external_link_count = _count_external_links(soup, url)
-    has_dates = bool(_DATE_RE.search(body_text))
+    date_published, date_modified, date_candidates = _extract_date_candidates(soup, body_text)
+    has_dates = bool(date_candidates)
     stat_count = len(_STAT_RE.findall(body_text))
     paragraphs, paragraph_link_counts = _extract_paragraphs(html_body, url)
     link_quality, link_audit_rows = _link_quality(soup, url)
+    media_items = _media_items(soup)
+    conversion_signals = _conversion_signals(soup, url)
 
     return ExtractedPage(
         url=url,
@@ -527,6 +831,9 @@ def extract(
         schema_blocks=schema_blocks,
         external_link_count=external_link_count,
         has_dates=has_dates,
+        date_published=date_published,
+        date_modified=date_modified,
+        date_candidates=date_candidates,
         stat_count=stat_count,
         paragraphs=paragraphs,
         paragraph_link_counts=paragraph_link_counts,
@@ -534,4 +841,6 @@ def extract(
         noindex_source=noindex_source,
         link_quality=link_quality,
         link_audit_rows=link_audit_rows,
+        media_items=media_items,
+        conversion_signals=conversion_signals,
     )

--- a/site_audit/freshness.py
+++ b/site_audit/freshness.py
@@ -1,0 +1,192 @@
+"""Content freshness analysis.
+
+Turns extractor date hints into page-level freshness diagnostics: how many
+pages expose dates, which pages are stale, and which content lacks any usable
+publication/update signal.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from datetime import date, datetime
+from email.utils import parsedate_to_datetime
+from statistics import median
+from typing import Iterable, Optional
+
+from .extractor import ExtractedPage
+
+
+@dataclass
+class FreshnessReport:
+    summary: dict
+    buckets: dict[str, int]
+    stale_pages: list[dict]
+    per_page: list[dict]
+
+
+_FORMATS = (
+    "%Y-%m-%d",
+    "%Y/%m/%d",
+    "%d.%m.%Y",
+    "%m/%d/%Y",
+    "%d/%m/%Y",
+    "%B %d, %Y",
+    "%b %d, %Y",
+    "%B %d %Y",
+    "%b %d %Y",
+)
+
+
+def _parse_date(value: str) -> Optional[date]:
+    raw = (value or "").strip()
+    if not raw:
+        return None
+    if len(raw) >= 10 and raw[4:5] == "-" and raw[7:8] == "-":
+        raw = raw[:10]
+    for fmt in _FORMATS:
+        try:
+            return datetime.strptime(raw, fmt).date()
+        except ValueError:
+            continue
+    try:
+        return parsedate_to_datetime(raw).date()
+    except Exception:
+        return None
+
+
+def _best_candidate(page: ExtractedPage) -> tuple[Optional[date], str, str]:
+    candidates = list(getattr(page, "date_candidates", []) or [])
+    if not candidates:
+        for value, kind, source in (
+            (getattr(page, "date_modified", ""), "modified", "field:date_modified"),
+            (getattr(page, "date_published", ""), "published", "field:date_published"),
+        ):
+            if value:
+                candidates.append({"date": value, "kind": kind, "source": source})
+
+    parsed: list[tuple[date, str, str]] = []
+    for candidate in candidates:
+        parsed_date = _parse_date(str(candidate.get("date", "")))
+        if parsed_date is None:
+            continue
+        parsed.append((
+            parsed_date,
+            str(candidate.get("kind") or "visible"),
+            str(candidate.get("source") or ""),
+        ))
+    if not parsed:
+        return None, "", ""
+
+    modified = [item for item in parsed if item[1] == "modified"]
+    if modified:
+        return max(modified, key=lambda item: item[0])
+    return max(parsed, key=lambda item: item[0])
+
+
+def _bucket(age_days: Optional[int], stale_days: int, very_stale_days: int) -> str:
+    if age_days is None:
+        return "unknown"
+    if age_days < 0:
+        return "future"
+    if age_days <= 90:
+        return "fresh"
+    if age_days <= stale_days:
+        return "aging"
+    if age_days <= very_stale_days:
+        return "stale"
+    return "very_stale"
+
+
+def analyze(
+    pages: Iterable[ExtractedPage],
+    today: Optional[date] = None,
+    stale_days: int = 365,
+    very_stale_days: int = 730,
+) -> FreshnessReport:
+    page_list = list(pages)
+    today_date = today or date.today()
+    bucket_counts: Counter[str] = Counter()
+    per_page: list[dict] = []
+    ages: list[int] = []
+    dated_values: list[date] = []
+
+    for page in page_list:
+        best_date, date_kind, date_source = _best_candidate(page)
+        age_days: Optional[int] = None
+        issues: list[str] = []
+        if best_date is None:
+            issues.append("missing_date")
+        else:
+            age_days = (today_date - best_date).days
+            dated_values.append(best_date)
+            if age_days >= 0:
+                ages.append(age_days)
+            if age_days < 0:
+                issues.append("future_date")
+            elif age_days > very_stale_days:
+                issues.append("very_stale")
+            elif age_days > stale_days:
+                issues.append("stale")
+
+        bucket = _bucket(age_days, stale_days, very_stale_days)
+        bucket_counts[bucket] += 1
+        per_page.append({
+            "url": page.url,
+            "title": page.title,
+            "date": best_date.isoformat() if best_date else "",
+            "date_kind": date_kind,
+            "date_source": date_source,
+            "age_days": age_days,
+            "bucket": bucket,
+            "issues": issues,
+        })
+
+    total = len(page_list)
+    stale_pages = [
+        row for row in per_page
+        if row["bucket"] in {"stale", "very_stale", "unknown", "future"}
+    ]
+    stale_pages.sort(key=lambda row: (
+        row["bucket"] != "unknown",
+        -(row["age_days"] if row["age_days"] is not None else 10**9),
+        row["url"],
+    ))
+    per_page.sort(key=lambda row: (
+        row["bucket"] != "unknown",
+        -(row["age_days"] if row["age_days"] is not None else 10**9),
+        row["url"],
+    ))
+
+    pages_with_date = len(dated_values)
+    stale_count = bucket_counts["stale"] + bucket_counts["very_stale"]
+    summary = {
+        "total_pages": total,
+        "pages_with_date": pages_with_date,
+        "date_coverage": pages_with_date / total if total else 0.0,
+        "missing_dates": bucket_counts["unknown"],
+        "pages_stale": stale_count,
+        "stale_share": stale_count / total if total else 0.0,
+        "pages_very_stale": bucket_counts["very_stale"],
+        "future_dates": bucket_counts["future"],
+        "median_age_days": int(median(ages)) if ages else None,
+        "newest_date": max(dated_values).isoformat() if dated_values else "",
+        "oldest_date": min(dated_values).isoformat() if dated_values else "",
+        "stale_days": stale_days,
+        "very_stale_days": very_stale_days,
+    }
+    return FreshnessReport(
+        summary=summary,
+        buckets=dict(bucket_counts),
+        stale_pages=stale_pages[:200],
+        per_page=per_page,
+    )
+
+
+def to_payload(report: FreshnessReport) -> dict:
+    return {
+        "summary": report.summary,
+        "buckets": report.buckets,
+        "stale_pages": report.stale_pages,
+        "per_page": report.per_page,
+    }

--- a/site_audit/html_report.py
+++ b/site_audit/html_report.py
@@ -44,6 +44,13 @@ _PLACEHOLDERS = {
     "__LINKBUILDING_JSON__": "linkbuilding",
     "__STRUCTURED_DATA_JSON__": "structured_data",
     "__METADATA_QUALITY_JSON__": "metadata_quality",
+    "__MEDIA_ACCESSIBILITY_JSON__": "media_accessibility",
+    "__PAGE_TYPES_JSON__": "page_types",
+    "__ENTITIES_JSON__": "entities",
+    "__FRESHNESS_JSON__": "freshness",
+    "__CONVERSION_JSON__": "conversion",
+    "__INDEXABILITY_JSON__": "indexability",
+    "__PERFORMANCE_JSON__": "performance",
 }
 
 
@@ -234,6 +241,13 @@ def write_html_report(
     linkbuilding: Optional[dict] = None,
     structured_data: Optional[dict] = None,
     metadata_quality: Optional[dict] = None,
+    media_accessibility: Optional[dict] = None,
+    page_types: Optional[dict] = None,
+    entities: Optional[dict] = None,
+    freshness: Optional[dict] = None,
+    conversion: Optional[dict] = None,
+    indexability: Optional[dict] = None,
+    performance: Optional[dict] = None,
 ) -> Path:
     template = template_path.read_text(encoding="utf-8")
 
@@ -264,6 +278,13 @@ def write_html_report(
         "linkbuilding": linkbuilding or {},
         "structured_data": structured_data or {},
         "metadata_quality": metadata_quality or {},
+        "media_accessibility": media_accessibility or {},
+        "page_types": page_types or {},
+        "entities": entities or {},
+        "freshness": freshness or {},
+        "conversion": conversion or {},
+        "indexability": indexability or {},
+        "performance": performance or {},
     }
 
     rendered = template

--- a/site_audit/indexability.py
+++ b/site_audit/indexability.py
@@ -1,0 +1,53 @@
+"""Indexability and crawlability funnel analysis."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from typing import Iterable
+
+
+@dataclass
+class IndexabilityReport:
+    summary: dict
+    status_counts: dict[str, int]
+    skipped: list[dict]
+    noindex_pages: list[dict]
+
+
+def analyze(fetched: Iterable, extraction_rows: list[dict], analyzed_urls: set[str]) -> IndexabilityReport:
+    fetched_list = list(fetched)
+    status_counts = Counter(str(getattr(row, "status", 0) or 0) for row in fetched_list)
+    skipped = [row for row in extraction_rows if row.get("status") != "analyzed"]
+    noindex_pages = [row for row in extraction_rows if row.get("reason") == "noindex"]
+    extracted_ok = sum(1 for row in extraction_rows if row.get("status") in {"analyzed", "skipped"})
+
+    reason_counts = Counter(row.get("reason", "unknown") for row in skipped)
+    total_fetched = len(fetched_list)
+    analyzed_count = len(analyzed_urls)
+    summary = {
+        "fetched_pages": total_fetched,
+        "extracted_pages": extracted_ok,
+        "analyzed_pages": analyzed_count,
+        "skipped_pages": len(skipped),
+        "noindex_pages": len(noindex_pages),
+        "indexable_share": analyzed_count / total_fetched if total_fetched else 0.0,
+        "noindex_share": len(noindex_pages) / total_fetched if total_fetched else 0.0,
+        "unusable_pages": reason_counts.get("unusable", 0),
+        "empty_embedding_pages": reason_counts.get("empty_embedding_text", 0),
+    }
+    return IndexabilityReport(
+        summary=summary,
+        status_counts=dict(status_counts),
+        skipped=skipped[:500],
+        noindex_pages=noindex_pages[:500],
+    )
+
+
+def to_payload(report: IndexabilityReport) -> dict:
+    return {
+        "summary": report.summary,
+        "status_counts": report.status_counts,
+        "skipped": report.skipped,
+        "noindex_pages": report.noindex_pages,
+    }

--- a/site_audit/media_accessibility.py
+++ b/site_audit/media_accessibility.py
@@ -1,0 +1,155 @@
+"""Media accessibility analysis."""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import Iterable
+from urllib.parse import urlparse
+
+from .extractor import ExtractedPage
+
+
+@dataclass
+class MediaAccessibilityReport:
+    summary: dict
+    issues_by_type: dict[str, int]
+    per_page: list[dict]
+    media_with_issues: list[dict]
+
+
+_GENERIC_ALT_RE = re.compile(r"^(?:image|img|photo|picture|graphic|icon|logo|banner)(?:\s+\d+)?$", re.I)
+
+
+def _image_filename(src: str) -> str:
+    path = urlparse(src or "").path or src or ""
+    name = PurePosixPath(path).stem
+    return re.sub(r"[-_]+", " ", name).strip().lower()
+
+
+def _is_decorative(item: dict) -> bool:
+    role = (item.get("role") or "").lower()
+    return bool(item.get("aria_hidden")) or role in {"presentation", "none"}
+
+
+def _image_issues(item: dict) -> list[str]:
+    issues: list[str] = []
+    alt = (item.get("alt") or "").strip()
+    alt_present = bool(item.get("alt_present"))
+    decorative = _is_decorative(item)
+    if not alt_present and not decorative:
+        issues.append("image_missing_alt")
+    if alt_present and not alt and item.get("in_link"):
+        if not (item.get("link_text") or item.get("link_title") or item.get("link_aria_label")):
+            issues.append("linked_image_empty_alt")
+    if alt:
+        if len(alt) > 125:
+            issues.append("image_long_alt")
+        if _GENERIC_ALT_RE.match(alt):
+            issues.append("image_generic_alt")
+        filename = _image_filename(item.get("src") or "")
+        if filename and alt.lower() == filename:
+            issues.append("image_filename_alt")
+    return issues
+
+
+def _media_issues(item: dict) -> list[str]:
+    media_type = item.get("type")
+    if media_type == "image":
+        return _image_issues(item)
+    if media_type == "video" and not item.get("has_captions"):
+        return ["video_missing_captions"]
+    if media_type == "audio" and not item.get("has_transcript_hint"):
+        return ["audio_missing_transcript"]
+    if media_type == "iframe" and not (item.get("title") or item.get("aria_label")):
+        return ["iframe_missing_title"]
+    return []
+
+
+def analyze(pages: Iterable[ExtractedPage]) -> MediaAccessibilityReport:
+    page_list = list(pages)
+    issues_by_type: Counter[str] = Counter()
+    per_page: list[dict] = []
+    media_with_issues: list[dict] = []
+    media_type_counts: Counter[str] = Counter()
+    pages_with_media = 0
+    pages_with_issues = 0
+    decorative_images = 0
+
+    for page in page_list:
+        items = list(page.media_items or [])
+        if items:
+            pages_with_media += 1
+        page_issues: Counter[str] = Counter()
+        for idx, item in enumerate(items):
+            media_type = str(item.get("type") or "unknown")
+            media_type_counts[media_type] += 1
+            if media_type == "image" and _is_decorative(item):
+                decorative_images += 1
+            issues = _media_issues(item)
+            if not issues:
+                continue
+            page_issues.update(issues)
+            issues_by_type.update(issues)
+            media_with_issues.append({
+                "url": page.url,
+                "title": page.title,
+                "index": idx,
+                "type": media_type,
+                "src": item.get("src", ""),
+                "alt": item.get("alt", ""),
+                "issues": issues,
+            })
+        if page_issues:
+            pages_with_issues += 1
+        per_page.append({
+            "url": page.url,
+            "title": page.title,
+            "media_count": len(items),
+            "image_count": sum(1 for item in items if item.get("type") == "image"),
+            "video_count": sum(1 for item in items if item.get("type") == "video"),
+            "audio_count": sum(1 for item in items if item.get("type") == "audio"),
+            "iframe_count": sum(1 for item in items if item.get("type") == "iframe"),
+            "issues": dict(page_issues),
+            "issue_count": sum(page_issues.values()),
+        })
+
+    total_pages = len(page_list)
+    summary = {
+        "total_pages": total_pages,
+        "pages_with_media": pages_with_media,
+        "pages_with_issues": pages_with_issues,
+        "issue_share": pages_with_issues / total_pages if total_pages else 0.0,
+        "total_media": sum(media_type_counts.values()),
+        "total_images": media_type_counts.get("image", 0),
+        "decorative_images": decorative_images,
+        "images_missing_alt": issues_by_type.get("image_missing_alt", 0),
+        "linked_images_empty_alt": issues_by_type.get("linked_image_empty_alt", 0),
+        "images_long_alt": issues_by_type.get("image_long_alt", 0),
+        "images_generic_alt": issues_by_type.get("image_generic_alt", 0),
+        "images_filename_alt": issues_by_type.get("image_filename_alt", 0),
+        "total_videos": media_type_counts.get("video", 0),
+        "videos_missing_captions": issues_by_type.get("video_missing_captions", 0),
+        "total_audio": media_type_counts.get("audio", 0),
+        "audio_missing_transcript": issues_by_type.get("audio_missing_transcript", 0),
+        "total_iframes": media_type_counts.get("iframe", 0),
+        "iframes_missing_title": issues_by_type.get("iframe_missing_title", 0),
+    }
+    per_page.sort(key=lambda row: (-row["issue_count"], -row["media_count"], row["url"]))
+    return MediaAccessibilityReport(
+        summary=summary,
+        issues_by_type=dict(issues_by_type),
+        per_page=per_page,
+        media_with_issues=media_with_issues[:300],
+    )
+
+
+def to_payload(report: MediaAccessibilityReport) -> dict:
+    return {
+        "summary": report.summary,
+        "issues_by_type": report.issues_by_type,
+        "per_page": report.per_page,
+        "media_with_issues": report.media_with_issues,
+    }

--- a/site_audit/page_types.py
+++ b/site_audit/page_types.py
@@ -1,0 +1,269 @@
+"""Page type and template classification.
+
+This module is intentionally heuristic and cheap: it uses signals the
+extractor already collects (URL path, title/H1, schema types, headings,
+word count, lists/tables, and paragraph count) to classify every page into
+an editorial page type and a reusable template family.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from typing import Iterable
+from urllib.parse import urlparse
+
+from .extractor import ExtractedPage
+
+
+@dataclass
+class PageTypeRow:
+    url: str
+    title: str
+    page_type: str
+    template_family: str
+    template_signature: str
+    confidence: float
+    signals: list[str]
+
+
+@dataclass
+class PageTypeReport:
+    summary: dict
+    type_counts: list[dict]
+    template_counts: list[dict]
+    per_page: list[dict]
+
+
+_ARTICLE_SCHEMA = {"Article", "NewsArticle", "BlogPosting", "TechArticle", "Report"}
+_PRODUCT_SCHEMA = {"Product", "Service"}
+_FAQ_SCHEMA = {"FAQPage", "QAPage", "HowTo"}
+_LOCAL_SCHEMA = {"LocalBusiness", "Organization"}
+
+_BLOG_RE = re.compile(r"/(blog|news|articles?|insights?|resources?|press)/", re.I)
+_PRODUCT_RE = re.compile(r"/(products?|solutions?|pricing|shop|store)/", re.I)
+_SERVICE_RE = re.compile(r"/(services?|agency|consulting)/", re.I)
+_DOCS_RE = re.compile(r"/(docs?|documentation|guides?|manual|help|support|kb|learn)/", re.I)
+_FAQ_RE = re.compile(r"/(faq|faqs|questions|how-to|howto)/", re.I)
+_CONTACT_RE = re.compile(r"/(contact|locations?|book|demo|request)/?$", re.I)
+_ABOUT_RE = re.compile(r"/(about|team|company|careers?)/?$", re.I)
+_LEGAL_RE = re.compile(r"/(privacy|terms|legal|cookies?|gdpr|impressum)/?$", re.I)
+_LISTING_RE = re.compile(r"/(category|categories|tag|tags|archive|author|topics?|collections?)/", re.I)
+_SEARCH_RE = re.compile(r"/(search|find)/?$", re.I)
+
+_QUESTION_RE = re.compile(r"\b(what|why|how|when|where|who|which|can|should|does|do|is|are)\b", re.I)
+
+
+def _path(url: str) -> str:
+    parsed = urlparse(url)
+    return parsed.path or "/"
+
+
+def _text_blob(page: ExtractedPage) -> str:
+    parts = [page.title, page.h1, page.description, " ".join(page.headings or [])]
+    return " ".join(part for part in parts if part).lower()
+
+
+def _schema_set(page: ExtractedPage) -> set[str]:
+    return {str(schema_type) for schema_type in (page.schema_types or [])}
+
+
+def _is_home(path: str) -> bool:
+    return path in ("", "/")
+
+
+def _bucket(value: int, cuts: tuple[int, ...]) -> str:
+    for cut in cuts:
+        if value <= cut:
+            return f"le{cut}"
+    return f"gt{cuts[-1]}"
+
+
+def _score_candidates(page: ExtractedPage) -> dict[str, list[str]]:
+    path = _path(page.url)
+    blob = _text_blob(page)
+    schema = _schema_set(page)
+    headings = page.headers_rich or []
+    paragraphs = page.paragraphs or []
+    candidates: dict[str, list[str]] = defaultdict(list)
+
+    if _is_home(path):
+        candidates["home"].append("root_url")
+    if schema & _ARTICLE_SCHEMA:
+        candidates["article"].append("article_schema")
+    if "BlogPosting" in schema:
+        candidates["blog_post"].append("blog_schema")
+    if _BLOG_RE.search(path):
+        candidates["blog_post"].append("blog_url")
+        if schema & _ARTICLE_SCHEMA:
+            candidates["blog_post"].append("article_in_blog_section")
+    if schema & _PRODUCT_SCHEMA:
+        candidates["product"].append("product_or_service_schema")
+    if _PRODUCT_RE.search(path):
+        candidates["product"].append("product_url")
+    if _SERVICE_RE.search(path) or "service" in blob:
+        candidates["service"].append("service_url_or_text")
+    if schema & _FAQ_SCHEMA or _FAQ_RE.search(path):
+        candidates["faq"].append("faq_howto_signal")
+    if _DOCS_RE.search(path):
+        candidates["docs"].append("docs_url")
+    if _CONTACT_RE.search(path) or "contact" in blob:
+        candidates["contact"].append("contact_signal")
+    if _ABOUT_RE.search(path) or any(word in blob for word in ("about us", "our team", "company")):
+        candidates["about"].append("about_signal")
+    if _LEGAL_RE.search(path):
+        candidates["legal"].append("legal_url")
+    if _SEARCH_RE.search(path):
+        candidates["search"].append("search_url")
+    if _LISTING_RE.search(path):
+        candidates["listing"].append("listing_url")
+
+    question_headings = sum(
+        1 for heading in headings
+        if _QUESTION_RE.search(str(heading.get("text", "")))
+    )
+    if question_headings >= 3:
+        candidates["faq"].append("question_headings")
+    if page.list_count >= 3 and page.word_count < 900 and len(paragraphs) <= 5:
+        candidates["listing"].append("many_lists_low_body")
+    if page.table_count >= 1 and any(word in blob for word in ("pricing", "compare", "specification", "plans")):
+        candidates["product"].append("commercial_table")
+    if page.has_dates and page.word_count >= 500 and not candidates.get("product"):
+        candidates["article"].append("dated_longform")
+    if page.word_count >= 700 and len(paragraphs) >= 4 and not _is_home(path):
+        candidates["article"].append("longform_body")
+    if schema & _LOCAL_SCHEMA and _CONTACT_RE.search(path):
+        candidates["contact"].append("local_business_contact")
+
+    return candidates
+
+
+def classify_page(page: ExtractedPage) -> PageTypeRow:
+    """Classify one extracted page."""
+    candidates = _score_candidates(page)
+    priority = [
+        "home", "contact", "legal", "search", "faq", "product", "service",
+        "docs", "blog_post", "article", "listing", "about",
+    ]
+    weighted = {
+        page_type: len(signals) + (1 if page_type in {"home", "contact", "legal", "search"} else 0)
+        for page_type, signals in candidates.items()
+    }
+    page_type = "other"
+    if weighted:
+        page_type = max(weighted, key=lambda name: (weighted[name], -priority.index(name) if name in priority else -99))
+    signals = sorted(set(candidates.get(page_type, [])))
+    confidence = min(0.95, 0.45 + 0.15 * len(signals)) if signals else 0.35
+    template_family = _template_family(page_type)
+    signature = template_signature(page, page_type, template_family)
+    return PageTypeRow(
+        url=page.url,
+        title=page.title,
+        page_type=page_type,
+        template_family=template_family,
+        template_signature=signature,
+        confidence=round(confidence, 2),
+        signals=signals,
+    )
+
+
+def _template_family(page_type: str) -> str:
+    if page_type == "home":
+        return "home_template"
+    if page_type in {"article", "blog_post", "docs", "faq"}:
+        return "content_template"
+    if page_type in {"product", "service"}:
+        return "commercial_template"
+    if page_type in {"listing", "search"}:
+        return "listing_template"
+    if page_type in {"contact", "about"}:
+        return "company_template"
+    if page_type == "legal":
+        return "legal_template"
+    return "generic_template"
+
+
+def template_signature(page: ExtractedPage, page_type: str, template_family: str) -> str:
+    """Build a stable structural fingerprint for template grouping."""
+    h1_count = page.h1_count or (1 if page.h1 else 0)
+    headers = page.headers_rich or []
+    header_levels = Counter(int(h.get("level", 0)) for h in headers if h.get("level"))
+    schema_bucket = "+".join(sorted(_schema_set(page))[:3]) or "no_schema"
+    return "|".join([
+        template_family,
+        page_type,
+        schema_bucket,
+        f"h1:{_bucket(h1_count, (0, 1, 2))}",
+        f"h2:{_bucket(header_levels.get(2, 0), (0, 2, 6))}",
+        f"h3:{_bucket(header_levels.get(3, 0), (0, 4, 10))}",
+        f"lists:{_bucket(page.list_count, (0, 1, 4))}",
+        f"tables:{_bucket(page.table_count, (0, 1, 3))}",
+        f"paras:{_bucket(len(page.paragraphs or []), (0, 3, 8))}",
+        f"words:{_bucket(page.word_count, (250, 750, 1500))}",
+    ])
+
+
+def analyze(pages: Iterable[ExtractedPage]) -> PageTypeReport:
+    page_list = list(pages)
+    rows = [classify_page(page) for page in page_list]
+    type_counts_counter = Counter(row.page_type for row in rows)
+    template_counts_counter = Counter(row.template_family for row in rows)
+    signature_groups: dict[str, list[PageTypeRow]] = defaultdict(list)
+    for row in rows:
+        signature_groups[row.template_signature].append(row)
+
+    per_page = [
+        {
+            "url": row.url,
+            "title": row.title,
+            "page_type": row.page_type,
+            "template_family": row.template_family,
+            "template_signature": row.template_signature,
+            "confidence": row.confidence,
+            "signals": row.signals,
+        }
+        for row in rows
+    ]
+    per_page.sort(key=lambda row: (row["page_type"], row["url"]))
+
+    total_pages = len(rows)
+    type_counts = [
+        {"page_type": page_type, "pages": count, "share": count / total_pages if total_pages else 0.0}
+        for page_type, count in type_counts_counter.most_common()
+    ]
+    template_counts = [
+        {
+            "template_family": family,
+            "pages": count,
+            "share": count / total_pages if total_pages else 0.0,
+            "signatures": sum(
+                1 for signature, group in signature_groups.items()
+                if group and group[0].template_family == family
+            ),
+        }
+        for family, count in template_counts_counter.most_common()
+    ]
+    summary = {
+        "total_pages": total_pages,
+        "page_type_count": len(type_counts_counter),
+        "template_family_count": len(template_counts_counter),
+        "template_signature_count": len(signature_groups),
+        "dominant_page_type": type_counts[0]["page_type"] if type_counts else "",
+        "dominant_template_family": template_counts[0]["template_family"] if template_counts else "",
+    }
+    return PageTypeReport(
+        summary=summary,
+        type_counts=type_counts,
+        template_counts=template_counts,
+        per_page=per_page,
+    )
+
+
+def to_payload(report: PageTypeReport) -> dict:
+    return {
+        "summary": report.summary,
+        "type_counts": report.type_counts,
+        "template_counts": report.template_counts,
+        "per_page": report.per_page,
+    }

--- a/site_audit/performance.py
+++ b/site_audit/performance.py
@@ -1,0 +1,195 @@
+"""Lightweight offline performance signals.
+
+This module intentionally avoids browser automation or network fetches. It
+uses only the HTML responses already collected by the crawler, so the output
+is a cheap set of page-weight and render-blocking heuristics rather than lab
+performance metrics.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from statistics import median
+from typing import Iterable
+
+from bs4 import BeautifulSoup
+
+
+_IMAGE_WEIGHT = 120_000
+_SCRIPT_WEIGHT = 35_000
+_STYLE_WEIGHT = 20_000
+_FONT_WEIGHT = 40_000
+_PRELOAD_WEIGHT = 20_000
+
+
+@dataclass
+class PerformanceReport:
+    summary: dict
+    buckets: dict
+    per_page: list[dict]
+    top_heavy_pages: list[dict]
+    render_blocking_pages: list[dict]
+
+
+def _html_weight(fetch) -> int:
+    byte_count = int(getattr(fetch, "content_length_bytes", 0) or 0)
+    if byte_count:
+        return byte_count
+    return len((getattr(fetch, "body", "") or "").encode("utf-8"))
+
+
+def _has_rel(tag, value: str) -> bool:
+    rel = tag.get("rel") or []
+    if isinstance(rel, str):
+        rel = rel.split()
+    return value.lower() in {str(item).lower() for item in rel}
+
+
+def _is_font_link(tag) -> bool:
+    href = str(tag.get("href") or "").lower()
+    as_attr = str(tag.get("as") or "").lower()
+    type_attr = str(tag.get("type") or "").lower()
+    return as_attr == "font" or "font/" in type_attr or any(ext in href for ext in (".woff", ".woff2", ".ttf", ".otf", ".eot"))
+
+
+def _is_blocking_stylesheet(tag) -> bool:
+    if not _has_rel(tag, "stylesheet") or tag.has_attr("disabled"):
+        return False
+    media = str(tag.get("media") or "").strip().lower()
+    return not media or media in {"all", "screen"}
+
+
+def _is_blocking_script(tag) -> bool:
+    if not tag.get("src"):
+        return False
+    script_type = str(tag.get("type") or "").strip().lower()
+    if script_type == "module":
+        return False
+    return not (tag.has_attr("async") or tag.has_attr("defer"))
+
+
+def _bucket(estimated_weight: int) -> str:
+    if estimated_weight < 500_000:
+        return "light"
+    if estimated_weight < 1_500_000:
+        return "moderate"
+    if estimated_weight < 3_000_000:
+        return "heavy"
+    return "very_heavy"
+
+
+def _percentile(values: list[float], q: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    pos = (len(ordered) - 1) * q
+    lo = int(pos)
+    hi = min(lo + 1, len(ordered) - 1)
+    frac = pos - lo
+    return float(ordered[lo] * (1 - frac) + ordered[hi] * frac)
+
+
+def _row(fetch) -> dict:
+    body = getattr(fetch, "body", "") or ""
+    soup = BeautifulSoup(body, "html.parser")
+    scripts = soup.find_all("script")
+    styles = soup.find_all("style")
+    links = soup.find_all("link")
+    images = soup.find_all("img")
+
+    script_count = len(scripts)
+    external_script_count = sum(1 for tag in scripts if tag.get("src"))
+    inline_script_count = script_count - external_script_count
+    stylesheet_count = sum(1 for tag in links if _has_rel(tag, "stylesheet"))
+    inline_style_count = len(styles)
+    style_attr_count = len(soup.select("[style]"))
+    font_count = sum(1 for tag in links if _is_font_link(tag))
+    preload_count = sum(1 for tag in links if _has_rel(tag, "preload"))
+    blocking_css_count = sum(1 for tag in links if _is_blocking_stylesheet(tag))
+    blocking_script_count = sum(1 for tag in scripts if _is_blocking_script(tag))
+    html_weight_bytes = _html_weight(fetch)
+    estimated_weight_bytes = (
+        html_weight_bytes
+        + len(images) * _IMAGE_WEIGHT
+        + external_script_count * _SCRIPT_WEIGHT
+        + stylesheet_count * _STYLE_WEIGHT
+        + font_count * _FONT_WEIGHT
+        + preload_count * _PRELOAD_WEIGHT
+    )
+
+    return {
+        "url": getattr(fetch, "url", ""),
+        "status": int(getattr(fetch, "status", 0) or 0),
+        "content_type": getattr(fetch, "content_type", "") or "",
+        "content_size_bytes": int(getattr(fetch, "content_length_bytes", 0) or html_weight_bytes),
+        "html_weight_bytes": html_weight_bytes,
+        "estimated_weight_bytes": estimated_weight_bytes,
+        "weight_bucket": _bucket(estimated_weight_bytes),
+        "image_count": len(images),
+        "script_count": script_count,
+        "external_script_count": external_script_count,
+        "inline_script_count": inline_script_count,
+        "stylesheet_count": stylesheet_count,
+        "inline_style_count": inline_style_count,
+        "style_attr_count": style_attr_count,
+        "font_count": font_count,
+        "preload_count": preload_count,
+        "resource_tag_count": len(images) + script_count + stylesheet_count + font_count + preload_count,
+        "render_blocking_css_count": blocking_css_count,
+        "render_blocking_script_count": blocking_script_count,
+        "render_blocking_count": blocking_css_count + blocking_script_count,
+    }
+
+
+def analyze(fetched_pages: Iterable) -> PerformanceReport:
+    rows = [_row(fetch) for fetch in fetched_pages]
+    bucket_counts = Counter(row["weight_bucket"] for row in rows)
+    statuses = Counter(str(row["status"]) for row in rows)
+    html_weights = [float(row["html_weight_bytes"]) for row in rows]
+    estimated_weights = [float(row["estimated_weight_bytes"]) for row in rows]
+    total_pages = len(rows)
+    pages_with_blocking = sum(1 for row in rows if row["render_blocking_count"] > 0)
+    heavy_pages = sum(1 for row in rows if row["weight_bucket"] in {"heavy", "very_heavy"})
+
+    summary = {
+        "total_pages": total_pages,
+        "status_counts": dict(sorted(statuses.items())),
+        "total_content_size_bytes": sum(int(row["content_size_bytes"]) for row in rows),
+        "total_html_weight_bytes": sum(int(row["html_weight_bytes"]) for row in rows),
+        "median_html_weight_bytes": int(median(html_weights)) if html_weights else 0,
+        "p90_html_weight_bytes": int(_percentile(html_weights, 0.9)),
+        "median_estimated_weight_bytes": int(median(estimated_weights)) if estimated_weights else 0,
+        "p90_estimated_weight_bytes": int(_percentile(estimated_weights, 0.9)),
+        "avg_resource_tags_per_page": round(sum(row["resource_tag_count"] for row in rows) / total_pages, 2) if total_pages else 0.0,
+        "total_images": sum(row["image_count"] for row in rows),
+        "total_scripts": sum(row["script_count"] for row in rows),
+        "total_stylesheets": sum(row["stylesheet_count"] for row in rows),
+        "total_fonts": sum(row["font_count"] for row in rows),
+        "total_preloads": sum(row["preload_count"] for row in rows),
+        "pages_with_render_blocking": pages_with_blocking,
+        "render_blocking_share": pages_with_blocking / total_pages if total_pages else 0.0,
+        "heavy_pages": heavy_pages,
+        "heavy_page_share": heavy_pages / total_pages if total_pages else 0.0,
+    }
+
+    return PerformanceReport(
+        summary=summary,
+        buckets={bucket: int(bucket_counts.get(bucket, 0)) for bucket in ("light", "moderate", "heavy", "very_heavy")},
+        per_page=sorted(rows, key=lambda row: (-row["estimated_weight_bytes"], row["url"])),
+        top_heavy_pages=sorted(rows, key=lambda row: (-row["estimated_weight_bytes"], row["url"]))[:25],
+        render_blocking_pages=[
+            row for row in sorted(rows, key=lambda row: (-row["render_blocking_count"], -row["estimated_weight_bytes"], row["url"]))
+            if row["render_blocking_count"] > 0
+        ][:25],
+    )
+
+
+def to_payload(report: PerformanceReport) -> dict:
+    return {
+        "summary": report.summary,
+        "buckets": report.buckets,
+        "top_heavy_pages": report.top_heavy_pages,
+        "render_blocking_pages": report.render_blocking_pages,
+        "per_page": report.per_page,
+    }

--- a/site_audit/pipeline.py
+++ b/site_audit/pipeline.py
@@ -46,6 +46,8 @@ from .content_quality import (
     wrong_home_paragraphs,
     wrong_home_payload,
 )
+from .conversion import analyze as analyze_conversion
+from .conversion import to_payload as conversion_payload
 from .paragraph_clustering import (
     cluster_and_label as cluster_paragraphs,
     project_paragraphs,
@@ -54,13 +56,19 @@ from .paragraph_clustering import (
 )
 from .crawler import Crawler, CrawlConfig
 from .embedder import DEFAULT_MODEL, EmbedInput, Embedder
+from .entities import analyze as analyze_entities
+from .entities import to_payload as entities_payload
 from .external_links import analyze as analyze_external
 from .external_links import to_payload as external_payload
 from .extractor import extract
+from .freshness import analyze as analyze_freshness
+from .freshness import to_payload as freshness_payload
 from .header_analysis import analyse as analyse_headers
 from .header_analysis import headers_for_scatter
 from .linkbuilding import analyse as analyse_linkbuilding
 from .html_report import write_html_report
+from .indexability import analyze as analyze_indexability
+from .indexability import to_payload as indexability_payload
 from .keyword_coverage import (
     auto_mine_queries, load_queries_from_file, match_queries,
     match_queries_to_paragraphs, paragraph_match_payload,
@@ -68,13 +76,19 @@ from .keyword_coverage import (
 )
 from .linkgraph import analyze as analyze_linkgraph
 from .linkgraph import to_payload as linkgraph_payload
+from .media_accessibility import analyze as analyze_media_accessibility
+from .media_accessibility import to_payload as media_accessibility_payload
 from .metadata_quality import analyze as analyze_metadata_quality
 from .metadata_quality import to_payload as metadata_quality_payload
+from .page_types import analyze as analyze_page_types
+from .page_types import to_payload as page_types_payload
 from .paragraph_density import compute_rows as compute_paragraph_density_rows
 from .paragraph_density import density_lookup as paragraph_density_lookup
 from .paragraph_density import to_payload as paragraph_density_payload
 from .paragraph_links import recommend as recommend_paragraph_links
 from .paragraph_links import to_payload as paragraph_links_payload
+from .performance import analyze as analyze_performance
+from .performance import to_payload as performance_payload
 from .recommendations import synthesize as synthesize_recommendations
 from .recommendations import to_payload as recommendations_payload
 from .report import build_duplicate_rows, build_outlier_rows, write_all
@@ -184,11 +198,18 @@ def run(config: PipelineConfig) -> dict:
     embed_inputs: list[EmbedInput] = []
     outlinks_map: dict[str, list[tuple[str, str]]] = {}
     external_map: dict[str, list[tuple[str, str]]] = {}
+    extraction_rows: list[dict] = []
 
     noindex_dropped = 0
     for r in fetched:
         ext = extract(r.url, r.body, max_chars=config.max_chars, x_robots_tag=getattr(r, "x_robots_tag", ""))
         if ext is None or not ext.title:
+            extraction_rows.append({
+                "url": r.url,
+                "status": "skipped",
+                "reason": "unusable",
+                "http_status": getattr(r, "status", 0),
+            })
             continue
         if ext.noindex:
             # The page asked search engines not to index it — exclude from
@@ -197,10 +218,25 @@ def run(config: PipelineConfig) -> dict:
             # contribute to authority), but the page itself does not
             # count toward focus / clusters / coverage / recommendations.
             noindex_dropped += 1
+            extraction_rows.append({
+                "url": r.url,
+                "title": ext.title,
+                "status": "skipped",
+                "reason": "noindex",
+                "source": ext.noindex_source,
+                "http_status": getattr(r, "status", 0),
+            })
             continue
         section = section_for_url(r.url)
         embed_text = ". ".join(part for part in [ext.title, ext.description, ext.body] if part)
         if not embed_text.strip():
+            extraction_rows.append({
+                "url": r.url,
+                "title": ext.title,
+                "status": "skipped",
+                "reason": "empty_embedding_text",
+                "http_status": getattr(r, "status", 0),
+            })
             continue
         page = PageInfo(
             url=r.url,
@@ -215,6 +251,13 @@ def run(config: PipelineConfig) -> dict:
         embed_inputs.append(EmbedInput(url=r.url, text=embed_text))
         outlinks_map[r.url] = r.outlinks or []
         external_map[r.url] = r.external_links or []
+        extraction_rows.append({
+            "url": r.url,
+            "title": ext.title,
+            "status": "analyzed",
+            "reason": "",
+            "http_status": getattr(r, "status", 0),
+        })
     if noindex_dropped:
         LOG.info("  dropped %d noindex pages (meta robots / X-Robots-Tag)", noindex_dropped)
 
@@ -223,6 +266,26 @@ def run(config: PipelineConfig) -> dict:
         return {"pages": 0}
 
     LOG.info("  prepared %d pages for embedding", len(pages))
+
+    indexability_data = indexability_payload(
+        analyze_indexability(fetched, extraction_rows, {p.url for p in pages})
+    )
+    ix_summary = indexability_data.get("summary", {}) or {}
+    LOG.info(
+        "  indexability: %.0f%% analyzed · %d noindex · %d skipped",
+        (ix_summary.get("indexable_share", 0.0) or 0.0) * 100,
+        ix_summary.get("noindex_pages", 0),
+        ix_summary.get("skipped_pages", 0),
+    )
+
+    performance_data = performance_payload(analyze_performance(fetched))
+    pf_summary = performance_data.get("summary", {}) or {}
+    LOG.info(
+        "  performance: median HTML %.0f KB · %.0f%% render-blocking · %d heavy pages",
+        (pf_summary.get("median_html_weight_bytes", 0) or 0) / 1024,
+        (pf_summary.get("render_blocking_share", 0.0) or 0.0) * 100,
+        pf_summary.get("heavy_pages", 0),
+    )
 
     # 3) Embed pages (model loaded here, reused below for queries)
     embedder = Embedder(config.model)
@@ -313,6 +376,53 @@ def run(config: PipelineConfig) -> dict:
         (mq_summary.get("issue_share", 0.0) or 0.0) * 100,
         mq_summary.get("missing_description", 0),
         mq_summary.get("missing_canonical", 0),
+    )
+
+    media_accessibility_data = media_accessibility_payload(analyze_media_accessibility(extracted_pages))
+    ma_summary = media_accessibility_data.get("summary", {}) or {}
+    LOG.info(
+        "  media accessibility: %.0f%% pages with issues · %d missing image alts · %d videos without captions",
+        (ma_summary.get("issue_share", 0.0) or 0.0) * 100,
+        ma_summary.get("images_missing_alt", 0),
+        ma_summary.get("videos_missing_captions", 0),
+    )
+
+    freshness_data = freshness_payload(analyze_freshness(extracted_pages))
+    fr_summary = freshness_data.get("summary", {}) or {}
+    LOG.info(
+        "  freshness: %.0f%% date coverage · %d stale · %d missing dates",
+        (fr_summary.get("date_coverage", 0.0) or 0.0) * 100,
+        fr_summary.get("pages_stale", 0),
+        fr_summary.get("missing_dates", 0),
+    )
+
+    conversion_data = conversion_payload(analyze_conversion(extracted_pages))
+    cv_summary = conversion_data.get("summary", {}) or {}
+    LOG.info(
+        "  conversion: %.0f%% CTA coverage · %.0f%% primary CTA coverage · %d forms · %d lead pages without capture",
+        (cv_summary.get("cta_coverage", 0.0) or 0.0) * 100,
+        (cv_summary.get("primary_cta_coverage", 0.0) or 0.0) * 100,
+        cv_summary.get("total_forms", 0),
+        cv_summary.get("lead_pages_without_capture", 0),
+    )
+
+    page_types_data = page_types_payload(analyze_page_types(extracted_pages))
+    pt_summary = page_types_data.get("summary", {}) or {}
+    LOG.info(
+        "  page types: %d types · %d template families · dominant %s / %s",
+        pt_summary.get("page_type_count", 0),
+        pt_summary.get("template_family_count", 0),
+        pt_summary.get("dominant_page_type", "—"),
+        pt_summary.get("dominant_template_family", "—"),
+    )
+
+    entities_data = entities_payload(analyze_entities(extracted_pages))
+    ent_summary = entities_data.get("summary", {}) or {}
+    LOG.info(
+        "  entities: %d unique · %.0f%% coverage · authority %.1f",
+        ent_summary.get("unique_entities", 0),
+        (ent_summary.get("entity_coverage", 0.0) or 0.0) * 100,
+        ent_summary.get("topical_authority_score", 0.0),
     )
 
     # 9) Link graph + recommendations
@@ -635,6 +745,13 @@ def run(config: PipelineConfig) -> dict:
         linkbuilding=linkbuilding_data,
         structured_data=structured_data_data,
         metadata_quality=metadata_quality_data,
+        media_accessibility=media_accessibility_data,
+        page_types=page_types_data,
+        entities=entities_data,
+        freshness=freshness_data,
+        conversion=conversion_data,
+        indexability=indexability_data,
+        performance=performance_data,
     )
 
     template_path = Path(__file__).resolve().parent.parent / "ui" / "index.html"
@@ -669,6 +786,13 @@ def run(config: PipelineConfig) -> dict:
             linkbuilding=linkbuilding_data,
             structured_data=structured_data_data,
             metadata_quality=metadata_quality_data,
+            media_accessibility=media_accessibility_data,
+            page_types=page_types_data,
+            entities=entities_data,
+            freshness=freshness_data,
+            conversion=conversion_data,
+            indexability=indexability_data,
+            performance=performance_data,
         )
         LOG.info("  HTML report: %s", html_path)
 

--- a/site_audit/report.py
+++ b/site_audit/report.py
@@ -293,6 +293,13 @@ def write_all(
     linkbuilding: Optional[dict] = None,
     structured_data: Optional[dict] = None,
     metadata_quality: Optional[dict] = None,
+    media_accessibility: Optional[dict] = None,
+    page_types: Optional[dict] = None,
+    entities: Optional[dict] = None,
+    freshness: Optional[dict] = None,
+    conversion: Optional[dict] = None,
+    indexability: Optional[dict] = None,
+    performance: Optional[dict] = None,
 ) -> dict:
     output_dir.mkdir(parents=True, exist_ok=True)
     write_site_metrics(output_dir / "site_metrics.json", result, model_name, domain)
@@ -344,4 +351,18 @@ def write_all(
         _write_json(output_dir / "structured_data.json", structured_data)
     if metadata_quality is not None:
         _write_json(output_dir / "metadata_quality.json", metadata_quality)
+    if media_accessibility is not None:
+        _write_json(output_dir / "media_accessibility.json", media_accessibility)
+    if page_types is not None:
+        _write_json(output_dir / "page_types.json", page_types)
+    if entities is not None:
+        _write_json(output_dir / "entities.json", entities)
+    if freshness is not None:
+        _write_json(output_dir / "freshness.json", freshness)
+    if conversion is not None:
+        _write_json(output_dir / "conversion.json", conversion)
+    if indexability is not None:
+        _write_json(output_dir / "indexability.json", indexability)
+    if performance is not None:
+        _write_json(output_dir / "performance.json", performance)
     return {"outliers": len(outliers), "duplicates": len(result.duplicate_pairs)}

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -1,0 +1,141 @@
+from pathlib import Path
+
+from site_audit.compare import build_payload
+from site_audit.conversion import analyze, to_payload
+from site_audit.extractor import ExtractedPage, extract
+
+
+def _page(
+    url: str,
+    title: str = "Useful page",
+    conversion_signals: dict | None = None,
+) -> ExtractedPage:
+    return ExtractedPage(
+        url=url,
+        title=title,
+        description="",
+        body="Useful content for testing conversion signals.",
+        word_count=120,
+        language="en",
+        conversion_signals=conversion_signals or {},
+    )
+
+
+def test_extract_conversion_signals_from_ctas_forms_and_contact_links() -> None:
+    html = """
+    <html><head><title>Book a consultation</title></head><body>
+      <h1>Book a consultation</h1>
+      <p>This page has enough body copy for the extractor fallback to keep it.
+      It explains a professional service, who it helps, how consultations work,
+      and why visitors should submit a request for a tailored quote today.</p>
+      <a class="btn primary" href="/contact">Request a quote</a>
+      <button>Book demo</button>
+      <a href="tel:+421900123456">Call us</a>
+      <form action="/lead" method="post">
+        <input type="text" name="name">
+        <input type="email" name="email">
+        <textarea name="message"></textarea>
+        <button type="submit">Send request</button>
+      </form>
+    </body></html>
+    """
+
+    page = extract("https://example.com/services", html, max_chars=2000)
+
+    assert page is not None
+    signals = page.conversion_signals
+    assert signals["cta_count"] == 4
+    assert signals["primary_cta_count"] == 3
+    assert signals["form_count"] == 1
+    assert signals["form_field_count"] == 3
+    assert signals["forms"][0]["has_submit"] is True
+    assert signals["contact_link_count"] == 1
+    assert [cta["text"] for cta in signals["ctas"]] == ["Request a quote", "Book demo", "Call us", "Send request"]
+
+
+def test_conversion_payload_flags_missing_and_weak_capture_paths() -> None:
+    report = to_payload(analyze([
+        _page(
+            "https://example.com/contact",
+            title="Contact sales",
+            conversion_signals={
+                "cta_count": 1,
+                "primary_cta_count": 1,
+                "ctas": [{"text": "Contact sales", "primary": True}],
+                "form_count": 1,
+                "form_field_count": 2,
+                "forms": [{"field_count": 2, "has_submit": True}],
+                "contact_link_count": 0,
+            },
+        ),
+        _page("https://example.com/pricing", title="Pricing"),
+        _page(
+            "https://example.com/blog/post",
+            conversion_signals={
+                "cta_count": 1,
+                "primary_cta_count": 0,
+                "ctas": [{"text": "Learn more", "primary": False}],
+                "form_count": 0,
+                "contact_link_count": 0,
+            },
+        ),
+        _page(
+            "https://example.com/services",
+            conversion_signals={
+                "cta_count": 9,
+                "primary_cta_count": 9,
+                "ctas": [{"text": f"Book demo {i}", "primary": True} for i in range(9)],
+                "form_count": 1,
+                "forms": [{"field_count": 1, "has_submit": False}],
+                "contact_link_count": 0,
+            },
+        ),
+    ]))
+
+    assert report["summary"]["total_pages"] == 4
+    assert report["summary"]["pages_with_cta"] == 3
+    assert report["summary"]["cta_coverage"] == 0.75
+    assert report["summary"]["primary_cta_coverage"] == 0.5
+    assert report["summary"]["form_coverage"] == 0.5
+    assert report["summary"]["lead_pages_without_capture"] == 1
+    assert report["summary"]["cta_overload_pages"] == 1
+    assert report["summary"]["forms_without_submit_pages"] == 1
+    assert report["issues_by_type"]["no_cta"] == 1
+    assert report["issues_by_type"]["only_generic_ctas"] == 1
+    assert report["top_ctas"][0] == {"text": "Contact sales", "count": 1}
+    assert report["per_page"][0]["url"] == "https://example.com/pricing"
+
+
+def test_compare_leaderboard_includes_conversion_metrics(tmp_path: Path) -> None:
+    for domain, cta_coverage, primary_coverage in [
+        ("a.example", 0.8, 0.6),
+        ("b.example", 0.3, 0.2),
+    ]:
+        report_dir = tmp_path / domain / "report"
+        report_dir.mkdir(parents=True)
+        (report_dir / "site_metrics.json").write_text(
+            '{"domain":"%s","model":"test-model","page_count":5}' % domain,
+            encoding="utf-8",
+        )
+        (report_dir / "pages.json").write_text("[]", encoding="utf-8")
+        (report_dir / "conversion.json").write_text(
+            (
+                '{"summary":{"cta_coverage":%s,'
+                '"primary_cta_coverage":%s,'
+                '"form_coverage":0.4,'
+                '"avg_ctas_per_page":2.5,'
+                '"lead_pages_without_capture":1,'
+                '"cta_overload_pages":2}}'
+            ) % (cta_coverage, primary_coverage),
+            encoding="utf-8",
+        )
+
+    payload = build_payload(["a.example", "b.example"], tmp_path)
+
+    rows = {row["domain"]: row for row in payload["leaderboard"]}
+    assert rows["a.example"]["cta_coverage"] == 0.8
+    assert rows["a.example"]["primary_cta_coverage"] == 0.6
+    assert rows["a.example"]["form_coverage"] == 0.4
+    assert rows["a.example"]["avg_ctas_per_page"] == 2.5
+    assert rows["b.example"]["cta_coverage"] == 0.3
+    assert rows["b.example"]["lead_pages_without_capture"] == 1

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1,0 +1,117 @@
+import json
+from pathlib import Path
+
+from site_audit.compare import build_payload
+from site_audit.entities import analyze, extract_entities_from_text, to_payload
+from site_audit.extractor import ExtractedPage, extract
+
+
+def _page(
+    url: str,
+    title: str,
+    body: str,
+    headings: list[str] | None = None,
+    schema_blocks: list[dict] | None = None,
+) -> ExtractedPage:
+    return ExtractedPage(
+        url=url,
+        title=title,
+        description="entity analysis for lower-case copy.",
+        body=body,
+        word_count=len(body.split()),
+        language="en",
+        headings=headings or [],
+        h1=headings[0] if headings else title,
+        headers_rich=[{"level": 1, "text": headings[0], "order": 0}] if headings else [],
+        schema_types=["Organization"] if schema_blocks else [],
+        schema_blocks=schema_blocks or [],
+    )
+
+
+def test_extracts_capitalized_entity_phrases() -> None:
+    entities = extract_entities_from_text(
+        "Acme Analytics works with Google Cloud, OpenAI, and Market Research teams."
+    )
+
+    assert "Acme Analytics" in entities
+    assert "Google Cloud" in entities
+    assert "OpenAI" in entities
+    assert "Market Research" in entities
+
+
+def test_extract_adds_schema_organization_names() -> None:
+    html = """
+    <html><head>
+      <title>Acme Analytics Strategy</title>
+      <script type="application/ld+json">
+        {"@context":"https://schema.org","@type":"Organization","name":"Acme Analytics LLC"}
+      </script>
+    </head><body>
+      <h1>Acme Analytics Entity Strategy</h1>
+      <p>Acme Analytics helps Google Cloud teams improve Digital Strategy.</p>
+    </body></html>
+    """
+
+    page = extract("https://example.com/entities", html, max_chars=2000)
+
+    assert page is not None
+    assert page.schema_blocks[0]["names"] == ["Acme Analytics LLC"]
+    payload = to_payload(analyze([page]))
+    assert payload["organizations"][0]["organization"] == "Acme Analytics LLC"
+
+
+def test_entities_payload_summarizes_coverage_depth_and_per_page_counts() -> None:
+    payload = to_payload(analyze([
+        _page(
+            "https://example.com/strategy",
+            "Digital Strategy for Acme Analytics",
+            "Acme Analytics explains Digital Strategy, Market Research, Google Cloud, OpenAI, "
+            "Search Analytics, and Customer Data Platforms for B2B Growth.",
+            headings=["Digital Strategy with Acme Analytics"],
+            schema_blocks=[{"valid": True, "types": ["Organization"], "names": ["Acme Analytics LLC"]}],
+        ),
+        _page(
+            "https://example.com/research",
+            "Market Research Playbook",
+            "Market Research connects Customer Data Platforms, Google Cloud, and Search Analytics.",
+            headings=["Market Research and Search Analytics"],
+        ),
+        _page("https://example.com/plain", "plain page", "short lower-case copy only."),
+    ]))
+
+    summary = payload["summary"]
+    assert summary["total_pages"] == 3
+    assert summary["pages_with_entities"] == 2
+    assert summary["entity_coverage"] == 2 / 3
+    assert summary["unique_entities"] >= 6
+    assert summary["organization_count"] == 1
+    assert summary["topical_authority_score"] > 0
+    assert payload["per_page"][0]["url"] == "https://example.com/plain"
+    assert any(row["entity"] == "Google Cloud" for row in payload["top_entities"])
+
+
+def test_compare_leaderboard_includes_entity_metrics(tmp_path: Path) -> None:
+    for domain, score in (("a.example", 72.5), ("b.example", 20.0)):
+        report_dir = tmp_path / domain / "report"
+        report_dir.mkdir(parents=True)
+        (report_dir / "site_metrics.json").write_text(json.dumps({"page_count": 2, "model": "test-model"}))
+        (report_dir / "pages.json").write_text(json.dumps([]))
+        (report_dir / "entities.json").write_text(json.dumps({
+            "summary": {
+                "entity_coverage": 0.75,
+                "unique_entities": 12,
+                "avg_entities_per_page": 6.0,
+                "entity_reuse_share": 0.5,
+                "organization_count": 2,
+                "organization_coverage": 0.5,
+                "topical_depth_share": 0.5,
+                "topical_authority_score": score,
+            }
+        }))
+
+    payload = build_payload(["a.example", "b.example"], tmp_path)
+    rows = {row["domain"]: row for row in payload["leaderboard"]}
+
+    assert rows["a.example"]["topical_authority_score"] == 72.5
+    assert rows["a.example"]["unique_entities"] == 12
+    assert rows["b.example"]["entity_coverage"] == 0.75

--- a/tests/test_freshness.py
+++ b/tests/test_freshness.py
@@ -1,0 +1,136 @@
+from datetime import date
+from pathlib import Path
+
+from site_audit.compare import build_payload
+from site_audit.extractor import ExtractedPage, extract
+from site_audit.freshness import analyze, to_payload
+
+
+def _page(
+    url: str,
+    title: str = "Freshness test page",
+    date_candidates=None,
+) -> ExtractedPage:
+    return ExtractedPage(
+        url=url,
+        title=title,
+        description="",
+        body="Useful content for testing freshness.",
+        word_count=120,
+        language="en",
+        date_candidates=date_candidates or [],
+        has_dates=bool(date_candidates),
+    )
+
+
+def test_extract_date_candidates_from_meta_time_and_jsonld() -> None:
+    html = """
+    <html><head>
+      <title>Freshness extraction test</title>
+      <meta property="article:published_time" content="2024-03-15T09:30:00+00:00">
+      <script type="application/ld+json">
+        {"@context":"https://schema.org","@type":"Article","dateModified":"2024-04-20"}
+      </script>
+    </head><body>
+      <h1>Freshness extraction test</h1>
+      <time datetime="2024-04-01">April 1, 2024</time>
+      <p>This page has enough body copy for the extractor fallback to keep it.
+      It discusses content freshness, publication dates, update timestamps,
+      JSON LD article metadata, and visible time elements in enough detail to
+      pass the minimum body threshold during extraction tests.</p>
+    </body></html>
+    """
+
+    page = extract("https://example.com/freshness", html, max_chars=2000)
+
+    assert page is not None
+    assert page.has_dates is True
+    assert page.date_published == "2024-03-15"
+    assert page.date_modified == "2024-04-20"
+    assert {"date": "2024-04-01", "source": "time", "kind": "visible"} in page.date_candidates
+    assert {"date": "2024-04-20", "source": "jsonld:dateModified", "kind": "modified"} in page.date_candidates
+
+
+def test_freshness_payload_buckets_stale_missing_and_future_dates() -> None:
+    report = to_payload(analyze([
+        _page("https://example.com/fresh", date_candidates=[
+            {"date": "2025-12-01", "source": "meta:article:modified_time", "kind": "modified"},
+        ]),
+        _page("https://example.com/stale", date_candidates=[
+            {"date": "2024-06-01", "source": "jsonld:datePublished", "kind": "published"},
+        ]),
+        _page("https://example.com/old", date_candidates=[
+            {"date": "2022-01-01", "source": "time", "kind": "visible"},
+        ]),
+        _page("https://example.com/missing"),
+        _page("https://example.com/future", date_candidates=[
+            {"date": "2026-06-01", "source": "body", "kind": "visible"},
+        ]),
+    ], today=date(2026, 1, 1)))
+
+    summary = report["summary"]
+    assert summary["total_pages"] == 5
+    assert summary["pages_with_date"] == 4
+    assert summary["date_coverage"] == 0.8
+    assert summary["missing_dates"] == 1
+    assert summary["pages_stale"] == 2
+    assert summary["pages_very_stale"] == 1
+    assert summary["future_dates"] == 1
+    assert report["buckets"]["fresh"] == 1
+    assert report["buckets"]["stale"] == 1
+    assert report["buckets"]["very_stale"] == 1
+    assert report["buckets"]["unknown"] == 1
+    assert report["buckets"]["future"] == 1
+
+    rows = {row["url"]: row for row in report["per_page"]}
+    assert rows["https://example.com/stale"]["issues"] == ["stale"]
+    assert rows["https://example.com/old"]["issues"] == ["very_stale"]
+    assert rows["https://example.com/missing"]["issues"] == ["missing_date"]
+    assert rows["https://example.com/future"]["issues"] == ["future_date"]
+
+
+def test_freshness_prefers_latest_modified_date_over_published() -> None:
+    report = to_payload(analyze([
+        _page("https://example.com/post", date_candidates=[
+            {"date": "2020-01-01", "source": "jsonld:datePublished", "kind": "published"},
+            {"date": "2025-10-15", "source": "jsonld:dateModified", "kind": "modified"},
+        ]),
+    ], today=date(2026, 1, 1)))
+
+    row = report["per_page"][0]
+    assert row["date"] == "2025-10-15"
+    assert row["date_kind"] == "modified"
+    assert row["bucket"] == "fresh"
+
+
+def test_compare_leaderboard_includes_freshness_metrics(tmp_path: Path) -> None:
+    for domain, date_coverage, stale_share in [
+        ("a.example", 0.8, 0.1),
+        ("b.example", 0.4, 0.5),
+    ]:
+        report_dir = tmp_path / domain / "report"
+        report_dir.mkdir(parents=True)
+        (report_dir / "site_metrics.json").write_text(
+            '{"domain":"%s","model":"test-model","page_count":5}' % domain,
+            encoding="utf-8",
+        )
+        (report_dir / "pages.json").write_text("[]", encoding="utf-8")
+        (report_dir / "freshness.json").write_text(
+            (
+                '{"summary":{"date_coverage":%s,'
+                '"stale_share":%s,'
+                '"missing_dates":2,'
+                '"pages_very_stale":1,'
+                '"median_age_days":120}}'
+            ) % (date_coverage, stale_share),
+            encoding="utf-8",
+        )
+
+    payload = build_payload(["a.example", "b.example"], tmp_path)
+
+    rows = {row["domain"]: row for row in payload["leaderboard"]}
+    assert rows["a.example"]["freshness_date_coverage"] == 0.8
+    assert rows["a.example"]["freshness_stale_share"] == 0.1
+    assert rows["a.example"]["freshness_missing_dates"] == 2
+    assert rows["b.example"]["freshness_date_coverage"] == 0.4
+    assert rows["b.example"]["freshness_stale_share"] == 0.5

--- a/tests/test_indexability.py
+++ b/tests/test_indexability.py
@@ -1,0 +1,78 @@
+from dataclasses import dataclass
+from pathlib import Path
+
+from site_audit.compare import build_payload
+from site_audit.indexability import analyze, to_payload
+
+
+@dataclass
+class _Fetched:
+    url: str
+    status: int = 200
+
+
+def test_indexability_payload_counts_funnel_and_reasons() -> None:
+    fetched = [
+        _Fetched("https://example.com/"),
+        _Fetched("https://example.com/noindex"),
+        _Fetched("https://example.com/bad"),
+    ]
+    rows = [
+        {"url": "https://example.com/", "status": "analyzed", "reason": "", "http_status": 200},
+        {
+            "url": "https://example.com/noindex",
+            "status": "skipped",
+            "reason": "noindex",
+            "source": "meta",
+            "http_status": 200,
+        },
+        {
+            "url": "https://example.com/bad",
+            "status": "skipped",
+            "reason": "unusable",
+            "http_status": 200,
+        },
+    ]
+
+    payload = to_payload(analyze(fetched, rows, {"https://example.com/"}))
+
+    assert payload["summary"]["fetched_pages"] == 3
+    assert payload["summary"]["analyzed_pages"] == 1
+    assert payload["summary"]["skipped_pages"] == 2
+    assert payload["summary"]["noindex_pages"] == 1
+    assert payload["summary"]["indexable_share"] == 1 / 3
+    assert payload["summary"]["noindex_share"] == 1 / 3
+    assert payload["summary"]["unusable_pages"] == 1
+    assert payload["status_counts"] == {"200": 3}
+    assert payload["noindex_pages"][0]["url"] == "https://example.com/noindex"
+
+
+def test_compare_leaderboard_includes_indexability_metrics(tmp_path: Path) -> None:
+    for domain, indexable_share, skipped_pages in [
+        ("a.example", 0.8, 2),
+        ("b.example", 0.4, 6),
+    ]:
+        report_dir = tmp_path / domain / "report"
+        report_dir.mkdir(parents=True)
+        (report_dir / "site_metrics.json").write_text(
+            '{"domain":"%s","model":"test-model","page_count":10}' % domain,
+            encoding="utf-8",
+        )
+        (report_dir / "pages.json").write_text("[]", encoding="utf-8")
+        (report_dir / "indexability.json").write_text(
+            (
+                '{"summary":{"indexable_share":%s,'
+                '"noindex_share":0.1,'
+                '"skipped_pages":%d}}'
+            ) % (indexable_share, skipped_pages),
+            encoding="utf-8",
+        )
+
+    payload = build_payload(["a.example", "b.example"], tmp_path)
+
+    rows = {row["domain"]: row for row in payload["leaderboard"]}
+    assert rows["a.example"]["indexable_share"] == 0.8
+    assert rows["a.example"]["noindex_share"] == 0.1
+    assert rows["a.example"]["skipped_pages"] == 2
+    assert rows["b.example"]["indexable_share"] == 0.4
+    assert rows["b.example"]["skipped_pages"] == 6

--- a/tests/test_media_accessibility.py
+++ b/tests/test_media_accessibility.py
@@ -1,0 +1,109 @@
+from pathlib import Path
+
+from site_audit.compare import build_payload
+from site_audit.extractor import ExtractedPage, extract
+from site_audit.media_accessibility import analyze, to_payload
+
+
+def _page(url: str, media_items: list[dict]) -> ExtractedPage:
+    return ExtractedPage(
+        url=url,
+        title="Media page",
+        description="",
+        body="Useful body content for a media accessibility test page.",
+        word_count=120,
+        language="en",
+        media_items=media_items,
+    )
+
+
+def test_extract_media_accessibility_fields() -> None:
+    html = """
+    <html><head><title>Media accessibility example</title></head><body>
+      <h1>Media accessibility example</h1>
+      <p>This page has enough body copy for the extractor fallback to keep it.
+      It discusses accessible images, videos, audio transcripts, embedded
+      iframes, captions, alternative text, and screen reader semantics in
+      enough detail to pass the minimum body threshold during extraction.</p>
+      <img src="/hero.jpg">
+      <img src="/decorative.png" alt="" role="presentation">
+      <a href="/brand"><img src="/logo.png" alt=""></a>
+      <video src="/demo.mp4"><track kind="captions" src="/demo.vtt"></video>
+      <audio src="/podcast.mp3"></audio>
+      <iframe src="/embed"></iframe>
+    </body></html>
+    """
+
+    page = extract("https://example.com/media", html, max_chars=2000)
+
+    assert page is not None
+    assert len(page.media_items) == 6
+    assert page.media_items[0]["type"] == "image"
+    assert page.media_items[0]["alt_present"] is False
+    assert page.media_items[1]["role"] == "presentation"
+    assert page.media_items[2]["in_link"] is True
+    assert page.media_items[3]["has_captions"] is True
+    assert page.media_items[4]["type"] == "audio"
+    assert page.media_items[5]["type"] == "iframe"
+
+
+def test_media_accessibility_payload_flags_media_issues() -> None:
+    report = to_payload(analyze([
+        _page("https://example.com/a", [
+            {"type": "image", "src": "/hero.jpg", "alt_present": False, "alt": ""},
+            {"type": "image", "src": "/decorative.png", "alt_present": True, "alt": "", "role": "presentation"},
+            {"type": "image", "src": "/brand-logo.png", "alt_present": True, "alt": "brand logo"},
+            {"type": "image", "src": "/linked.png", "alt_present": True, "alt": "", "in_link": True},
+        ]),
+        _page("https://example.com/b", [
+            {"type": "video", "src": "/demo.mp4", "has_captions": False},
+            {"type": "audio", "src": "/podcast.mp3", "has_transcript_hint": False},
+            {"type": "iframe", "src": "/embed", "title": ""},
+        ]),
+    ]))
+
+    assert report["summary"]["total_pages"] == 2
+    assert report["summary"]["pages_with_media"] == 2
+    assert report["summary"]["pages_with_issues"] == 2
+    assert report["summary"]["images_missing_alt"] == 1
+    assert report["summary"]["decorative_images"] == 1
+    assert report["summary"]["linked_images_empty_alt"] == 1
+    assert report["summary"]["images_filename_alt"] == 1
+    assert report["summary"]["videos_missing_captions"] == 1
+    assert report["summary"]["audio_missing_transcript"] == 1
+    assert report["summary"]["iframes_missing_title"] == 1
+    assert report["issues_by_type"]["image_missing_alt"] == 1
+    assert any(row["type"] == "video" for row in report["media_with_issues"])
+
+
+def test_compare_leaderboard_includes_media_accessibility_metrics(tmp_path: Path) -> None:
+    for domain, issue_share, missing_alt in [
+        ("a.example", 0.25, 1),
+        ("b.example", 0.75, 3),
+    ]:
+        report_dir = tmp_path / domain / "report"
+        report_dir.mkdir(parents=True)
+        (report_dir / "site_metrics.json").write_text(
+            '{"domain":"%s","model":"test-model","page_count":4}' % domain,
+            encoding="utf-8",
+        )
+        (report_dir / "pages.json").write_text("[]", encoding="utf-8")
+        (report_dir / "media_accessibility.json").write_text(
+            (
+                '{"summary":{"issue_share":%s,'
+                '"images_missing_alt":%d,'
+                '"linked_images_empty_alt":2,'
+                '"videos_missing_captions":1,'
+                '"iframes_missing_title":4}}'
+            ) % (issue_share, missing_alt),
+            encoding="utf-8",
+        )
+
+    payload = build_payload(["a.example", "b.example"], tmp_path)
+
+    rows = {row["domain"]: row for row in payload["leaderboard"]}
+    assert rows["a.example"]["media_accessibility_issue_share"] == 0.25
+    assert rows["a.example"]["images_missing_alt"] == 1
+    assert rows["a.example"]["linked_images_empty_alt"] == 2
+    assert rows["b.example"]["media_accessibility_issue_share"] == 0.75
+    assert rows["b.example"]["images_missing_alt"] == 3

--- a/tests/test_page_types.py
+++ b/tests/test_page_types.py
@@ -1,0 +1,127 @@
+from pathlib import Path
+
+from site_audit.compare import build_payload
+from site_audit.extractor import ExtractedPage
+from site_audit.page_types import analyze, classify_page, to_payload
+
+
+def _page(
+    url: str,
+    title: str = "Test page",
+    schema_types=None,
+    word_count: int = 500,
+    headings=None,
+    h1: str = "Test page",
+    list_count: int = 0,
+    table_count: int = 0,
+    paragraphs=None,
+    has_dates: bool = False,
+) -> ExtractedPage:
+    return ExtractedPage(
+        url=url,
+        title=title,
+        description="Useful test page description.",
+        body="Useful content for page type classification.",
+        word_count=word_count,
+        language="en",
+        h1=h1,
+        h1_count=1 if h1 else 0,
+        headings=headings or [],
+        headers_rich=[
+            {"level": 1, "text": h1, "order": 0},
+            *[
+                {"level": 2, "text": heading, "order": i + 1}
+                for i, heading in enumerate(headings or [])
+            ],
+        ] if h1 else [],
+        list_count=list_count,
+        table_count=table_count,
+        schema_types=schema_types or [],
+        paragraphs=paragraphs or ["paragraph one", "paragraph two", "paragraph three", "paragraph four"],
+        has_dates=has_dates,
+    )
+
+
+def test_classify_schema_and_url_page_types() -> None:
+    assert classify_page(_page(
+        "https://example.com/blog/how-to-audit-pages",
+        schema_types=["BlogPosting"],
+        has_dates=True,
+    )).page_type == "blog_post"
+    assert classify_page(_page(
+        "https://example.com/products/site-audit",
+        schema_types=["Product"],
+    )).page_type == "product"
+    assert classify_page(_page(
+        "https://example.com/contact",
+        title="Contact Acme",
+    )).page_type == "contact"
+
+
+def test_listing_and_faq_use_structural_signals() -> None:
+    listing = classify_page(_page(
+        "https://example.com/category/tools",
+        word_count=300,
+        list_count=4,
+        paragraphs=["short intro"],
+    ))
+    faq = classify_page(_page(
+        "https://example.com/support/questions",
+        headings=["What is auditing?", "How does it work?", "Can I export data?"],
+    ))
+
+    assert listing.page_type == "listing"
+    assert "many_lists_low_body" in listing.signals
+    assert faq.page_type == "faq"
+    assert "question_headings" in faq.signals
+
+
+def test_payload_summarizes_types_and_template_families() -> None:
+    report = to_payload(analyze([
+        _page("https://example.com/"),
+        _page("https://example.com/blog/a", schema_types=["Article"], has_dates=True),
+        _page("https://example.com/blog/b", schema_types=["Article"], has_dates=True),
+        _page("https://example.com/products/widget", schema_types=["Product"]),
+    ]))
+
+    assert report["summary"]["total_pages"] == 4
+    assert report["summary"]["page_type_count"] == 3
+    assert report["summary"]["dominant_page_type"] == "blog_post"
+    assert report["summary"]["template_signature_count"] >= 3
+    counts = {row["page_type"]: row["pages"] for row in report["type_counts"]}
+    assert counts["blog_post"] == 2
+    assert counts["home"] == 1
+    assert counts["product"] == 1
+
+
+def test_compare_leaderboard_includes_page_type_metrics(tmp_path: Path) -> None:
+    for domain, dominant_type, type_count in [
+        ("a.example", "article", 4),
+        ("b.example", "product", 2),
+    ]:
+        report_dir = tmp_path / domain / "report"
+        report_dir.mkdir(parents=True)
+        (report_dir / "site_metrics.json").write_text(
+            '{"domain":"%s","model":"test-model","page_count":4}' % domain,
+            encoding="utf-8",
+        )
+        (report_dir / "pages.json").write_text("[]", encoding="utf-8")
+        (report_dir / "page_types.json").write_text(
+            (
+                '{"summary":{"page_type_count":%d,'
+                '"template_family_count":3,'
+                '"template_signature_count":5,'
+                '"dominant_page_type":"%s",'
+                '"dominant_template_family":"content_template"}}'
+            ) % (type_count, dominant_type),
+            encoding="utf-8",
+        )
+
+    payload = build_payload(["a.example", "b.example"], tmp_path)
+
+    rows = {row["domain"]: row for row in payload["leaderboard"]}
+    assert rows["a.example"]["page_type_count"] == 4
+    assert rows["a.example"]["template_family_count"] == 3
+    assert rows["a.example"]["dominant_page_type"] == "article"
+    assert rows["b.example"]["page_type_count"] == 2
+    assert rows["b.example"]["dominant_page_type"] == "product"

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,0 +1,102 @@
+from dataclasses import dataclass
+from pathlib import Path
+
+from site_audit.compare import build_payload
+from site_audit.performance import analyze, to_payload
+
+
+@dataclass
+class _Fetched:
+    url: str
+    body: str
+    status: int = 200
+    content_type: str = "text/html"
+    content_length_bytes: int = 0
+
+
+def test_performance_payload_counts_resources_and_blocking_heuristics() -> None:
+    html = """
+    <html><head>
+      <link rel="stylesheet" href="/app.css">
+      <link rel="stylesheet" href="/print.css" media="print">
+      <link rel="preload" as="font" href="/font.woff2" type="font/woff2">
+      <style>.hero{color:red}</style>
+      <script src="/blocking.js"></script>
+      <script src="/deferred.js" defer></script>
+      <script type="module" src="/module.js"></script>
+      <script>window.inline = true;</script>
+    </head><body>
+      <img src="/one.jpg">
+      <img src="/two.jpg">
+      <div style="display:none"></div>
+    </body></html>
+    """
+
+    payload = to_payload(analyze([_Fetched("https://example.com/", html, content_length_bytes=1234)]))
+    row = payload["per_page"][0]
+
+    assert payload["summary"]["total_pages"] == 1
+    assert payload["summary"]["status_counts"] == {"200": 1}
+    assert row["content_size_bytes"] == 1234
+    assert row["html_weight_bytes"] == 1234
+    assert row["image_count"] == 2
+    assert row["script_count"] == 4
+    assert row["external_script_count"] == 3
+    assert row["inline_script_count"] == 1
+    assert row["stylesheet_count"] == 2
+    assert row["inline_style_count"] == 1
+    assert row["style_attr_count"] == 1
+    assert row["font_count"] == 1
+    assert row["preload_count"] == 1
+    assert row["render_blocking_css_count"] == 1
+    assert row["render_blocking_script_count"] == 1
+    assert payload["summary"]["pages_with_render_blocking"] == 1
+
+
+def test_performance_payload_buckets_and_heavy_pages() -> None:
+    payload = to_payload(analyze([
+        _Fetched("https://example.com/light", "<html></html>", content_length_bytes=100_000),
+        _Fetched("https://example.com/heavy", "<html>" + "<img>" * 30 + "</html>", content_length_bytes=100_000),
+    ]))
+
+    assert payload["buckets"]["light"] == 1
+    assert payload["buckets"]["very_heavy"] == 1
+    assert payload["summary"]["heavy_pages"] == 1
+    assert payload["summary"]["heavy_page_share"] == 0.5
+    assert payload["top_heavy_pages"][0]["url"] == "https://example.com/heavy"
+
+
+def test_compare_leaderboard_includes_performance_metrics(tmp_path: Path) -> None:
+    for domain, median_html, blocking_share in [
+        ("a.example", 20000, 0.25),
+        ("b.example", 80000, 0.75),
+    ]:
+        report_dir = tmp_path / domain / "report"
+        report_dir.mkdir(parents=True)
+        (report_dir / "site_metrics.json").write_text(
+            '{"domain":"%s","model":"test-model","page_count":5}' % domain,
+            encoding="utf-8",
+        )
+        (report_dir / "pages.json").write_text("[]", encoding="utf-8")
+        (report_dir / "performance.json").write_text(
+            (
+                '{"summary":{"median_html_weight_bytes":%d,'
+                '"p90_estimated_weight_bytes":150000,'
+                '"avg_resource_tags_per_page":7.5,'
+                '"render_blocking_share":%s,'
+                '"heavy_page_share":0.2,'
+                '"total_images":10,'
+                '"total_scripts":8,'
+                '"total_stylesheets":4}}'
+            ) % (median_html, blocking_share),
+            encoding="utf-8",
+        )
+
+    payload = build_payload(["a.example", "b.example"], tmp_path)
+
+    rows = {row["domain"]: row for row in payload["leaderboard"]}
+    assert rows["a.example"]["median_html_weight_bytes"] == 20000
+    assert rows["a.example"]["render_blocking_share"] == 0.25
+    assert rows["a.example"]["avg_resource_tags_per_page"] == 7.5
+    assert rows["b.example"]["median_html_weight_bytes"] == 80000
+    assert rows["b.example"]["heavy_page_share"] == 0.2

--- a/ui/compare.html
+++ b/ui/compare.html
@@ -34,7 +34,14 @@
           <button data-group="overview"  class="lb-group px-2 py-1 rounded border border-gray-300 bg-white">Overview</button>
           <button data-group="topic"     class="lb-group px-2 py-1 rounded border border-gray-300 bg-white">Topic shape</button>
           <button data-group="geo"       class="lb-group px-2 py-1 rounded border border-gray-300 bg-white">GEO answer-ability</button>
+          <button data-group="entities"  class="lb-group px-2 py-1 rounded border border-gray-300 bg-white">Entities</button>
+          <button data-group="pageTypes" class="lb-group px-2 py-1 rounded border border-gray-300 bg-white">Page types</button>
           <button data-group="metadata"  class="lb-group px-2 py-1 rounded border border-gray-300 bg-white">Metadata</button>
+          <button data-group="media"     class="lb-group px-2 py-1 rounded border border-gray-300 bg-white">Media</button>
+          <button data-group="freshness" class="lb-group px-2 py-1 rounded border border-gray-300 bg-white">Freshness</button>
+          <button data-group="conversion" class="lb-group px-2 py-1 rounded border border-gray-300 bg-white">Conversion</button>
+          <button data-group="indexability" class="lb-group px-2 py-1 rounded border border-gray-300 bg-white">Indexability</button>
+          <button data-group="performance" class="lb-group px-2 py-1 rounded border border-gray-300 bg-white">Performance</button>
           <button data-group="linking"   class="lb-group px-2 py-1 rounded border border-gray-300 bg-white">Internal linking</button>
           <button data-group="linkbuilding" class="lb-group px-2 py-1 rounded border border-gray-300 bg-white">Linkbuilding</button>
           <button data-group="headers"   class="lb-group px-2 py-1 rounded border border-gray-300 bg-white">Headers</button>
@@ -152,6 +159,24 @@
       { key: 'invalid_jsonld_blocks', label: 'Invalid JSON-LD', better: 'low', fmt: 'int' },
       { key: 'schema_type_count',     label: 'Schema types', better: 'high', fmt: 'int' },
     ],
+    entities: [
+      { key: 'pages',                    label: 'Pages', better: 'na', fmt: 'int' },
+      { key: 'topical_authority_score',  label: 'Authority score', better: 'high', fmt: '0.0' },
+      { key: 'entity_coverage',          label: 'Entity coverage', better: 'high', fmt: 'pct' },
+      { key: 'unique_entities',          label: 'Unique entities', better: 'high', fmt: 'int' },
+      { key: 'avg_entities_per_page',    label: 'Avg entities/page', better: 'high', fmt: '0.0' },
+      { key: 'entity_reuse_share',       label: 'Reuse share', better: 'high', fmt: 'pct' },
+      { key: 'organization_coverage',    label: 'Org coverage', better: 'high', fmt: 'pct' },
+      { key: 'topical_depth_share',      label: 'Depth share', better: 'high', fmt: 'pct' },
+    ],
+    pageTypes: [
+      { key: 'pages',                    label: 'Pages', better: 'na', fmt: 'int' },
+      { key: 'page_type_count',          label: 'Page types', better: 'na', fmt: 'int' },
+      { key: 'template_family_count',    label: 'Template families', better: 'na', fmt: 'int' },
+      { key: 'template_signature_count', label: 'Template signatures', better: 'na', fmt: 'int' },
+      { key: 'dominant_page_type',       label: 'Dominant type', better: 'na', fmt: 'str' },
+      { key: 'dominant_template_family', label: 'Dominant template', better: 'na', fmt: 'str' },
+    ],
     linking: [
       { key: 'pages',             label: 'Pages',        better: 'na',   fmt: 'int' },
       { key: 'median_in_degree',  label: 'In-degree median', better: 'high', fmt: '0' },
@@ -166,6 +191,45 @@
       { key: 'duplicate_title_pages',   label: 'Duplicate titles', better: 'low', fmt: 'int' },
       { key: 'missing_canonical',       label: 'Missing canonical', better: 'low', fmt: 'int' },
       { key: 'incomplete_open_graph',   label: 'Incomplete OG', better: 'low', fmt: 'int' },
+    ],
+    media: [
+      { key: 'pages',                            label: 'Pages', better: 'na', fmt: 'int' },
+      { key: 'media_accessibility_issue_share',  label: 'Pages with issues', better: 'low', fmt: 'pct' },
+      { key: 'images_missing_alt',               label: 'Missing alt', better: 'low', fmt: 'int' },
+      { key: 'linked_images_empty_alt',          label: 'Linked empty alt', better: 'low', fmt: 'int' },
+      { key: 'videos_missing_captions',          label: 'Videos no captions', better: 'low', fmt: 'int' },
+      { key: 'iframes_missing_title',            label: 'Iframes no title', better: 'low', fmt: 'int' },
+    ],
+    freshness: [
+      { key: 'pages',                      label: 'Pages', better: 'na', fmt: 'int' },
+      { key: 'freshness_date_coverage',    label: 'Date coverage', better: 'high', fmt: 'pct' },
+      { key: 'freshness_stale_share',      label: 'Stale share', better: 'low', fmt: 'pct' },
+      { key: 'freshness_missing_dates',    label: 'Missing dates', better: 'low', fmt: 'int' },
+      { key: 'freshness_very_stale_pages', label: 'Very stale', better: 'low', fmt: 'int' },
+      { key: 'freshness_median_age_days',  label: 'Median age days', better: 'low', fmt: 'int' },
+    ],
+    conversion: [
+      { key: 'pages',                      label: 'Pages', better: 'na', fmt: 'int' },
+      { key: 'cta_coverage',               label: 'CTA coverage', better: 'high', fmt: 'pct' },
+      { key: 'primary_cta_coverage',       label: 'Primary CTA %', better: 'high', fmt: 'pct' },
+      { key: 'form_coverage',              label: 'Form coverage', better: 'high', fmt: 'pct' },
+      { key: 'avg_ctas_per_page',          label: 'Avg CTAs/page', better: 'na', fmt: '0.0' },
+      { key: 'lead_pages_without_capture', label: 'Lead leaks', better: 'low', fmt: 'int' },
+      { key: 'cta_overload_pages',         label: 'CTA overload', better: 'low', fmt: 'int' },
+    ],
+    indexability: [
+      { key: 'pages',            label: 'Analyzed pages', better: 'na', fmt: 'int' },
+      { key: 'indexable_share',  label: 'Analyzed share', better: 'high', fmt: 'pct' },
+      { key: 'noindex_share',    label: 'Noindex share', better: 'low', fmt: 'pct' },
+      { key: 'skipped_pages',    label: 'Skipped pages', better: 'low', fmt: 'int' },
+    ],
+    performance: [
+      { key: 'pages',                       label: 'Pages', better: 'na', fmt: 'int' },
+      { key: 'median_html_weight_bytes',    label: 'Median HTML bytes', better: 'low', fmt: 'int' },
+      { key: 'p90_estimated_weight_bytes',  label: 'P90 est. bytes', better: 'low', fmt: 'int' },
+      { key: 'avg_resource_tags_per_page',  label: 'Avg resource tags', better: 'low', fmt: '0.00' },
+      { key: 'render_blocking_share',       label: 'Render-blocking %', better: 'low', fmt: 'pct' },
+      { key: 'heavy_page_share',            label: 'Heavy page %', better: 'low', fmt: 'pct' },
     ],
     density: [
       { key: 'pages',                       label: 'Pages',          better: 'na',   fmt: 'int' },
@@ -214,6 +278,7 @@
   let lbSort = { key: null, dir: 1 };
 
   function fmt(v, code) {
+    if (code === 'str') return v == null || v === '' ? '—' : String(v);
     if (v == null || isNaN(v)) return '—';
     if (code === 'int')   return Math.round(v).toLocaleString();
     if (code === 'pct')   return (v * 100).toFixed(1) + '%';

--- a/ui/index.html
+++ b/ui/index.html
@@ -337,6 +337,27 @@
       </div>
     </div>
 
+    <!-- Indexability -->
+    <div class="bg-white border border-gray-200 rounded-lg shadow-sm p-5 mb-8" id="indexability-block">
+      <div class="mb-3">
+        <h3 class="text-lg font-semibold">Indexability funnel</h3>
+        <p class="text-xs text-gray-500 mt-1">
+          Crawl-to-analysis path: fetched pages, extracted HTML, noindex exclusions, skipped pages, and final analyzed corpus.
+        </p>
+      </div>
+      <div id="audit-indexability-summary" class="grid sm:grid-cols-3 lg:grid-cols-5 gap-3 text-sm mb-5"></div>
+      <div class="grid lg:grid-cols-2 gap-5 text-xs">
+        <div>
+          <h4 class="font-semibold mb-2">Noindex pages</h4>
+          <div id="audit-indexability-noindex" class="max-h-72 overflow-y-auto"></div>
+        </div>
+        <div>
+          <h4 class="font-semibold mb-2">Skipped pages</h4>
+          <div id="audit-indexability-skipped" class="max-h-72 overflow-y-auto"></div>
+        </div>
+      </div>
+    </div>
+
     <!-- Structured data -->
     <div class="bg-white border border-gray-200 rounded-lg shadow-sm p-5 mb-8" id="structured-data-block">
       <div class="mb-3">
@@ -373,6 +394,122 @@
       </div>
       <div id="audit-metadata-summary" class="grid sm:grid-cols-3 lg:grid-cols-5 gap-3 text-sm mb-5"></div>
       <div id="audit-metadata-pages" class="text-xs max-h-96 overflow-y-auto"></div>
+    </div>
+
+    <!-- Media accessibility -->
+    <div class="bg-white border border-gray-200 rounded-lg shadow-sm p-5 mb-8" id="media-accessibility-block">
+      <div class="mb-3">
+        <h3 class="text-lg font-semibold">Media accessibility</h3>
+        <p class="text-xs text-gray-500 mt-1">
+          Images, video, audio, and embeds checked for assistive-text basics: useful alt text, captions, transcripts, and iframe titles.
+        </p>
+      </div>
+      <div id="audit-media-summary" class="grid sm:grid-cols-3 lg:grid-cols-5 gap-3 text-sm mb-5"></div>
+      <div id="audit-media-issues" class="text-xs max-h-96 overflow-y-auto"></div>
+    </div>
+
+    <!-- Page types -->
+    <div class="bg-white border border-gray-200 rounded-lg shadow-sm p-5 mb-8" id="page-types-block">
+      <div class="mb-3">
+        <h3 class="text-lg font-semibold">Page types and templates</h3>
+        <p class="text-xs text-gray-500 mt-1">
+          Heuristic classification of crawled pages into editorial types and reusable template families.
+        </p>
+      </div>
+      <div id="audit-page-types-summary" class="grid sm:grid-cols-3 lg:grid-cols-5 gap-3 text-sm mb-5"></div>
+      <div class="grid lg:grid-cols-3 gap-5 text-xs">
+        <div>
+          <h4 class="font-semibold mb-2">Page type mix</h4>
+          <div id="audit-page-types-counts" class="max-h-72 overflow-y-auto"></div>
+        </div>
+        <div>
+          <h4 class="font-semibold mb-2">Template families</h4>
+          <div id="audit-page-types-templates" class="max-h-72 overflow-y-auto"></div>
+        </div>
+        <div>
+          <h4 class="font-semibold mb-2">Low-confidence pages</h4>
+          <div id="audit-page-types-pages" class="max-h-72 overflow-y-auto"></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Entities -->
+    <div class="bg-white border border-gray-200 rounded-lg shadow-sm p-5 mb-8" id="entities-block">
+      <div class="mb-3">
+        <h3 class="text-lg font-semibold">Entities and topical authority</h3>
+        <p class="text-xs text-gray-500 mt-1">
+          Offline entity-like phrase analysis from schema, metadata, headings, and body copy.
+        </p>
+      </div>
+      <div id="audit-entities-summary" class="grid sm:grid-cols-3 lg:grid-cols-5 gap-3 text-sm mb-5"></div>
+      <div class="grid lg:grid-cols-3 gap-5 text-xs">
+        <div>
+          <h4 class="font-semibold mb-2">Top entities</h4>
+          <div id="audit-entities-top" class="max-h-72 overflow-y-auto"></div>
+        </div>
+        <div>
+          <h4 class="font-semibold mb-2">Organizations</h4>
+          <div id="audit-entities-orgs" class="max-h-72 overflow-y-auto"></div>
+        </div>
+        <div>
+          <h4 class="font-semibold mb-2">Thin entity pages</h4>
+          <div id="audit-entities-pages" class="max-h-72 overflow-y-auto"></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Content freshness -->
+    <div class="bg-white border border-gray-200 rounded-lg shadow-sm p-5 mb-8" id="freshness-block">
+      <div class="mb-3">
+        <h3 class="text-lg font-semibold">Content freshness</h3>
+        <p class="text-xs text-gray-500 mt-1">
+          Publication and modification dates from metadata, JSON-LD, <code>&lt;time&gt;</code>, and visible body dates. Pages older than one year are stale; older than two years are very stale.
+        </p>
+      </div>
+      <div id="audit-freshness-summary" class="grid sm:grid-cols-3 lg:grid-cols-5 gap-3 text-sm mb-5"></div>
+      <div id="audit-freshness-pages" class="text-xs max-h-96 overflow-y-auto"></div>
+    </div>
+
+    <!-- Performance -->
+    <div class="bg-white border border-gray-200 rounded-lg shadow-sm p-5 mb-8" id="performance-block">
+      <div class="mb-3">
+        <h3 class="text-lg font-semibold">Lightweight performance signals</h3>
+        <p class="text-xs text-gray-500 mt-1">
+          Offline HTML/resource heuristics from crawled pages: page weight buckets, render-blocking resources, scripts, stylesheets, fonts, and images.
+        </p>
+      </div>
+      <div id="audit-performance-summary" class="grid sm:grid-cols-3 lg:grid-cols-5 gap-3 text-sm mb-5"></div>
+      <div class="grid lg:grid-cols-2 gap-5 text-xs">
+        <div>
+          <h4 class="font-semibold mb-2">Heaviest pages</h4>
+          <div id="audit-performance-heavy" class="max-h-72 overflow-y-auto"></div>
+        </div>
+        <div>
+          <h4 class="font-semibold mb-2">Render-blocking pages</h4>
+          <div id="audit-performance-blocking" class="max-h-72 overflow-y-auto"></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Conversion signals -->
+    <div class="bg-white border border-gray-200 rounded-lg shadow-sm p-5 mb-8" id="conversion-block">
+      <div class="mb-3">
+        <h3 class="text-lg font-semibold">Conversion and CTA signals</h3>
+        <p class="text-xs text-gray-500 mt-1">
+          Calls to action, forms, and direct-contact links. Lead pages without a form, phone, or email capture are likely conversion leaks.
+        </p>
+      </div>
+      <div id="audit-conversion-summary" class="grid sm:grid-cols-3 lg:grid-cols-5 gap-3 text-sm mb-5"></div>
+      <div class="grid lg:grid-cols-2 gap-5 text-xs">
+        <div>
+          <h4 class="font-semibold mb-2">Top CTA text</h4>
+          <div id="audit-conversion-ctas" class="max-h-72 overflow-y-auto"></div>
+        </div>
+        <div>
+          <h4 class="font-semibold mb-2">Pages to review</h4>
+          <div id="audit-conversion-pages" class="max-h-72 overflow-y-auto"></div>
+        </div>
+      </div>
     </div>
 
     <!-- Answerability -->
@@ -759,6 +896,13 @@
 <script type="application/json" id="data-linkbuilding">__LINKBUILDING_JSON__</script>
 <script type="application/json" id="data-structured-data">__STRUCTURED_DATA_JSON__</script>
 <script type="application/json" id="data-metadata-quality">__METADATA_QUALITY_JSON__</script>
+<script type="application/json" id="data-media-accessibility">__MEDIA_ACCESSIBILITY_JSON__</script>
+<script type="application/json" id="data-page-types">__PAGE_TYPES_JSON__</script>
+<script type="application/json" id="data-entities">__ENTITIES_JSON__</script>
+<script type="application/json" id="data-freshness">__FRESHNESS_JSON__</script>
+<script type="application/json" id="data-conversion">__CONVERSION_JSON__</script>
+<script type="application/json" id="data-indexability">__INDEXABILITY_JSON__</script>
+<script type="application/json" id="data-performance">__PERFORMANCE_JSON__</script>
 <script>
 (function() {
   const basePath = '/data';
@@ -813,6 +957,15 @@
     return d3.csvParse(text);
   }
 
+  function card(label, value, hint, hintClass='text-gray-400') {
+    return `
+      <div class="border border-gray-200 rounded p-3">
+        <div class="text-2xl font-semibold">${value}</div>
+        <div class="text-xs text-gray-500">${label}</div>
+        ${hint ? `<div class="text-xs ${hintClass} mt-0.5">${hint}</div>` : ''}
+      </div>`;
+  }
+
   async function boot() {
     try {
       const inlinedScatter = readInlined('data-scatterplot');
@@ -841,8 +994,15 @@
       const inlinedLinkbuilding = readInlined('data-linkbuilding');
       const inlinedStructuredData = readInlined('data-structured-data');
       const inlinedMetadataQuality = readInlined('data-metadata-quality');
+      const inlinedMediaAccessibility = readInlined('data-media-accessibility');
+      const inlinedPageTypes = readInlined('data-page-types');
+      const inlinedEntities = readInlined('data-entities');
+      const inlinedFreshness = readInlined('data-freshness');
+      const inlinedConversion = readInlined('data-conversion');
+      const inlinedIndexability = readInlined('data-indexability');
+      const inlinedPerformance = readInlined('data-performance');
 
-      let scatter, metrics, sections, outliers, duplicates, clusters, coverage, answerability, linkgraph, external, paraLinks, clusterOverlap, paraClusters, paraScatter, fanout, titleMismatch, wrongHome, improvement, competitive, recommendations, paraDensity, headerAnalysis, headerScatter, linkbuilding, structuredData, metadataQuality;
+      let scatter, metrics, sections, outliers, duplicates, clusters, coverage, answerability, linkgraph, external, paraLinks, clusterOverlap, paraClusters, paraScatter, fanout, titleMismatch, wrongHome, improvement, competitive, recommendations, paraDensity, headerAnalysis, headerScatter, linkbuilding, structuredData, metadataQuality, mediaAccessibility, pageTypes, entities, freshness, conversion, indexability, performance;
       if (inlinedMetrics) {
         scatter = inlinedScatter;
         metrics = inlinedMetrics;
@@ -870,8 +1030,15 @@
         linkbuilding = inlinedLinkbuilding || {};
         structuredData = inlinedStructuredData || {};
         metadataQuality = inlinedMetadataQuality || {};
+        mediaAccessibility = inlinedMediaAccessibility || {};
+        pageTypes = inlinedPageTypes || {};
+        entities = inlinedEntities || {};
+        freshness = inlinedFreshness || {};
+        conversion = inlinedConversion || {};
+        indexability = inlinedIndexability || {};
+        performance = inlinedPerformance || {};
       } else {
-        [scatter, metrics, sections, outliers, duplicates, clusters, coverage, answerability, linkgraph, external, paraLinks, clusterOverlap, paraClusters, paraScatter, fanout, titleMismatch, wrongHome, improvement, competitive, recommendations, paraDensity, headerAnalysis, headerScatter, linkbuilding, structuredData, metadataQuality] = await Promise.all([
+        [scatter, metrics, sections, outliers, duplicates, clusters, coverage, answerability, linkgraph, external, paraLinks, clusterOverlap, paraClusters, paraScatter, fanout, titleMismatch, wrongHome, improvement, competitive, recommendations, paraDensity, headerAnalysis, headerScatter, linkbuilding, structuredData, metadataQuality, mediaAccessibility, pageTypes, entities, freshness, conversion, indexability, performance] = await Promise.all([
           loadJSON('scatterplot.json').catch(() => null),
           loadJSON('site_metrics.json'),
           loadJSON('section_report.json').catch(() => []),
@@ -898,6 +1065,13 @@
           loadJSON('linkbuilding.json').catch(() => ({})),
           loadJSON('structured_data.json').catch(() => ({})),
           loadJSON('metadata_quality.json').catch(() => ({})),
+          loadJSON('media_accessibility.json').catch(() => ({})),
+          loadJSON('page_types.json').catch(() => ({})),
+          loadJSON('entities.json').catch(() => ({})),
+          loadJSON('freshness.json').catch(() => ({})),
+          loadJSON('conversion.json').catch(() => ({})),
+          loadJSON('indexability.json').catch(() => ({})),
+          loadJSON('performance.json').catch(() => ({})),
         ]);
       }
       state.scatter = scatter;
@@ -929,6 +1103,13 @@
       state.linkbuilding = linkbuilding || {};
       state.structuredData = structuredData || {};
       state.metadataQuality = metadataQuality || {};
+      state.mediaAccessibility = mediaAccessibility || {};
+      state.pageTypes = pageTypes || {};
+      state.entities = entities || {};
+      state.freshness = freshness || {};
+      state.conversion = conversion || {};
+      state.indexability = indexability || {};
+      state.performance = performance || {};
       state.linkCountMode = 'hist';
       document.getElementById('header-domain').textContent =
         `${metrics.domain || ''} · ${metrics.page_count || 0} pages · model ${metrics.model || ''}`;
@@ -948,8 +1129,15 @@
       renderTreemap();
       renderHeatmap();
       renderCoverage('all');
+      renderIndexability();
       renderStructuredData();
       renderMetadataQuality();
+      renderMediaAccessibility();
+      renderPageTypes();
+      renderEntities();
+      renderFreshness();
+      renderPerformance();
+      renderConversion();
       renderAnswerability();
       renderLinkgraph();
       renderLinkbuilding();
@@ -1903,6 +2091,46 @@
     el.innerHTML = summary + rows;
   }
 
+  function renderIndexability() {
+    const block = document.getElementById('indexability-block');
+    const data = state.indexability || {};
+    const summary = data.summary || {};
+    if (!summary.fetched_pages) {
+      block.style.display = 'none';
+      return;
+    }
+    document.getElementById('audit-indexability-summary').innerHTML =
+      card('Fetched', (summary.fetched_pages || 0).toLocaleString(), 'HTML pages fetched') +
+      card('Analyzed', (summary.analyzed_pages || 0).toLocaleString(),
+        `${((summary.indexable_share || 0) * 100).toFixed(0)}% of fetched pages`,
+        (summary.indexable_share || 0) >= 0.7 ? 'text-green-600' : 'text-orange-600') +
+      card('Noindex', (summary.noindex_pages || 0).toLocaleString(),
+        'excluded by meta robots or X-Robots-Tag',
+        summary.noindex_pages ? 'text-orange-600' : 'text-green-600') +
+      card('Skipped', (summary.skipped_pages || 0).toLocaleString(),
+        'unusable, noindex, or empty text') +
+      card('Unusable', (summary.unusable_pages || 0).toLocaleString(),
+        'failed extraction or missing title');
+
+    const noindex = data.noindex_pages || [];
+    document.getElementById('audit-indexability-noindex').innerHTML = noindex.length
+      ? noindex.slice(0, 100).map(r => `
+        <div class="border-b border-gray-100 py-2">
+          <a class="text-blue-600 hover:underline break-all" href="${escapeHtml(r.url)}" target="_blank" rel="noopener">${escapeHtml(r.url)}</a>
+          <div class="text-gray-500 mt-1">source: ${escapeHtml(r.source || 'unknown')}</div>
+        </div>`).join('')
+      : '<div class="text-gray-500">No noindex pages were excluded.</div>';
+
+    const skipped = (data.skipped || []).filter(r => r.reason !== 'noindex');
+    document.getElementById('audit-indexability-skipped').innerHTML = skipped.length
+      ? skipped.slice(0, 100).map(r => `
+        <div class="border-b border-gray-100 py-2">
+          <a class="text-blue-600 hover:underline break-all" href="${escapeHtml(r.url)}" target="_blank" rel="noopener">${escapeHtml(r.url)}</a>
+          <div class="text-gray-500 mt-1">${escapeHtml(r.reason || 'skipped')}</div>
+        </div>`).join('')
+      : '<div class="text-gray-500">No non-indexability skips found.</div>';
+  }
+
   function renderStructuredData() {
     const block = document.getElementById('structured-data-block');
     const data = state.structuredData || {};
@@ -1983,6 +2211,243 @@
             <div class="text-gray-500 mt-1">title ${r.title_length || 0} chars · description ${r.description_length || 0} chars · canonical ${escapeHtml(r.canonical_url || 'missing')}</div>
           </div>`;
       }).join('') || '<div class="text-gray-500">No metadata issues found.</div>';
+  }
+
+  function renderMediaAccessibility() {
+    const block = document.getElementById('media-accessibility-block');
+    const data = state.mediaAccessibility || {};
+    const summary = data.summary || {};
+    if (!summary.total_pages || !summary.total_media) {
+      block.style.display = 'none';
+      return;
+    }
+    document.getElementById('audit-media-summary').innerHTML =
+      card('Pages with issues', `${((summary.issue_share || 0) * 100).toFixed(0)}%`,
+        `${summary.pages_with_issues || 0} / ${summary.total_pages || 0} pages flagged`,
+        summary.pages_with_issues ? 'text-orange-600' : 'text-green-600') +
+      card('Missing image alt', (summary.images_missing_alt || 0).toLocaleString(),
+        `${summary.total_images || 0} images total`) +
+      card('Linked empty alt', (summary.linked_images_empty_alt || 0).toLocaleString(),
+        'image links without accessible text') +
+      card('Videos no captions', (summary.videos_missing_captions || 0).toLocaleString(),
+        `${summary.total_videos || 0} videos total`) +
+      card('Iframes no title', (summary.iframes_missing_title || 0).toLocaleString(),
+        `${summary.total_iframes || 0} iframes total`);
+
+    document.getElementById('audit-media-issues').innerHTML =
+      (data.media_with_issues || []).slice(0, 200).map(r => {
+        const issues = (r.issues || []).map(issue =>
+          `<span class="inline-block bg-gray-100 text-gray-700 px-1.5 py-0.5 rounded mr-1 mb-1">${escapeHtml(issue.replaceAll('_', ' '))}</span>`
+        ).join('');
+        return `
+          <div class="border-b border-gray-100 py-2">
+            <a class="text-blue-600 hover:underline break-all" href="${escapeHtml(r.url)}" target="_blank" rel="noopener">${escapeHtml(r.url)}</a>
+            <div class="mt-1">${issues}</div>
+            <div class="text-gray-500 mt-1">${escapeHtml(r.type || 'media')} · ${escapeHtml(r.src || '(inline)')} ${r.alt ? `· alt "${escapeHtml(r.alt)}"` : ''}</div>
+          </div>`;
+      }).join('') || '<div class="text-gray-500">No media accessibility issues found.</div>';
+  }
+
+  function renderPageTypes() {
+    const block = document.getElementById('page-types-block');
+    const data = state.pageTypes || {};
+    const summary = data.summary || {};
+    if (!summary.total_pages) {
+      block.style.display = 'none';
+      return;
+    }
+    document.getElementById('audit-page-types-summary').innerHTML =
+      card('Page types', (summary.page_type_count || 0).toLocaleString(), 'distinct page classifications') +
+      card('Template families', (summary.template_family_count || 0).toLocaleString(), 'broad reusable layouts') +
+      card('Template signatures', (summary.template_signature_count || 0).toLocaleString(), 'structural fingerprints') +
+      card('Dominant type', escapeHtml(summary.dominant_page_type || '—'), 'most common page class') +
+      card('Dominant template', escapeHtml(summary.dominant_template_family || '—'), 'most common template family');
+
+    document.getElementById('audit-page-types-counts').innerHTML =
+      (data.type_counts || []).map(r => `
+        <div class="flex justify-between gap-3 border-b border-gray-100 py-1">
+          <span>${escapeHtml(r.page_type || '')}</span>
+          <span class="font-mono text-gray-600">${Number(r.pages || 0).toLocaleString()} · ${((r.share || 0) * 100).toFixed(0)}%</span>
+        </div>`).join('') || '<div class="text-gray-500">No page types found.</div>';
+
+    document.getElementById('audit-page-types-templates').innerHTML =
+      (data.template_counts || []).map(r => `
+        <div class="flex justify-between gap-3 border-b border-gray-100 py-1">
+          <span>${escapeHtml(r.template_family || '')}</span>
+          <span class="font-mono text-gray-600">${Number(r.pages || 0).toLocaleString()} · ${Number(r.signatures || 0).toLocaleString()} signatures</span>
+        </div>`).join('') || '<div class="text-gray-500">No templates found.</div>';
+
+    document.getElementById('audit-page-types-pages').innerHTML =
+      (data.per_page || []).filter(r => (r.confidence || 0) < 0.6).slice(0, 100).map(r => `
+        <div class="border-b border-gray-100 py-2">
+          <a class="text-blue-600 hover:underline break-all" href="${escapeHtml(r.url)}" target="_blank" rel="noopener">${escapeHtml(r.url)}</a>
+          <div class="text-gray-500 mt-1">${escapeHtml(r.page_type || 'other')} · ${escapeHtml(r.template_family || '')} · confidence ${Number(r.confidence || 0).toFixed(2)}</div>
+        </div>`).join('') || '<div class="text-gray-500">No low-confidence page classifications.</div>';
+  }
+
+  function renderEntities() {
+    const block = document.getElementById('entities-block');
+    const data = state.entities || {};
+    const summary = data.summary || {};
+    if (!summary.total_pages) {
+      block.style.display = 'none';
+      return;
+    }
+    document.getElementById('audit-entities-summary').innerHTML =
+      card('Authority score', Number(summary.topical_authority_score || 0).toFixed(1),
+        '0–100 heuristic from coverage, depth, reuse, and organizations',
+        (summary.topical_authority_score || 0) >= 60 ? 'text-green-600' : 'text-orange-600') +
+      card('Entity coverage', `${((summary.entity_coverage || 0) * 100).toFixed(0)}%`,
+        `${summary.pages_with_entities || 0} / ${summary.total_pages || 0} pages`) +
+      card('Unique entities', (summary.unique_entities || 0).toLocaleString(), 'distinct entity-like phrases') +
+      card('Entity reuse', `${((summary.entity_reuse_share || 0) * 100).toFixed(0)}%`,
+        `${summary.entities_reused_across_pages || 0} entities appear on 2+ pages`) +
+      card('Organizations', (summary.organization_count || 0).toLocaleString(),
+        `${((summary.organization_coverage || 0) * 100).toFixed(0)}% page coverage`);
+
+    document.getElementById('audit-entities-top').innerHTML =
+      (data.top_entities || []).slice(0, 80).map(r => `
+        <div class="flex justify-between gap-3 border-b border-gray-100 py-1">
+          <span>${escapeHtml(r.entity || '')}</span>
+          <span class="font-mono text-gray-600">${Number(r.mentions || 0).toLocaleString()} · ${Number(r.pages || 0).toLocaleString()}p</span>
+        </div>`).join('') || '<div class="text-gray-500">No entities found.</div>';
+
+    document.getElementById('audit-entities-orgs').innerHTML =
+      (data.organizations || []).slice(0, 80).map(r => `
+        <div class="flex justify-between gap-3 border-b border-gray-100 py-1">
+          <span>${escapeHtml(r.organization || '')}</span>
+          <span class="font-mono text-gray-600">${Number(r.mentions || 0).toLocaleString()} · ${Number(r.pages || 0).toLocaleString()}p</span>
+        </div>`).join('') || '<div class="text-gray-500">No organization entities found.</div>';
+
+    document.getElementById('audit-entities-pages').innerHTML =
+      (data.per_page || []).filter(r => (r.entity_count || 0) < 3).slice(0, 100).map(r => `
+        <div class="border-b border-gray-100 py-2">
+          <a class="text-blue-600 hover:underline break-all" href="${escapeHtml(r.url)}" target="_blank" rel="noopener">${escapeHtml(r.url)}</a>
+          <div class="text-gray-500 mt-1">${Number(r.entity_count || 0).toLocaleString()} entities · ${Number(r.entity_mentions || 0).toLocaleString()} mentions</div>
+        </div>`).join('') || '<div class="text-gray-500">No thin entity pages found.</div>';
+  }
+
+  function renderFreshness() {
+    const block = document.getElementById('freshness-block');
+    const data = state.freshness || {};
+    const summary = data.summary || {};
+    if (!summary.total_pages) {
+      block.style.display = 'none';
+      return;
+    }
+    const card = (label, value, hint, hintClass='text-gray-400') => `
+      <div class="border border-gray-200 rounded p-3">
+        <div class="text-2xl font-semibold">${value}</div>
+        <div class="text-xs text-gray-500">${label}</div>
+        ${hint ? `<div class="text-xs ${hintClass} mt-0.5">${hint}</div>` : ''}
+      </div>`;
+    document.getElementById('audit-freshness-summary').innerHTML =
+      card('Date coverage', `${((summary.date_coverage || 0) * 100).toFixed(0)}%`,
+        `${summary.pages_with_date || 0} / ${summary.total_pages || 0} pages expose a date`,
+        (summary.date_coverage || 0) >= 0.7 ? 'text-green-600' : 'text-orange-600') +
+      card('Stale pages', (summary.pages_stale || 0).toLocaleString(),
+        `older than ${summary.stale_days || 365} days`,
+        summary.pages_stale ? 'text-orange-600' : 'text-green-600') +
+      card('Very stale', (summary.pages_very_stale || 0).toLocaleString(),
+        `older than ${summary.very_stale_days || 730} days`,
+        summary.pages_very_stale ? 'text-red-600' : 'text-green-600') +
+      card('Missing dates', (summary.missing_dates || 0).toLocaleString(),
+        'pages with no usable date signal') +
+      card('Median age', summary.median_age_days == null ? '—' : `${Number(summary.median_age_days).toLocaleString()}d`,
+        summary.newest_date ? `newest ${summary.newest_date}` : '');
+
+    document.getElementById('audit-freshness-pages').innerHTML =
+      (data.stale_pages || []).slice(0, 200).map(r => {
+        const bucketClass = r.bucket === 'very_stale' ? 'bg-red-100 text-red-800'
+          : r.bucket === 'stale' ? 'bg-orange-100 text-orange-800'
+          : r.bucket === 'future' ? 'bg-purple-100 text-purple-800'
+          : 'bg-gray-100 text-gray-700';
+        const age = r.age_days == null ? 'unknown age' : `${Number(r.age_days).toLocaleString()} days old`;
+        return `
+          <div class="border-b border-gray-100 py-2">
+            <div class="flex items-start gap-2 flex-wrap">
+              <span class="text-xs px-1.5 py-0.5 rounded ${bucketClass}">${escapeHtml(String(r.bucket || 'unknown').replaceAll('_', ' '))}</span>
+              <a class="text-blue-600 hover:underline break-all" href="${escapeHtml(r.url)}" target="_blank" rel="noopener">${escapeHtml(r.url)}</a>
+            </div>
+            <div class="text-gray-500 mt-1">${escapeHtml(r.date || 'missing date')} · ${escapeHtml(age)} · ${escapeHtml(r.date_source || 'no source')}</div>
+          </div>`;
+      }).join('') || '<div class="text-gray-500">No stale or undated pages found.</div>';
+  }
+
+  function renderPerformance() {
+    const block = document.getElementById('performance-block');
+    const data = state.performance || {};
+    const summary = data.summary || {};
+    if (!summary.total_pages) {
+      block.style.display = 'none';
+      return;
+    }
+    const kb = bytes => `${(Number(bytes || 0) / 1024).toFixed(0)} KB`;
+    document.getElementById('audit-performance-summary').innerHTML =
+      card('Median HTML', kb(summary.median_html_weight_bytes), `${kb(summary.p90_html_weight_bytes)} p90`) +
+      card('P90 estimated weight', kb(summary.p90_estimated_weight_bytes), 'HTML + heuristic resource weights') +
+      card('Resource tags/page', Number(summary.avg_resource_tags_per_page || 0).toFixed(1), 'images, scripts, CSS, fonts, preloads') +
+      card('Render-blocking', `${((summary.render_blocking_share || 0) * 100).toFixed(0)}%`,
+        `${summary.pages_with_render_blocking || 0} pages`,
+        summary.pages_with_render_blocking ? 'text-orange-600' : 'text-green-600') +
+      card('Heavy pages', `${((summary.heavy_page_share || 0) * 100).toFixed(0)}%`,
+        `${summary.heavy_pages || 0} pages in heavy/very heavy buckets`);
+
+    const pageRow = r => `
+      <div class="border-b border-gray-100 py-2">
+        <a class="text-blue-600 hover:underline break-all" href="${escapeHtml(r.url)}" target="_blank" rel="noopener">${escapeHtml(r.url)}</a>
+        <div class="text-gray-500 mt-1">
+          ${escapeHtml(r.weight_bucket || 'unknown')} · est. ${kb(r.estimated_weight_bytes)} · HTML ${kb(r.html_weight_bytes)} ·
+          ${Number(r.resource_tag_count || 0).toLocaleString()} resources · ${Number(r.render_blocking_count || 0).toLocaleString()} blocking
+        </div>
+      </div>`;
+    document.getElementById('audit-performance-heavy').innerHTML =
+      (data.top_heavy_pages || []).slice(0, 100).map(pageRow).join('') || '<div class="text-gray-500">No heavy pages found.</div>';
+    document.getElementById('audit-performance-blocking').innerHTML =
+      (data.render_blocking_pages || []).slice(0, 100).map(pageRow).join('') || '<div class="text-gray-500">No render-blocking resources found.</div>';
+  }
+
+  function renderConversion() {
+    const block = document.getElementById('conversion-block');
+    const data = state.conversion || {};
+    const summary = data.summary || {};
+    if (!summary.total_pages) {
+      block.style.display = 'none';
+      return;
+    }
+    document.getElementById('audit-conversion-summary').innerHTML =
+      card('CTA coverage', `${((summary.cta_coverage || 0) * 100).toFixed(0)}%`,
+        `${summary.pages_with_cta || 0} / ${summary.total_pages || 0} pages have a CTA`,
+        (summary.cta_coverage || 0) >= 0.8 ? 'text-green-600' : 'text-orange-600') +
+      card('Primary CTA coverage', `${((summary.primary_cta_coverage || 0) * 100).toFixed(0)}%`,
+        `${summary.pages_with_primary_cta || 0} pages with transactional CTA`) +
+      card('Forms', (summary.total_forms || 0).toLocaleString(),
+        `${((summary.form_coverage || 0) * 100).toFixed(0)}% page coverage`) +
+      card('Lead leaks', (summary.lead_pages_without_capture || 0).toLocaleString(),
+        'lead pages without form/phone/email',
+        summary.lead_pages_without_capture ? 'text-red-600' : 'text-green-600') +
+      card('Avg CTAs/page', Number(summary.avg_ctas_per_page || 0).toFixed(1),
+        `${summary.cta_overload_pages || 0} overloaded pages`);
+
+    document.getElementById('audit-conversion-ctas').innerHTML =
+      (data.top_ctas || []).slice(0, 40).map(r => `
+        <div class="flex justify-between gap-3 border-b border-gray-100 py-1">
+          <span>${escapeHtml(r.text)}</span>
+          <span class="font-mono text-gray-600">${Number(r.count || 0).toLocaleString()}</span>
+        </div>`).join('') || '<div class="text-gray-500">No CTA text found.</div>';
+
+    document.getElementById('audit-conversion-pages').innerHTML =
+      (data.per_page || []).filter(r => (r.issues || []).length).slice(0, 80).map(r => {
+        const issues = (r.issues || []).map(issue =>
+          `<span class="inline-block bg-gray-100 text-gray-700 px-1.5 py-0.5 rounded mr-1 mb-1">${escapeHtml(issue.replaceAll('_', ' '))}</span>`
+        ).join('');
+        return `
+          <div class="border-b border-gray-100 py-2">
+            <a class="text-blue-600 hover:underline break-all" href="${escapeHtml(r.url)}" target="_blank" rel="noopener">${escapeHtml(r.url)}</a>
+            <div class="mt-1">${issues}</div>
+            <div class="text-gray-500 mt-1">${r.cta_count || 0} CTAs · ${r.primary_cta_count || 0} primary · ${r.form_count || 0} forms · ${r.contact_link_count || 0} contact links</div>
+          </div>`;
+      }).join('') || '<div class="text-gray-500">No conversion issues found.</div>';
   }
 
   function renderLinkgraph() {


### PR DESCRIPTION
Implements the remaining audit report issues with focused analyzers, report payloads, comparison metrics, UI sections, and unit tests.

Closes #2.
Closes #3.
Closes #4.
Closes #6.
Closes #7.
Closes #8.
Closes #9.

Validation:
- ./.venv/bin/python -m pytest
- ./.venv/bin/python -m compileall -q site_audit
- node script syntax check for ui/index.html and ui/compare.html