### PR TITLE
Fix IndexError on macOS: reinitialize position_ids buffer after model load

### DIFF
--- a/site_audit/embedder.py
+++ b/site_audit/embedder.py
@@ -55,6 +55,17 @@ class Embedder:
         self._model = SentenceTransformer(
             self.model_name, trust_remote_code=True, device=device
         )
+        # On macOS (Apple Silicon), the gte-multilingual-base model's
+        # position_ids buffer (persistent=False) appears to contain garbage
+        # memory after loading rather than the expected arange values.
+        # Reinitializing it here works around the issue.
+        import torch as _torch
+        _am = self._model[0].auto_model
+        _am.embeddings.register_buffer(
+            "position_ids",
+            _torch.arange(_am.config.max_position_embeddings, dtype=_torch.long),
+            persistent=False,
+        )
 
     def encode(self, texts: list[str], batch_size: int = 32, show_progress: bool = False) -> np.ndarray:
         if not texts:


### PR DESCRIPTION
Fixes #54

## What this does

After `SentenceTransformer` loads `gte-multilingual-base`, the `embeddings.position_ids` buffer (registered with `persistent=False`) appears to contain garbage memory on macOS / Apple Silicon instead of the expected `torch.arange(max_position_embeddings)` values. This causes an `IndexError` deep inside the RoPE positional encoding on the very first `encode()` call.

The fix is a single `register_buffer` call in `Embedder._ensure()` that reinitializes the tensor to the correct values right after the model is loaded.

## Why here and not upstream

The issue seems to live somewhere in the PyTorch + custom `transformers` module + MPS interaction, which is tricky to isolate. Adding the reinitialization in `site-audit` is a safe, low-risk workaround that unblocks macOS users immediately — and it's a no-op on platforms where the buffer is already correct.

## Testing

Verified on macOS (Apple Silicon, M-series) with Python 3.12 and PyTorch 2.x:

- Before: `site-audit run <domain>` crashes immediately when embedding starts
- After: full audit completes successfully

## Changes

- `site_audit/embedder.py` — 10 lines added to `_ensure()`, no other changes

Happy to adjust anything!