### PR TITLE
fix: distinguish 'other schema present' from 'no schema' in answerability scoring

### DIFF
--- a/site_audit/answerability.py
+++ b/site_audit/answerability.py
@@ -58,8 +58,11 @@ def score_page(page: ExtractedPage) -> AnswerabilityScore:
     elif schema_types & _STRUCTURED_TYPES:
         breakdown["structured_schema"] = 1.5
         flags.append(f"structured schema: {sorted(schema_types & _STRUCTURED_TYPES)[0]}")
+    elif schema_types:
+        other = ", ".join(sorted(schema_types)[:3])
+        flags.append(f"schema present ({other}) — consider adding Article/FAQ/HowTo")
     else:
-        flags.append("no Article/FAQ/HowTo schema")
+        flags.append("no schema markup")
 
     q_h = _question_heading_count(page)
     if q_h >= 3:


### PR DESCRIPTION
Fixes #58

Hi! Thank you for building site-audit — I've found it really useful.

## What this changes

In `score_page()` inside `answerability.py`, the `else` branch after the `_STRUCTURED_TYPES` check was firing for any page that had schema markup outside the FAQ/Article/HowTo sets (e.g. `DefinedTerm`, `JobPosting`, `BreadcrumbList`). Those pages were flagged as `"no Article/FAQ/HowTo schema"`, which is technically true but misleading — it hides the fact that structured data is actually present.

This PR splits that branch into two:

- **Has schema, but not the preferred types** → `"schema present (X) — consider adding Article/FAQ/HowTo"` (constructive suggestion)
- **No schema at all** → `"no schema markup"` (clear call-out)

## Change

```python
# before
else:
    flags.append("no Article/FAQ/HowTo schema")

# after
elif schema_types:
    other = ", ".join(sorted(schema_types)[:3])
    flags.append(f"schema present ({other}) — consider adding Article/FAQ/HowTo")
else:
    flags.append("no schema markup")
```

## Testing

Verified manually with four cases: `DefinedTerm` (other schema), `Article` (structured), `FAQPage` (FAQ), and no schema. All produce the expected flag and score.

Happy to tweak anything — and thanks again for the project!