### PR TITLE
Add SERP paragraph gap analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # site-audit
 
+For interpreting competitor paragraph gaps, see [SERP Paragraph Gap Analysis](docs/serp-paragraph-gap-analysis.md). It explains how to choose relevant keywords, read missing/partial topics, and turn the report into an editorial action plan.
+
+For section-by-section interpretation of the report UI, see [Report Section Guide](docs/report-sections.md).
+
 Crawl any website, embed every page, and surface near-duplicates,
 outliers, topic clusters, GEO citability, and internal-link
 recommendations on an interactive D3 scatterplot.

--- a/docs/report-sections.md
+++ b/docs/report-sections.md
@@ -1,0 +1,424 @@
+# Report Section Guide
+
+This guide explains how to read each major section in a `site-audit` report and what action a user should take from it.
+
+Use every section as a decision aid, not as proof of causality. SEO and GEO outcomes are influenced by content, internal links, backlinks, brand, freshness, search intent, technical health, and provider sampling. The useful workflow is:
+
+1. Confirm the affected URL is the correct target page.
+2. Check whether the issue is relevant to the business.
+3. Prioritize high-impact pages and clusters.
+4. Make one clear editorial, technical, or linking change.
+5. Rerun the audit and monitor GSC/Ahrefs later.
+
+<a id="hist-block"></a>
+## Per-page similarity to site centroid
+
+Shows how closely each page aligns with the overall site topic. Very low similarity pages may be off-topic, localized noise, thin utility pages, or unrelated content.
+
+Action: review the low-similarity tail. Keep pages that serve a strategic purpose, move misplaced content to a better section, or deindex/remove pages that dilute topical focus.
+
+<a id="action-plan-block"></a>
+## Action plan
+
+Aggregates findings from multiple analyses into a prioritized task list.
+
+Action: start here when you need execution priorities. Validate the suggested URL and issue type, then assign each item to content, technical SEO, internal linking, or product/UX.
+
+<a id="improvement-block"></a>
+## GEO pages most in need of editing
+
+Identifies pages with weak content quality, answerability, structural, or topical signals for generative search visibility.
+
+Action: rewrite high-priority pages with clearer answers, better headings, stronger evidence, and more direct intent coverage.
+
+<a id="title-mismatch-block"></a>
+## Title does not match content
+
+Finds pages where the title promises a topic that the body does not strongly support.
+
+Action: either rewrite the title to match the page, or add sections that satisfy the title's promise.
+
+<a id="headers-block"></a>
+## Header structure
+
+Audits H1-H6 structure, hierarchy, repeated headings, and heading drift.
+
+Action: fix missing/multiple H1s, make H2/H3s descriptive, and ensure headings form a logical outline of the page.
+
+<a id="heading-impact-block"></a>
+## Heading impact map
+
+Connects headings to search demand, paragraph support, and page context.
+
+Action: rename headings that carry demand but are vague, and add paragraphs under headings that currently lack substance.
+
+<a id="clusters-block"></a>
+## Topic clusters
+
+Groups pages by semantic similarity and auto-labels the dominant topics.
+
+Action: use clusters to understand site architecture. Strong clusters can become hubs; weak or mixed clusters may need better grouping, internal links, or clearer page targeting.
+
+<a id="treemap-block"></a>
+## Topic mass treemap
+
+Visualizes how much content exists in each topic cluster.
+
+Action: compare content mass with business importance. Large low-value clusters may be bloat; small high-value clusters may need expansion.
+
+<a id="ahrefs-block"></a>
+## Organic search demand overlay
+
+Shows Ahrefs, GSC, or DataForSEO search demand mapped onto audited pages and clusters.
+
+Action: prioritize pages with meaningful demand, weak rankings, or high opportunity. Filter out irrelevant traffic before making content decisions.
+
+<a id="best-pages-block"></a>
+## Best page reverse engineering
+
+Explains what successful pages on the site have in common.
+
+Action: turn recurring strengths into a template checklist for new or refreshed pages.
+
+<a id="paragraph-impact-block"></a>
+## Winning paragraphs
+
+Surfaces paragraphs that appear to carry important topic or keyword value.
+
+Action: preserve these paragraphs during edits, improve their evidence, and add internal links around them.
+
+<a id="weak-paragraphs-block"></a>
+## Weak paragraphs and content decay
+
+Flags duplicated, stale, generic, off-topic, unsupported, or poorly linked paragraphs.
+
+Action: rewrite, merge, remove, cite, move, or link the flagged paragraphs depending on the recommended action.
+
+<a id="semantic-ablation-block"></a>
+## Semantic ablation
+
+Estimates whether removing a paragraph would hurt or improve page-topic alignment.
+
+Action: protect topic carriers. Consider removing or moving noise candidates if they do not serve users or conversions.
+
+<a id="keyword-attribution-block"></a>
+## Keyword traffic attribution
+
+Maps ranking keywords to the page paragraph that best supports them.
+
+Action: strengthen paragraphs that support valuable keywords, and create missing paragraphs where demand has no strong on-page support.
+
+<a id="heatmap-block"></a>
+## Cluster overlap heatmap
+
+Shows which topic clusters are semantically close or overlapping.
+
+Action: use overlap to find consolidation, hub, and internal-link opportunities. High overlap can also indicate cannibalization risk.
+
+<a id="coverage-block"></a>
+## Keyword coverage
+
+Checks whether target queries have a strong matching page.
+
+Action: create pages for gaps, differentiate cannibalized queries, and improve pages with weak coverage.
+
+<a id="indexability-block"></a>
+## Indexability funnel
+
+Summarizes crawlability, noindex, canonical, robots, and skipped-page signals.
+
+Action: fix accidental noindex/canonical/robots issues before content work. Content improvements do not matter if the page cannot be indexed.
+
+<a id="structured-data-block"></a>
+## Structured data health
+
+Audits JSON-LD/schema coverage and opportunities.
+
+Action: add schema only where visible page content supports it. Prioritize FAQ, Article, Product, HowTo, or Organization schema when relevant.
+
+<a id="trust-signals-block"></a>
+## E-E-A-T and trust signals
+
+Looks for evidence, author, citations, dates, company, policy, and credibility signals.
+
+Action: add author/reviewer details, dates, sources, examples, policies, and proof where users need confidence.
+
+<a id="conversion-balance-block"></a>
+## Conversion vs SEO balance
+
+Compares informational usefulness with conversion pressure.
+
+Action: reduce premature CTAs on informational pages, or add stronger conversion paths to commercial pages that already satisfy intent.
+
+<a id="metadata-quality-block"></a>
+## SERP metadata quality
+
+Audits titles, descriptions, canonicals, and social metadata.
+
+Action: rewrite metadata for clarity, intent match, and uniqueness. Fix missing or duplicated descriptions and bad canonicals.
+
+<a id="media-accessibility-block"></a>
+## Media accessibility
+
+Checks images, videos, iframes, alt text, captions, and media metadata.
+
+Action: add meaningful alt text, captions/transcripts, dimensions, and accessible labels where media supports the page.
+
+<a id="page-types-block"></a>
+## Page types and templates
+
+Classifies pages into templates such as article, FAQ, product, tool, category, and contact.
+
+Action: verify important keywords are mapped to the right page type. If the SERP wants comparison pages, a pure product page may not be enough.
+
+<a id="template-patterns-block"></a>
+## Template success patterns
+
+Identifies reusable page/template traits associated with stronger outcomes.
+
+Action: apply proven patterns to similar weak pages, but avoid blindly copying patterns across different intents.
+
+<a id="entities-block"></a>
+## Entities and topical authority
+
+Extracts named entities and recurring concepts across the site.
+
+Action: build topical authority around core entities, and remove or isolate entity clusters that are irrelevant to the business.
+
+<a id="entity-coverage-block"></a>
+## Entity coverage score
+
+Compares each page's entity coverage against its topic context.
+
+Action: add missing core entities when they help users understand the topic. Do not stuff entities that do not belong naturally.
+
+<a id="information-gain-block"></a>
+## Information gain and originality
+
+Estimates whether pages add distinctive information or mostly repeat common content.
+
+Action: add first-hand examples, workflows, data, screenshots, opinions, comparisons, or implementation details.
+
+<a id="freshness-block"></a>
+## Content freshness
+
+Checks dates and stale content signals.
+
+Action: update pages where freshness matters to the query. Add visible modified dates only when the content was truly reviewed.
+
+<a id="freshness-impact-block"></a>
+## Freshness impact
+
+Connects freshness issues to sections or pages where search demand may be affected.
+
+Action: prioritize refreshes where stale content overlaps with valuable traffic or rankings.
+
+<a id="performance-block"></a>
+## Lightweight performance signals
+
+Reports simple page-weight and render-blocking indicators.
+
+Action: use this as a triage signal. Run Lighthouse/WebPageTest before major performance engineering.
+
+<a id="performance-explainer-block"></a>
+## Performance explainer
+
+Looks for relationships between performance features and observed outcomes.
+
+Action: treat findings as correlation. Prioritize performance fixes that affect templates, critical pages, or user experience.
+
+<a id="conversion-block"></a>
+## Conversion and CTA signals
+
+Audits CTAs, forms, contacts, and conversion paths.
+
+Action: ensure commercial pages have clear next steps and informational pages have appropriate soft conversions.
+
+<a id="answerability-block"></a>
+## GEO answer-ability score
+
+Scores whether pages are likely to answer questions directly and extractably.
+
+Action: add concise answer blocks, question headings, lists, tables, definitions, and evidence.
+
+<a id="answer-blocks-block"></a>
+## Answer blocks and snippet candidates
+
+Finds paragraphs that could serve as answer/snippet blocks.
+
+Action: improve weak answer blocks with direct wording, specificity, and source-backed facts.
+
+<a id="cannibalization-block"></a>
+## Content cannibalization by intent
+
+Finds multiple pages competing for the same or similar intent.
+
+Action: merge, canonicalize, retarget, or differentiate pages. Avoid having several weak pages chase the same query.
+
+<a id="duplicate-fragments-block"></a>
+## Duplicate strong fragments
+
+Finds repeated content fragments that may dilute pages.
+
+Action: keep necessary template text, but remove or rewrite boilerplate that appears as main content across many pages.
+
+<a id="linkgraph-block"></a>
+## Top authority and orphan pages
+
+Shows internal PageRank-style authority pages and pages with no inbound links.
+
+Action: link important orphan pages from relevant hubs, and use authority pages to distribute internal equity.
+
+<a id="linkflow-block"></a>
+## Internal link equity flow
+
+Visualizes how internal authority flows between pages or sections.
+
+Action: strengthen flows into high-value pages and reduce wasted links to low-value destinations.
+
+<a id="traffic-pagerank-block"></a>
+## Traffic-weighted PageRank
+
+Compares search demand with internal link support.
+
+Action: prioritize high-demand pages with weak internal authority. Add contextual links from relevant strong pages.
+
+<a id="high-demand-link-block"></a>
+## High-demand low-link pages
+
+Lists pages with search opportunity but poor internal-link support.
+
+Action: add links from hubs, related articles, templates, and high-authority pages.
+
+<a id="hub-bottleneck-block"></a>
+## Hub and bottleneck pages
+
+Identifies pages that connect or block important internal-link paths.
+
+Action: strengthen useful hubs and reduce dependence on fragile bottlenecks.
+
+<a id="link-removal-block"></a>
+## Internal link removal simulation
+
+Estimates risk from removing internal links.
+
+Action: avoid removing links marked as important unless you replace them with better contextual links.
+
+<a id="link-addition-block"></a>
+## Suggested internal links
+
+Recommends high-similarity source-target links that do not currently exist.
+
+Action: add only links that are useful to readers and naturally fit the paragraph context.
+
+<a id="linkbuilding-block"></a>
+## Linkbuilding overview
+
+Summarizes external backlink or outbound-link-oriented signals where available.
+
+Action: use as a directional view of link health, anchor quality, and external authority gaps.
+
+<a id="link-counts-block"></a>
+## Internal links per page
+
+Shows inbound and outbound internal-link distribution.
+
+Action: fix pages with too few meaningful inbound links or excessive low-value outbound links.
+
+<a id="para-density-block"></a>
+## Paragraph link density
+
+Measures how many links appear inside paragraph text.
+
+Action: add contextual links to isolated paragraphs, and reduce spammy/link-stuffed paragraphs.
+
+<a id="para-links-block"></a>
+## In-paragraph link recommendations
+
+Suggests paragraph-level internal links.
+
+Action: add links where the source paragraph genuinely introduces the target topic.
+
+<a id="wrong-home-block"></a>
+## Paragraphs that belong on a different page
+
+Finds paragraphs whose semantic home appears to be another page.
+
+Action: move, rewrite, or link these paragraphs so each page stays focused.
+
+<a id="para-clusters-block"></a>
+## Paragraph topic clusters
+
+Groups paragraphs across the site by topic.
+
+Action: identify duplicated themes, missing hubs, scattered topics, and paragraphs that should be consolidated.
+
+<a id="fanout-block"></a>
+## Query to paragraph fanout
+
+Shows whether a query is supported by one focused paragraph, scattered across many, or missing.
+
+Action: consolidate scattered support into a clearer section, or create a paragraph for gaps.
+
+<a id="competitive-block"></a>
+## Competitor comparison
+
+Compares your target page with competitor URLs at structural and paragraph-topic levels.
+
+Action: confirm the target page, add relevant missing topics, improve partial topics, ignore irrelevant competitor topics, and rerun. If auto mode was used, first inspect the auto-selected keyword table and reject any keyword that does not match the product strategy. See also [SERP Paragraph Gap Analysis](serp-paragraph-gap-analysis.md).
+
+<a id="hits-block"></a>
+## HITS hubs and authorities
+
+Shows pages that behave as hubs or authorities in the internal link graph.
+
+Action: use strong hubs to link into strategic pages, and improve authority pages that deserve more support.
+
+<a id="depth-block"></a>
+## Buried pages
+
+Lists pages far from the homepage by click depth.
+
+Action: reduce depth for important pages using navigation, hubs, breadcrumbs, or contextual links.
+
+<a id="cluster-auth-block"></a>
+## Topic-cluster authorities
+
+Shows authority pages inside each topic cluster.
+
+Action: use cluster authorities as hubs and ensure they link to related conversion and support pages.
+
+<a id="anchor-block"></a>
+## Anchor-text analysis
+
+Audits anchor text descriptiveness and relevance.
+
+Action: replace vague anchors such as “read more” with descriptive anchors that match the target page.
+
+<a id="contextual-link-block"></a>
+## Contextual link impact
+
+Scores the usefulness of links inside meaningful content areas.
+
+Action: prioritize main-content links over template/nav links when supporting important pages.
+
+<a id="internal-link-patterns-block"></a>
+## Internal link pattern library
+
+Finds reusable internal-linking patterns and weak pages that need them.
+
+Action: apply successful patterns to similar pages, especially within the same page type or topic cluster.
+
+<a id="external-block"></a>
+## External links and citation density
+
+Shows most-cited external domains and citation density.
+
+Action: cite authoritative sources where claims need support. Remove low-quality or irrelevant external links.
+
+<a id="broken-block"></a>
+## Broken outbound links
+
+Lists outbound links that failed checks when external checking is enabled.
+
+Action: replace, remove, or update broken citations.

--- a/docs/serp-paragraph-gap-analysis.md
+++ b/docs/serp-paragraph-gap-analysis.md
@@ -1,0 +1,268 @@
+# SERP Paragraph Gap Analysis
+
+This report answers a narrow question:
+
+> For a keyword or keyword cluster, what paragraph-level topics are common across ranking competitor pages, and which of those topics are missing or weak on our best matching page?
+
+It does not prove why Google ranks a competitor higher. Rankings also depend on backlinks, internal links, brand, topical authority, freshness, technical health, SERP layout, personalization, and provider sampling. Treat the output as content evidence from the current SERP, not as a causal ranking diagnosis.
+
+## When To Use It
+
+Use this analysis for business-relevant keywords where you already know the page should compete, or where you are deciding whether to create a new page.
+
+Do not use it for every keyword that brings traffic. Many keywords can be irrelevant to the product, too broad, localized, branded, informational-only, or attached to pages that should not become commercial targets.
+
+Good candidates:
+
+- product, service, use-case, and comparison queries
+- keywords with impressions or traffic potential
+- keywords where the site ranks below stronger competitors
+- clusters with clear business value
+- clusters where you have, or can create, a target page
+
+Poor candidates:
+
+- foreign-language traffic that is not part of the current strategy
+- glossary, entertainment, or curiosity keywords with weak product fit
+- competitor brand terms unless there is a deliberate comparison strategy
+- keywords where the SERP intent is forums, videos, jobs, news, or local listings
+- keywords whose best target page would not help the business
+
+## Input Format
+
+Run the audit with a competitive TSV:
+
+```text
+# AI automation platforms
+AI automation platforms	best ai automation platforms	https://competitor.example/best-ai-platforms	1
+AI automation platforms	best ai automation platforms	https://competitor.example/ai-automation-tools	2
+
+# AI voice agents
+AI voice agents	best ai voice agents	https://competitor.example/voice-agents	1
+```
+
+Supported row formats:
+
+- `query<TAB>competitor_url`
+- `cluster<TAB>query<TAB>competitor_url<TAB>rank`
+- `cluster | query | rank | competitor_url`
+
+Rows with the same cluster/query are grouped into one SERP paragraph model.
+
+## How The Analysis Works
+
+For each query group:
+
+1. Find the best matching page on your site using query/page embeddings, with conservative demotion for low-intent pages such as author, tag, category, glossary, and localized pages.
+2. Fetch each competitor URL.
+3. Extract competitor paragraphs.
+4. Embed competitor paragraphs in the same vector space as your site paragraphs.
+5. Cluster competitor paragraphs into SERP topics.
+6. Compare each SERP topic against paragraphs on your selected page.
+7. Classify each topic as covered, partial, or missing.
+8. Score priority based on competitor prevalence and coverage weakness.
+
+## How To Read The Report
+
+Start with the selected page.
+
+If the report says the matching page is an author page, unrelated blog post, localized page, glossary page, or tool page that should not rank for the query, do not edit that page blindly. The correct action is to choose or create the real target page and rerun the analysis.
+
+Then read topics in this order:
+
+- `missing`: competitors cover this topic, but your selected page has no close paragraph.
+- `partial`: your page has a related paragraph, but it is weaker or less direct than competitor coverage.
+- `covered`: your page already has a close paragraph-level match.
+
+Priority means:
+
+- `critical`: missing topic seen across most competitors.
+- `high`: missing or partial topic seen across many competitors.
+- `medium`: topic may matter, but competitor evidence is weaker.
+- `covered`: usually no content expansion needed.
+
+## Editorial Action Plan
+
+For each keyword cluster:
+
+1. Confirm the target URL is the page you actually want to rank.
+2. Review missing high-priority topics.
+3. Decide which missing topics are relevant to your product and buying journey.
+4. Add new sections only for relevant missing topics.
+5. Improve existing paragraphs for partial topics.
+6. Ignore irrelevant competitor topics instead of copying them.
+7. Add concrete evidence: examples, workflows, pricing detail, comparisons, screenshots, tables, FAQs, citations, or implementation steps.
+8. Add internal links from related pages to the target page.
+9. Rerun the analysis.
+10. Track ranking and impression changes later in GSC or Ahrefs.
+
+## What To Do With Missing Topics
+
+A missing topic should become a new section only when it is relevant.
+
+Example:
+
+```text
+Topic: pricing, free plan, monthly cost
+Coverage: missing
+Seen on: 5/5 competitors
+Priority: high
+```
+
+Possible action:
+
+- Add a section titled `How much does an AI automation platform cost?`
+- Cover free vs paid plans, seat limits, task volume, implementation cost, and when your product is more cost-effective.
+- Add a small table if the query has buying/comparison intent.
+
+## What To Do With Partial Topics
+
+Partial means the page already touches the topic. Do not create a duplicate section by default.
+
+Improve the closest paragraph:
+
+- make the heading clearer
+- add concrete examples
+- add product-specific detail
+- include a decision criterion
+- add screenshots or tables
+- link to a deeper supporting page
+
+Example:
+
+```text
+Topic: visual workflow builder
+Coverage: partial
+Seen on: 5/5 competitors
+```
+
+Possible action:
+
+- Expand the existing workflow-builder paragraph.
+- Explain triggers, nodes, integrations, testing, human review, and deployment.
+- Add an internal link to a workflow template or product documentation page.
+
+## What To Ignore
+
+Do not add every topic competitors mention.
+
+Ignore a topic when:
+
+- it does not match your product
+- it attracts the wrong audience
+- it belongs on another page
+- it is only present on one weak competitor page
+- it would dilute the page's intent
+- it is a SERP artifact from a different page type
+
+The right question is not:
+
+> What are competitors saying that we can copy?
+
+The right question is:
+
+> Which search-intent requirements are common in winning pages, relevant to our product, and missing or weak on our target page?
+
+## Keyword Selection With Ahrefs And DataForSEO
+
+Use Ahrefs, GSC, and DataForSEO for different jobs.
+
+Ahrefs or GSC should decide which keywords deserve analysis:
+
+- current position
+- impressions or traffic potential
+- matched URL
+- business relevance
+- cluster size
+- ranking gap
+- trend or lost traffic
+
+DataForSEO should fetch current SERP URLs after filtering:
+
+- top organic URLs
+- current titles/descriptions
+- rank position
+- SERP item type
+- location/language-specific results
+
+To avoid wasting API credits:
+
+1. Start from Ahrefs/GSC keywords.
+2. Remove irrelevant languages, branded noise, glossary-only terms, and non-business topics.
+3. Keep only product, service, use-case, and comparison clusters.
+4. Require a relevant target URL or planned target URL.
+5. Cap the run, for example: top 3 clusters, top 3 keywords per cluster, top 5 URLs per keyword.
+6. Cache SERP results and competitor fetches.
+
+## Auto Mode
+
+Manual TSV input is safest when you already know the exact keywords and competitor URLs. Auto mode is useful when you want the audit to choose relevant opportunities from Ahrefs/GSC/DataForSEO search data and then fetch live SERP URLs from DataForSEO.
+
+Run:
+
+```bash
+site-audit run flowhunt.io \
+  --competitive-auto \
+  --competitive-auto-product-seed "AI workflow automation" \
+  --competitive-auto-product-seed "AI agents" \
+  --competitive-auto-clusters 3 \
+  --competitive-auto-keywords-per-cluster 1 \
+  --competitive-auto-results-per-keyword 5
+```
+
+Auto mode does this:
+
+1. Reads organic keywords from the selected search provider payload.
+2. Rejects non-Latin keywords by default.
+3. Rejects low-intent pages such as author, tag, category, glossary, and localized pages.
+4. Scores business relevance using commercial modifiers, intent labels, page type, demand, and optional product seed phrases.
+5. Selects the highest-priority clusters and keywords within your caps.
+6. Calls DataForSEO live SERP only for those selected keywords.
+7. Runs paragraph gap analysis against the resulting competitor URLs.
+
+Recommended cost controls:
+
+- keep `--competitive-auto-clusters` low, for example `3` to `10`
+- keep `--competitive-auto-keywords-per-cluster` at `1` or `2`
+- keep `--competitive-auto-results-per-keyword` at `5`
+- use product seeds for every run
+- use `--competitive-auto-refresh-serp` only when you really need fresh SERPs
+
+If your business intentionally targets non-Latin keywords, add:
+
+```bash
+--competitive-auto-allow-nonlatin
+```
+
+If the selected keywords are wrong, tighten product seeds or raise:
+
+```bash
+--competitive-auto-min-relevance
+```
+
+## Recommended User Workflow
+
+For a content strategist:
+
+```text
+1. Pick a relevant keyword cluster.
+2. Confirm or assign the target page.
+3. Run SERP paragraph gap analysis.
+4. Mark each missing/partial topic as add, improve, ignore, or move.
+5. Produce a content brief.
+6. Edit the page.
+7. Add internal links.
+8. Rerun the analysis.
+9. Monitor rankings and impressions.
+```
+
+For a developer building automation:
+
+```text
+1. Build keyword relevance filters before DataForSEO calls.
+2. Let users define allowed URL patterns and product seed terms.
+3. Fetch SERP URLs only for selected keywords.
+4. Group competitor pages by cluster.
+5. Generate paragraph gap recommendations.
+6. Save ignored topics so they do not reappear every run.
+```

--- a/site_audit/cli.py
+++ b/site_audit/cli.py
@@ -136,6 +136,16 @@ def _run_command(args: argparse.Namespace) -> int:
         dataforseo_keywords_limit=args.dataforseo_keywords_limit,
         dataforseo_refresh=args.dataforseo_refresh,
         dataforseo_include_clickstream=args.dataforseo_include_clickstream,
+        competitive_auto=args.competitive_auto,
+        competitive_auto_clusters=args.competitive_auto_clusters,
+        competitive_auto_keywords_per_cluster=args.competitive_auto_keywords_per_cluster,
+        competitive_auto_results_per_keyword=args.competitive_auto_results_per_keyword,
+        competitive_auto_min_relevance=args.competitive_auto_min_relevance,
+        competitive_auto_min_position=args.competitive_auto_min_position,
+        competitive_auto_max_position=args.competitive_auto_max_position,
+        competitive_auto_product_seeds=args.competitive_auto_product_seed,
+        competitive_auto_allow_nonlatin=args.competitive_auto_allow_nonlatin,
+        competitive_auto_refresh_serp=args.competitive_auto_refresh_serp,
     )
     summary = run(config)
     if summary.get("pages", 0) == 0:
@@ -410,6 +420,26 @@ def build_parser() -> argparse.ArgumentParser:
     run_p.add_argument("--no-snapshot", action="store_true",
                        help="Do not copy this finished report into projects/<domain>/snapshots/")
     run_p.add_argument("--competitive", default=None, help="TSV file with `query<TAB>competitor_url` per line")
+    run_p.add_argument("--competitive-auto", action="store_true",
+                       help="Auto-select relevant search clusters and fetch top SERP URLs from DataForSEO for paragraph-gap analysis")
+    run_p.add_argument("--competitive-auto-clusters", type=int, default=3,
+                       help="Max relevant keyword clusters to analyze in --competitive-auto mode (default: 3)")
+    run_p.add_argument("--competitive-auto-keywords-per-cluster", type=int, default=1,
+                       help="Max keywords per selected cluster to fetch SERPs for (default: 1)")
+    run_p.add_argument("--competitive-auto-results-per-keyword", type=int, default=5,
+                       help="Top organic SERP URLs per keyword to analyze (default: 5)")
+    run_p.add_argument("--competitive-auto-min-relevance", type=float, default=0.35,
+                       help="Minimum keyword business-relevance score for auto competitive analysis (default: 0.35)")
+    run_p.add_argument("--competitive-auto-min-position", type=int, default=2,
+                       help="Only auto-analyze keywords ranking at this position or worse (default: 2)")
+    run_p.add_argument("--competitive-auto-max-position", type=int, default=20,
+                       help="Only auto-analyze keywords ranking at this position or better (default: 20)")
+    run_p.add_argument("--competitive-auto-product-seed", action="append", default=[],
+                       help="Product/service seed phrase for relevance filtering; repeat for multiple seeds")
+    run_p.add_argument("--competitive-auto-allow-nonlatin", action="store_true",
+                       help="Allow non-Latin keywords in auto competitive selection")
+    run_p.add_argument("--competitive-auto-refresh-serp", action="store_true",
+                       help="Ignore cached DataForSEO SERP snapshots for auto competitive targets")
     run_p.add_argument("--queries-file", default=None, help="Optional file: one target query per line")
     run_p.add_argument("--auto-queries-max", type=int, default=200)
     run_p.add_argument("--coverage-threshold", type=float, default=0.55, help="Min similarity for query→page to count as 'covered'")

--- a/site_audit/competitive_analysis.py
+++ b/site_audit/competitive_analysis.py
@@ -21,17 +21,42 @@ fetched twice across runs.
 from __future__ import annotations
 
 import logging
+import json
+import os
+import re
+import hashlib
 from dataclasses import dataclass
+from datetime import date
 from pathlib import Path
-from typing import Iterable, Optional
+from typing import Iterable, NamedTuple, Optional
+from urllib.parse import urlparse
 
 import numpy as np
+import requests
 
 from .answerability import score_page
 from .crawler import Crawler, CrawlConfig
 from .extractor import extract
+from .dataforseo import dataforseo_credentials
 
 LOG = logging.getLogger(__name__)
+DATAFORSEO_SERP_BASE_URL = "https://api.dataforseo.com/v3/serp"
+_LOCALE_PREFIXES = {
+    "ar", "cs", "da", "de", "es", "fi", "fr", "hu", "id", "it", "ja", "ko",
+    "nl", "no", "pl", "pt", "ro", "sk", "sv", "th", "tr", "uk", "vi", "zh",
+}
+_LOW_INTENT_PATHS = {"author", "tag", "category", "glossary", "woordenlijst", "glosario", "glossario"}
+_PRODUCT_INTENT_PATHS = {"services", "ai-tools", "ai-flow-templates", "integrations", "blog", "faq"}
+_COMMERCIAL_WORDS = re.compile(
+    r"\b(best|top|software|platform|tool|tools|app|apps|automation|agent|agents|chatbot|"
+    r"workflow|business|compare|comparison|alternative|pricing|solution|service|services)\b",
+    re.I,
+)
+_NOISE_WORDS = re.compile(
+    r"\b(free\s+online|definition|meaning|wiki|lyrics|game|movie|jobs?|salary|course|"
+    r"template|generator|checker|translator|image|photo)\b",
+    re.I,
+)
 
 
 @dataclass
@@ -51,27 +76,146 @@ class CompetitorComparison:
     error: Optional[str] = None
 
 
+class CompetitiveTarget(NamedTuple):
+    query: str
+    competitor_url: str
+    cluster: str = ""
+    rank: int = 0
+
+
+@dataclass
+class CompetitorPage:
+    target: CompetitiveTarget
+    title: str
+    paragraphs: list[str]
+    paragraph_embeddings: np.ndarray
+    structural_gaps: list[dict]
+    answerability: float
+    paragraph_count: int
+    error: Optional[str] = None
+
+
+@dataclass
+class CompetitiveAutoConfig:
+    enabled: bool = False
+    max_clusters: int = 3
+    keywords_per_cluster: int = 1
+    results_per_keyword: int = 5
+    min_position: int = 2
+    max_position: int = 20
+    min_relevance: float = 0.35
+    product_seeds: list[str] | None = None
+    allow_nonlatin: bool = False
+    refresh_serp: bool = False
+    location_code: Optional[int] = None
+    location_name: Optional[str] = None
+    language_code: Optional[str] = None
+    language_name: Optional[str] = None
+
+
+def _split_competitive_line(line: str) -> list[str]:
+    if "\t" in line:
+        return [p.strip() for p in line.split("\t") if p.strip()]
+    if " | " in line:
+        return [p.strip() for p in line.split(" | ") if p.strip()]
+    if "  " in line:
+        return [p.strip() for p in line.split("  ") if p.strip()]
+    return []
+
+
+def _parse_target(parts: list[str], current_cluster: str = "") -> CompetitiveTarget | None:
+    if len(parts) < 2:
+        return None
+    url_i = next((i for i, p in enumerate(parts) if p.startswith(("http://", "https://"))), -1)
+    if url_i < 0:
+        return None
+    url = parts[url_i]
+    rank = 0
+    cluster = current_cluster
+    query = ""
+    before = parts[:url_i]
+    if len(before) == 1:
+        query = before[0]
+    elif len(before) >= 2:
+        cluster = before[0] or cluster
+        query = before[1]
+        for value in before[2:]:
+            try:
+                rank = int(value)
+                break
+            except ValueError:
+                continue
+    for value in parts[url_i + 1:]:
+        if not rank:
+            try:
+                rank = int(value)
+                continue
+            except ValueError:
+                pass
+        if not cluster:
+            cluster = value
+    if not query:
+        return None
+    return CompetitiveTarget(query=query, competitor_url=url, cluster=cluster, rank=rank)
+
+
+def _safe_int(value) -> int:
+    try:
+        return int(float(value or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _safe_float(value) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _target_domain(domain: str) -> str:
+    parsed = urlparse(domain if "://" in domain else f"https://{domain}")
+    host = (parsed.netloc or parsed.path).split("/")[0].lower()
+    return host[4:] if host.startswith("www.") else host
+
+
+def _is_own_url(url: str, domain: str) -> bool:
+    host = urlparse(url if "://" in url else f"https://{url}").netloc.lower()
+    target = _target_domain(domain)
+    return host == target or host.endswith(f".{target}")
+
+
+def _ascii_ratio(text: str) -> float:
+    letters = [ch for ch in text or "" if ch.isalpha()]
+    if not letters:
+        return 1.0
+    ascii_letters = [ch for ch in letters if ord(ch) < 128]
+    return len(ascii_letters) / max(len(letters), 1)
+
+
+def _cache_key(payload: dict) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+
 def load_competitive_pairs(path: Path) -> list[tuple[str, str]]:
-    out: list[tuple[str, str]] = []
+    return [(t.query, t.competitor_url) for t in load_competitive_targets(path)]
+
+
+def load_competitive_targets(path: Path) -> list[CompetitiveTarget]:
+    targets: list[CompetitiveTarget] = []
+    current_cluster = ""
     for raw in Path(path).read_text(encoding="utf-8").splitlines():
         line = raw.strip()
-        if not line or line.startswith("#"):
+        if not line:
             continue
-        # Accept tab, two-spaces, or pipe as separator.
-        if "\t" in line:
-            q, u = line.split("\t", 1)
-        elif " | " in line:
-            q, u = line.split(" | ", 1)
-        elif "  " in line:
-            q, u = line.split("  ", 1)
-        else:
-            # treat the whole line as URL with empty query (rare)
+        if line.startswith("#"):
+            current_cluster = line.lstrip("#").strip()
             continue
-        q = q.strip()
-        u = u.strip()
-        if q and u:
-            out.append((q, u))
-    return out
+        target = _parse_target(_split_competitive_line(line), current_cluster=current_cluster)
+        if target is not None:
+            targets.append(target)
+    return targets
 
 
 def _fetch_one(url: str, http_cache, user_agent: str) -> Optional[str]:
@@ -90,6 +234,375 @@ def _fetch_one(url: str, http_cache, user_agent: str) -> Optional[str]:
     if res is None or "html" not in res.content_type:
         return None
     return res.body
+
+
+def _page_multiplier(page) -> float:
+    url = getattr(page, "url", "") or ""
+    parsed = urlparse(url)
+    parts = [p for p in (parsed.path or "").split("/") if p]
+    multiplier = 1.0
+    if parts and parts[0].lower() in _LOCALE_PREFIXES:
+        multiplier *= 0.72
+        parts = parts[1:]
+    first = parts[0].lower() if parts else ""
+    if first in _LOW_INTENT_PATHS:
+        multiplier *= 0.45
+    if first in _PRODUCT_INTENT_PATHS or not first:
+        multiplier *= 1.06
+    language = (getattr(page, "language", "") or "").lower()
+    if language and language not in {"en", "eng"}:
+        multiplier *= 0.82
+    title = (getattr(page, "title", "") or "").lower()
+    if first == "author" or title.startswith(("author", "autor", "autor:")):
+        multiplier *= 0.5
+    return multiplier
+
+
+def _url_intent_multiplier(url: str) -> float:
+    parsed = urlparse(url if "://" in url else f"https://{url}")
+    parts = [p for p in (parsed.path or "").split("/") if p]
+    multiplier = 1.0
+    if parts and parts[0].lower() in _LOCALE_PREFIXES:
+        multiplier *= 0.72
+        parts = parts[1:]
+    first = parts[0].lower() if parts else ""
+    if first in _LOW_INTENT_PATHS:
+        multiplier *= 0.45
+    if first in _PRODUCT_INTENT_PATHS or not first:
+        multiplier *= 1.06
+    return multiplier
+
+
+def _best_our_page(query: str, pages, page_embeddings: np.ndarray, embedder) -> tuple[int, float]:
+    q_emb = embedder.encode([query])[0]
+    sims = np.clip(page_embeddings @ q_emb, -1.0, 1.0)
+    adjusted = np.asarray([
+        float(sim) * _page_multiplier(page)
+        for sim, page in zip(sims, pages)
+    ], dtype=np.float32)
+    idx = int(np.argmax(adjusted))
+    return idx, float(sims[idx])
+
+
+def _page_by_url(pages) -> dict[str, object]:
+    return {getattr(page, "url", ""): page for page in pages if getattr(page, "url", "")}
+
+
+def _keyword_cluster(row: dict) -> str:
+    return (
+        str(row.get("cluster_label") or "").strip()
+        or str(row.get("section") or "").strip()
+        or str(row.get("matched_url") or row.get("url") or "").strip()
+        or "unclustered"
+    )
+
+
+def _keyword_relevance(
+    row: dict,
+    *,
+    page_lookup: dict[str, object],
+    seed_embeddings: np.ndarray,
+    embedder,
+    config: CompetitiveAutoConfig,
+) -> tuple[float, list[str]]:
+    keyword = str(row.get("keyword") or "").strip()
+    reasons: list[str] = []
+    if not keyword:
+        return 0.0, ["missing_keyword"]
+    if not config.allow_nonlatin and _ascii_ratio(keyword) < 0.85:
+        return 0.0, ["nonlatin_keyword"]
+    position = _safe_int(row.get("position"))
+    if position and (position < config.min_position or position > config.max_position):
+        return 0.0, ["position_out_of_range"]
+    url = row.get("matched_url") or row.get("url") or ""
+    page = page_lookup.get(url)
+    url_multiplier = _page_multiplier(page) if page is not None else _url_intent_multiplier(url)
+    if url_multiplier < 0.8:
+        return 0.0, ["low_intent_page"]
+    if _NOISE_WORDS.search(keyword):
+        reasons.append("noise_term")
+    if _COMMERCIAL_WORDS.search(keyword):
+        reasons.append("commercial_modifier")
+
+    score = 0.0
+    if "commercial_modifier" in reasons:
+        score += 0.35
+    intents = {str(x).lower() for x in (row.get("intents") or [])}
+    if intents & {"commercial", "transactional"}:
+        score += 0.25
+        reasons.append("commercial_intent")
+    if url:
+        score += min(0.25, max(0.0, (url_multiplier - 0.8) * 0.6))
+        reasons.append("eligible_target_page")
+    traffic = _safe_float(row.get("traffic"))
+    volume = _safe_float(row.get("volume"))
+    if traffic > 0 or volume > 0:
+        score += 0.1
+        reasons.append("has_demand")
+
+    if len(seed_embeddings):
+        q_emb = embedder.encode([keyword], batch_size=16, show_progress=False)[0]
+        seed_sim = float(np.max(seed_embeddings @ q_emb))
+        score = 0.65 * score + 0.35 * max(0.0, seed_sim)
+        if seed_sim >= config.min_relevance:
+            reasons.append("seed_match")
+        else:
+            reasons.append("weak_seed_match")
+
+    if "noise_term" in reasons:
+        score *= 0.45
+    return score, reasons
+
+
+def select_competitive_auto_keywords(
+    search_payload: dict,
+    pages,
+    embedder,
+    config: CompetitiveAutoConfig,
+) -> dict:
+    rows = list((search_payload or {}).get("organic_keywords") or [])
+    if not rows:
+        return {"status": "no_search_keywords", "selected_keywords": [], "clusters": [], "rejected": []}
+
+    page_lookup = _page_by_url(pages)
+    seeds = [s.strip() for s in (config.product_seeds or []) if s and s.strip()]
+    seed_embeddings = (
+        embedder.encode(seeds, batch_size=16, show_progress=False).astype(np.float32)
+        if seeds else np.zeros((0, 0), dtype=np.float32)
+    )
+    buckets: dict[str, dict] = {}
+    rejected: list[dict] = []
+    for row in rows:
+        relevance, reasons = _keyword_relevance(
+            row,
+            page_lookup=page_lookup,
+            seed_embeddings=seed_embeddings,
+            embedder=embedder,
+            config=config,
+        )
+        if relevance < config.min_relevance:
+            if len(rejected) < 80:
+                rejected.append({
+                    "keyword": row.get("keyword") or "",
+                    "position": _safe_int(row.get("position")),
+                    "traffic": _safe_int(row.get("traffic")),
+                    "matched_url": row.get("matched_url") or row.get("url") or "",
+                    "relevance": round(relevance, 4),
+                    "reasons": reasons,
+                })
+            continue
+        cluster = _keyword_cluster(row)
+        bucket = buckets.setdefault(cluster, {
+            "cluster": cluster,
+            "traffic": 0,
+            "volume": 0,
+            "keywords": [],
+            "matched_urls": {},
+        })
+        traffic = _safe_int(row.get("traffic"))
+        volume = _safe_int(row.get("volume"))
+        position = _safe_int(row.get("position"))
+        opportunity = (traffic or max(1, volume // 100)) * max(1, min(12, position or 10))
+        item = {
+            "keyword": row.get("keyword") or "",
+            "position": position,
+            "traffic": traffic,
+            "volume": volume,
+            "matched_url": row.get("matched_url") or row.get("url") or "",
+            "cluster": cluster,
+            "relevance": round(relevance, 4),
+            "opportunity_score": round(opportunity * relevance, 2),
+            "reasons": reasons,
+        }
+        bucket["keywords"].append(item)
+        bucket["traffic"] += traffic
+        bucket["volume"] += volume
+        if item["matched_url"]:
+            bucket["matched_urls"][item["matched_url"]] = bucket["matched_urls"].get(item["matched_url"], 0) + traffic
+
+    clusters = []
+    for bucket in buckets.values():
+        bucket["keywords"].sort(key=lambda r: (r["opportunity_score"], r["traffic"], r["volume"]), reverse=True)
+        top_keywords = bucket["keywords"][: max(1, config.keywords_per_cluster)]
+        clusters.append({
+            "cluster": bucket["cluster"],
+            "traffic": bucket["traffic"],
+            "volume": bucket["volume"],
+            "keywords": top_keywords,
+            "keyword_count": len(bucket["keywords"]),
+            "matched_urls": sorted(
+                [{"url": url, "traffic": traffic} for url, traffic in bucket["matched_urls"].items()],
+                key=lambda r: r["traffic"],
+                reverse=True,
+            )[:5],
+            "score": round(sum(float(k["opportunity_score"]) for k in top_keywords), 2),
+        })
+    clusters.sort(key=lambda r: (r["score"], r["traffic"], r["volume"]), reverse=True)
+    clusters = clusters[: max(0, config.max_clusters)]
+    selected = [kw for cluster in clusters for kw in cluster["keywords"]]
+    return {
+        "status": "ok" if selected else "no_relevant_keywords",
+        "selected_keywords": selected,
+        "clusters": clusters,
+        "rejected": rejected,
+        "summary": {
+            "source_keywords": len(rows),
+            "eligible_clusters": len(buckets),
+            "selected_clusters": len(clusters),
+            "selected_keywords": len(selected),
+            "max_clusters": config.max_clusters,
+            "keywords_per_cluster": config.keywords_per_cluster,
+            "results_per_keyword": config.results_per_keyword,
+            "min_relevance": config.min_relevance,
+            "product_seeds": seeds,
+        },
+    }
+
+
+def _serp_cache_path(cache_dir: Path, task: dict) -> Path:
+    root = Path(cache_dir) / "dataforseo_serp"
+    root.mkdir(parents=True, exist_ok=True)
+    return root / f"serp_{date.today().isoformat()}_{_cache_key(task)}.json"
+
+
+def _load_serp_cache(cache_dir: Path, task: dict) -> dict | None:
+    root = Path(cache_dir) / "dataforseo_serp"
+    if not root.exists():
+        return None
+    key = _cache_key(task)
+    candidates = sorted(root.glob(f"serp_*_{key}.json"), key=lambda p: p.stat().st_mtime, reverse=True)
+    for path in candidates:
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+    return None
+
+
+def _fetch_dataforseo_serp(keyword: str, cache_dir: Path, config: CompetitiveAutoConfig) -> dict:
+    task: dict = {
+        "keyword": keyword,
+        "depth": max(10, min(100, config.results_per_keyword * 2)),
+    }
+    task["location_code"] = int(config.location_code or 2840)
+    if config.language_code:
+        task["language_code"] = config.language_code
+    else:
+        task["language_code"] = "en"
+    if not config.refresh_serp:
+        cached = _load_serp_cache(cache_dir, task)
+        if cached is not None:
+            cached.setdefault("meta", {})["cache_status"] = "hit"
+            return cached
+    login, password = dataforseo_credentials()
+    if not login or not password:
+        return {
+            "meta": {
+                "status": "missing_api_key",
+                "cache_status": "miss",
+                "message": "Set DATAFORSEO_LOGIN and DATAFORSEO_PASSWORD to fetch live SERP URLs.",
+            },
+            "raw": {},
+        }
+    endpoint = f"{DATAFORSEO_SERP_BASE_URL}/google/organic/live/advanced"
+    resp = requests.post(endpoint, json=[task], auth=(login, password), timeout=120)
+    if resp.status_code >= 400:
+        return {
+            "meta": {"status": "error", "cache_status": "miss", "message": f"HTTP {resp.status_code}: {resp.text[:500]}"},
+            "raw": {},
+        }
+    raw = resp.json()
+    status_code = _safe_int(raw.get("status_code"))
+    if status_code not in (20000, 20100):
+        return {
+            "meta": {"status": "error", "cache_status": "miss", "message": raw.get("status_message") or "DataForSEO SERP request failed"},
+            "raw": raw,
+        }
+    for task_row in raw.get("tasks") or []:
+        task_status = _safe_int(task_row.get("status_code"))
+        if task_status not in (20000, 20100):
+            return {
+                "meta": {
+                    "status": "error",
+                    "cache_status": "miss",
+                    "message": task_row.get("status_message") or "DataForSEO SERP task failed",
+                    "task": task,
+                },
+                "raw": raw,
+            }
+    payload = {"meta": {"status": "ok", "cache_status": "miss", "fetched_at": date.today().isoformat(), "task": task}, "raw": raw}
+    _serp_cache_path(cache_dir, task).write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    return payload
+
+
+def _serp_items(payload: dict) -> list[dict]:
+    out: list[dict] = []
+    raw = payload.get("raw") or {}
+    for task in raw.get("tasks") or []:
+        for result in task.get("result") or []:
+            for item in result.get("items") or []:
+                if isinstance(item, dict):
+                    out.append(item)
+    return out
+
+
+def build_auto_competitive_targets(
+    domain: str,
+    search_payload: dict,
+    pages,
+    embedder,
+    cache_dir: Path,
+    config: CompetitiveAutoConfig,
+) -> tuple[list[CompetitiveTarget], dict]:
+    selection = select_competitive_auto_keywords(search_payload, pages, embedder, config)
+    targets: list[CompetitiveTarget] = []
+    serp_rows: list[dict] = []
+    if selection.get("status") != "ok":
+        return [], {"status": selection.get("status"), "selection": selection, "serp": []}
+
+    for selected in selection.get("selected_keywords") or []:
+        keyword = selected.get("keyword") or ""
+        cluster = selected.get("cluster") or keyword
+        serp_payload = _fetch_dataforseo_serp(keyword, cache_dir, config)
+        meta = serp_payload.get("meta") or {}
+        if meta.get("status") != "ok":
+            serp_rows.append({"keyword": keyword, "cluster": cluster, "status": meta.get("status"), "message": meta.get("message", "")})
+            continue
+        seen: set[str] = set()
+        keyword_targets = []
+        for item in _serp_items(serp_payload):
+            if item.get("type") != "organic":
+                continue
+            url = item.get("url") or ""
+            if not url or _is_own_url(url, domain) or url in seen:
+                continue
+            seen.add(url)
+            rank = _safe_int(item.get("rank_group") or item.get("rank_absolute"))
+            target = CompetitiveTarget(query=keyword, competitor_url=url, cluster=cluster, rank=rank)
+            keyword_targets.append(target)
+            if len(keyword_targets) >= config.results_per_keyword:
+                break
+        targets.extend(keyword_targets)
+        serp_rows.append({
+            "keyword": keyword,
+            "cluster": cluster,
+            "status": "ok",
+            "cache_status": meta.get("cache_status", ""),
+            "targets": [
+                {"url": target.competitor_url, "rank": target.rank}
+                for target in keyword_targets
+            ],
+        })
+    return targets, {
+        "status": "ok" if targets else "no_serp_targets",
+        "selection": selection,
+        "serp": serp_rows,
+        "summary": {
+            "selected_keywords": len(selection.get("selected_keywords") or []),
+            "serp_targets": len(targets),
+            "clusters": len(selection.get("clusters") or []),
+        },
+    }
 
 
 def _structural_diff(ours_ext, theirs_ext) -> list[dict]:
@@ -258,6 +771,259 @@ def _missing_topics(
     return out
 
 
+def _topic_label(docs: list[str], labels: np.ndarray, cid: int) -> str:
+    try:
+        from .cluster_labels import _compute_ctfidf
+        k = int(labels.max()) + 1 if len(labels) else 0
+        cluster_docs = [""] * k
+        for i, c in enumerate(labels):
+            cluster_docs[int(c)] = (cluster_docs[int(c)] + " " + (docs[i] or "")).strip()
+        ctfidf, words = _compute_ctfidf(cluster_docs, ngram_range=(1, 2), min_df=1)
+    except Exception:
+        return f"topic {cid + 1}"
+    if not words or cid >= ctfidf.shape[0]:
+        return f"topic {cid + 1}"
+    scores = ctfidf[cid]
+    top_idx = np.argsort(-scores)[:10]
+    terms: list[str] = []
+    seen: set[str] = set()
+    for j in top_idx:
+        if scores[j] <= 0:
+            continue
+        term = words[int(j)]
+        if any(term in old or old in term for old in seen if term != old):
+            continue
+        seen.add(term)
+        terms.append(term)
+        if len(terms) >= 4:
+            break
+    return ", ".join(terms) or f"topic {cid + 1}"
+
+
+def _cluster_paragraphs(embeddings: np.ndarray, max_clusters: int = 12) -> np.ndarray:
+    if len(embeddings) == 0:
+        return np.zeros((0,), dtype=np.int32)
+    if len(embeddings) < 6:
+        labels = np.full((len(embeddings),), -1, dtype=np.int32)
+        next_label = 0
+        for i, emb in enumerate(embeddings):
+            if labels[i] >= 0:
+                continue
+            labels[i] = next_label
+            sims = embeddings @ emb
+            for j in range(i + 1, len(embeddings)):
+                if labels[j] < 0 and sims[j] >= 0.78:
+                    labels[j] = next_label
+            next_label += 1
+        return labels
+    k = max(2, min(max_clusters, len(embeddings) // 3))
+    try:
+        import faiss  # type: ignore
+        kmeans = faiss.Kmeans(d=embeddings.shape[1], k=k, niter=35, verbose=False, seed=42)
+        kmeans.train(embeddings.astype(np.float32))
+        _, labels = kmeans.index.search(embeddings.astype(np.float32), 1)
+        return labels.flatten().astype(np.int32)
+    except Exception:
+        # Deterministic fallback: group each paragraph with the earliest
+        # paragraph above a high similarity floor. It is rough, but keeps the
+        # report useful when faiss is unavailable.
+        labels = np.full((len(embeddings),), -1, dtype=np.int32)
+        next_label = 0
+        for i, emb in enumerate(embeddings):
+            if labels[i] >= 0:
+                continue
+            labels[i] = next_label
+            sims = embeddings @ emb
+            for j in range(i + 1, len(embeddings)):
+                if labels[j] < 0 and sims[j] >= 0.78:
+                    labels[j] = next_label
+            next_label += 1
+        return labels
+
+
+def build_serp_paragraph_gap(
+    *,
+    query: str,
+    cluster: str,
+    our_url: str,
+    our_title: str,
+    our_paragraphs: list[str],
+    our_paragraph_embeddings: np.ndarray,
+    competitor_pages: list[CompetitorPage],
+    missing_threshold: float = 0.62,
+    covered_threshold: float = 0.78,
+) -> dict:
+    usable = [p for p in competitor_pages if not p.error and len(p.paragraph_embeddings) > 0]
+    if not usable:
+        return {
+            "query": query,
+            "cluster": cluster or query,
+            "our_url": our_url,
+            "our_title": our_title,
+            "competitors": len(competitor_pages),
+            "status": "no_competitor_paragraphs",
+            "topics": [],
+            "missing_topics": [],
+            "weak_topics": [],
+            "off_intent_paragraphs": [],
+        }
+
+    texts: list[str] = []
+    owners: list[CompetitorPage] = []
+    for page in usable:
+        for text in page.paragraphs:
+            texts.append(text)
+            owners.append(page)
+    embeddings = np.vstack([p.paragraph_embeddings for p in usable]).astype(np.float32)
+    labels = _cluster_paragraphs(embeddings)
+    competitor_count = len({p.target.competitor_url for p in usable})
+    topics: list[dict] = []
+    centroids: list[np.ndarray] = []
+
+    for cid in sorted(set(int(x) for x in labels)):
+        idxs = [i for i, label in enumerate(labels) if int(label) == cid]
+        if not idxs:
+            continue
+        sub = embeddings[idxs]
+        centroid = sub.mean(axis=0)
+        norm = np.linalg.norm(centroid)
+        if norm > 0:
+            centroid = centroid / norm
+        centroids.append(centroid.astype(np.float32))
+        owner_urls = []
+        owner_titles = {}
+        best_rank = 999
+        for i in idxs:
+            page = owners[i]
+            owner_urls.append(page.target.competitor_url)
+            owner_titles[page.target.competitor_url] = page.title
+            if page.target.rank:
+                best_rank = min(best_rank, page.target.rank)
+        unique_urls = sorted(set(owner_urls))
+        prevalence = len(unique_urls) / max(competitor_count, 1)
+        if len(our_paragraph_embeddings):
+            sims = our_paragraph_embeddings @ centroid
+            best_i = int(np.argmax(sims))
+            best_sim = float(sims[best_i])
+            best_para = our_paragraphs[best_i] if best_i < len(our_paragraphs) else ""
+        else:
+            best_i = None
+            best_sim = 0.0
+            best_para = ""
+        if best_sim >= covered_threshold:
+            coverage = "covered"
+        elif best_sim >= missing_threshold:
+            coverage = "partial"
+        else:
+            coverage = "missing"
+        if coverage == "missing" and prevalence >= 0.8:
+            priority = "critical"
+        elif coverage in {"missing", "partial"} and prevalence >= 0.6:
+            priority = "high"
+        elif coverage == "missing":
+            priority = "medium"
+        else:
+            priority = "covered"
+        representative_scores = sub @ centroid
+        representative_order = np.argsort(-representative_scores)[:3]
+        examples = []
+        seen_example_urls: set[str] = set()
+        for local_i in representative_order:
+            global_i = idxs[int(local_i)]
+            page = owners[global_i]
+            if page.target.competitor_url in seen_example_urls:
+                continue
+            seen_example_urls.add(page.target.competitor_url)
+            examples.append({
+                "url": page.target.competitor_url,
+                "title": page.title,
+                "rank": page.target.rank,
+                "paragraph": texts[global_i][:360],
+            })
+        topics.append({
+            "label": _topic_label(texts, labels, cid),
+            "coverage": coverage,
+            "priority": priority,
+            "competitor_paragraphs": len(idxs),
+            "competitor_urls": unique_urls,
+            "competitor_coverage": len(unique_urls),
+            "competitor_prevalence": round(prevalence, 3),
+            "best_competitor_rank": None if best_rank == 999 else best_rank,
+            "our_best_similarity": round(best_sim, 4),
+            "our_best_paragraph_index": best_i,
+            "our_best_paragraph": best_para[:280],
+            "examples": examples,
+        })
+
+    priority_order = {"critical": 0, "high": 1, "medium": 2, "covered": 3}
+    topics.sort(key=lambda r: (
+        priority_order.get(r["priority"], 9),
+        -float(r.get("competitor_prevalence", 0.0)),
+        int(r.get("best_competitor_rank") or 99),
+        -int(r.get("competitor_paragraphs", 0)),
+    ))
+
+    off_intent: list[dict] = []
+    if len(our_paragraph_embeddings) and centroids:
+        topic_matrix = np.vstack(centroids).astype(np.float32)
+        for i, (text, emb) in enumerate(zip(our_paragraphs, our_paragraph_embeddings)):
+            words = len((text or "").split())
+            if words < 35:
+                continue
+            best_topic_sim = float(np.max(topic_matrix @ emb))
+            if best_topic_sim < 0.52:
+                off_intent.append({
+                    "paragraph_index": i,
+                    "similarity_to_serp_topics": round(best_topic_sim, 4),
+                    "paragraph": text[:300],
+                })
+        off_intent.sort(key=lambda r: r["similarity_to_serp_topics"])
+
+    structural_counts: dict[str, dict] = {}
+    for page in usable:
+        for gap in page.structural_gaps:
+            signal = gap.get("signal") or ""
+            if not signal:
+                continue
+            row = structural_counts.setdefault(signal, {
+                "signal": signal,
+                "competitors": 0,
+                "advice": gap.get("advice") or "",
+                "ours": gap.get("ours"),
+                "max_theirs": gap.get("theirs"),
+            })
+            row["competitors"] += 1
+            row["max_theirs"] = gap.get("theirs")
+
+    return {
+        "query": query,
+        "cluster": cluster or query,
+        "our_url": our_url,
+        "our_title": our_title,
+        "competitors": competitor_count,
+        "status": "ok",
+        "topics": topics,
+        "missing_topics": [t for t in topics if t["coverage"] == "missing"],
+        "weak_topics": [t for t in topics if t["coverage"] == "partial"],
+        "covered_topics": [t for t in topics if t["coverage"] == "covered"],
+        "off_intent_paragraphs": off_intent[:10],
+        "structural_patterns": sorted(
+            structural_counts.values(),
+            key=lambda r: int(r.get("competitors", 0)),
+            reverse=True,
+        ),
+        "summary": {
+            "topics": len(topics),
+            "missing": sum(1 for t in topics if t["coverage"] == "missing"),
+            "partial": sum(1 for t in topics if t["coverage"] == "partial"),
+            "covered": sum(1 for t in topics if t["coverage"] == "covered"),
+            "critical": sum(1 for t in topics if t["priority"] == "critical"),
+            "high": sum(1 for t in topics if t["priority"] == "high"),
+            "off_intent_paragraphs": len(off_intent),
+        },
+    }
+
+
 def compare_one(
     query: str,
     competitor_url: str,
@@ -270,12 +1036,9 @@ def compare_one(
     user_agent: str,
 ) -> CompetitorComparison:
     # 1) find our best page for this query
-    q_emb = embedder.encode([query])[0]
-    sims = np.clip(page_embeddings @ q_emb, -1.0, 1.0)
-    our_idx = int(np.argmax(sims))
+    our_idx, our_best_sim = _best_our_page(query, pages, page_embeddings, embedder)
     our_best_url = pages[our_idx].url
     our_best_title = pages[our_idx].title
-    our_best_sim = float(sims[our_idx])
 
     # 2) fetch competitor page
     body = _fetch_one(competitor_url, http_cache, user_agent)
@@ -342,6 +1105,153 @@ def compare_one(
         paragraph_count_ours=len(our_paras),
         paragraph_count_theirs=len(theirs_paragraphs),
     )
+
+
+def compare_serp_targets(
+    targets: list[CompetitiveTarget],
+    pages,
+    page_embeddings: np.ndarray,
+    paragraph_records: list,
+    extracted_pages: list,
+    embedder,
+    http_cache,
+    user_agent: str,
+) -> dict:
+    by_query: dict[tuple[str, str], list[CompetitorPage]] = {}
+    legacy_rows: list[CompetitorComparison] = []
+    best_page_cache: dict[str, tuple[int, float]] = {}
+
+    for target in targets:
+        if target.query not in best_page_cache:
+            best_page_cache[target.query] = _best_our_page(target.query, pages, page_embeddings, embedder)
+        our_idx, our_sim = best_page_cache[target.query]
+        ours_ext = extracted_pages[our_idx]
+        our_paras = [r[2] for r in paragraph_records if r[0] == our_idx]
+
+        body = _fetch_one(target.competitor_url, http_cache, user_agent)
+        if body is None:
+            error = "could not fetch competitor URL"
+            page = CompetitorPage(target, "", [], np.zeros((0, page_embeddings.shape[1]), dtype=np.float32), [], 0.0, 0, error)
+            by_query.setdefault((target.cluster or target.query, target.query), []).append(page)
+            legacy_rows.append(CompetitorComparison(
+                query=target.query,
+                competitor_url=target.competitor_url,
+                competitor_title="",
+                our_best_url=pages[our_idx].url,
+                our_best_title=pages[our_idx].title,
+                our_best_similarity=round(our_sim, 4),
+                answerability_ours=0,
+                answerability_theirs=0,
+                structural_gaps=[],
+                missing_topics=[],
+                paragraph_count_ours=len(our_paras),
+                paragraph_count_theirs=0,
+                error=error,
+            ))
+            continue
+
+        theirs_ext = extract(target.competitor_url, body, max_chars=8000)
+        if theirs_ext is None:
+            error = "competitor page had no usable content"
+            page = CompetitorPage(target, "", [], np.zeros((0, page_embeddings.shape[1]), dtype=np.float32), [], 0.0, 0, error)
+            by_query.setdefault((target.cluster or target.query, target.query), []).append(page)
+            legacy_rows.append(CompetitorComparison(
+                query=target.query,
+                competitor_url=target.competitor_url,
+                competitor_title="",
+                our_best_url=pages[our_idx].url,
+                our_best_title=pages[our_idx].title,
+                our_best_similarity=round(our_sim, 4),
+                answerability_ours=0,
+                answerability_theirs=0,
+                structural_gaps=[],
+                missing_topics=[],
+                paragraph_count_ours=len(our_paras),
+                paragraph_count_theirs=0,
+                error=error,
+            ))
+            continue
+
+        structural = _structural_diff(ours_ext, theirs_ext)
+        theirs_paragraphs = theirs_ext.paragraphs or []
+        if theirs_paragraphs:
+            theirs_para_embs = embedder.encode(theirs_paragraphs, batch_size=64).astype(np.float32)
+        else:
+            theirs_para_embs = np.zeros((0, page_embeddings.shape[1]), dtype=np.float32)
+        our_para_embs_list = [r[3] for r in paragraph_records if r[0] == our_idx]
+        our_paras_embs = (
+            np.stack(our_para_embs_list).astype(np.float32) if our_para_embs_list
+            else np.zeros((0, page_embeddings.shape[1]), dtype=np.float32)
+        )
+        missing = _missing_topics(
+            theirs_para_embs,
+            theirs_paragraphs,
+            page_embeddings[our_idx],
+            our_paras_embs,
+            our_paras,
+        )
+        answerability_ours = score_page(ours_ext).score
+        answerability_theirs = score_page(theirs_ext).score
+        legacy_rows.append(CompetitorComparison(
+            query=target.query,
+            competitor_url=target.competitor_url,
+            competitor_title=theirs_ext.title or target.competitor_url,
+            our_best_url=pages[our_idx].url,
+            our_best_title=pages[our_idx].title,
+            our_best_similarity=round(our_sim, 4),
+            answerability_ours=round(answerability_ours, 2),
+            answerability_theirs=round(answerability_theirs, 2),
+            structural_gaps=structural,
+            missing_topics=missing,
+            paragraph_count_ours=len(our_paras),
+            paragraph_count_theirs=len(theirs_paragraphs),
+        ))
+        by_query.setdefault((target.cluster or target.query, target.query), []).append(CompetitorPage(
+            target=target,
+            title=theirs_ext.title or target.competitor_url,
+            paragraphs=theirs_paragraphs,
+            paragraph_embeddings=theirs_para_embs,
+            structural_gaps=structural,
+            answerability=round(answerability_theirs, 2),
+            paragraph_count=len(theirs_paragraphs),
+        ))
+
+    serp_clusters: list[dict] = []
+    for (cluster, query), competitor_pages in by_query.items():
+        our_idx, _ = best_page_cache[query]
+        our_para_embs_list = [r[3] for r in paragraph_records if r[0] == our_idx]
+        our_paras = [r[2] for r in paragraph_records if r[0] == our_idx]
+        our_paras_embs = (
+            np.stack(our_para_embs_list).astype(np.float32) if our_para_embs_list
+            else np.zeros((0, page_embeddings.shape[1]), dtype=np.float32)
+        )
+        serp_clusters.append(build_serp_paragraph_gap(
+            query=query,
+            cluster=cluster,
+            our_url=pages[our_idx].url,
+            our_title=pages[our_idx].title,
+            our_paragraphs=our_paras,
+            our_paragraph_embeddings=our_paras_embs,
+            competitor_pages=competitor_pages,
+        ))
+
+    serp_clusters.sort(key=lambda r: (
+        int((r.get("summary") or {}).get("critical", 0)),
+        int((r.get("summary") or {}).get("high", 0)),
+        int((r.get("summary") or {}).get("missing", 0)),
+    ), reverse=True)
+
+    return {
+        "summary": {
+            "queries": len(by_query),
+            "competitor_urls": len(targets),
+            "serp_clusters": len(serp_clusters),
+            "critical_missing_topics": sum(int((r.get("summary") or {}).get("critical", 0)) for r in serp_clusters),
+            "high_priority_topics": sum(int((r.get("summary") or {}).get("high", 0)) for r in serp_clusters),
+        },
+        "comparisons": to_payload(legacy_rows),
+        "serp_clusters": serp_clusters,
+    }
 
 
 def to_payload(rows: Iterable[CompetitorComparison]) -> list[dict]:

--- a/site_audit/html_report.py
+++ b/site_audit/html_report.py
@@ -264,7 +264,7 @@ def write_html_report(
     title_mismatch: Optional[list] = None,
     wrong_home: Optional[list] = None,
     page_improvement: Optional[list] = None,
-    competitive: Optional[list] = None,
+    competitive: Optional[dict | list] = None,
     recommendations: Optional[dict] = None,
     paragraph_density: Optional[dict] = None,
     header_analysis: Optional[dict] = None,

--- a/site_audit/pipeline.py
+++ b/site_audit/pipeline.py
@@ -44,9 +44,10 @@ from .cannibalization import build_cannibalization
 from .duplicate_fragments import build_duplicate_fragments
 from .cluster_labels import cluster_overlap_matrix, label_clusters
 from .competitive_analysis import (
-    compare_one as compare_competitor,
-    load_competitive_pairs,
-    to_payload as competitive_payload,
+    CompetitiveAutoConfig,
+    build_auto_competitive_targets,
+    compare_serp_targets,
+    load_competitive_targets,
 )
 from .content_quality import (
     improvement_payload,
@@ -198,6 +199,16 @@ class PipelineConfig:
     paragraph_scatter_sample: int = 5000
     paragraph_num_clusters: int = 60
     competitive_pairs_file: Optional[Path] = None
+    competitive_auto: bool = False
+    competitive_auto_clusters: int = 3
+    competitive_auto_keywords_per_cluster: int = 1
+    competitive_auto_results_per_keyword: int = 5
+    competitive_auto_min_relevance: float = 0.35
+    competitive_auto_min_position: int = 2
+    competitive_auto_max_position: int = 20
+    competitive_auto_product_seeds: list[str] = field(default_factory=list)
+    competitive_auto_allow_nonlatin: bool = False
+    competitive_auto_refresh_serp: bool = False
     queries_file: Optional[Path] = None
     auto_queries_max: int = 200
     coverage_threshold: float = 0.55
@@ -777,23 +788,7 @@ def run(config: PipelineConfig) -> dict:
             len(page_improvement_data),
         )
 
-    # 11e) Competitive analysis (optional, takes a query/url file)
-    competitive_data: list[dict] = []
-    if config.competitive_pairs_file and config.competitive_pairs_file.is_file():
-        pairs = load_competitive_pairs(config.competitive_pairs_file)
-        if pairs:
-            LOG.info("  competitive: comparing against %d competitor URLs", len(pairs))
-            comparisons = []
-            for q, url in pairs:
-                cmp_result = compare_competitor(
-                    q, url, pages, embeddings, paragraph_records,
-                    extracted_pages, embedder, http_cache,
-                    user_agent=crawl_config.user_agent,
-                )
-                comparisons.append(cmp_result)
-            competitive_data = competitive_payload(comparisons)
-
-    # 11.f) Linkbuilding overview — site-level link health, anchor
+    # 11e) Linkbuilding overview — site-level link health, anchor
     # quality audit, and a UMAP scatter of the most-used anchor texts.
     linkbuilding_data: dict = {}
     if pages:
@@ -814,7 +809,7 @@ def run(config: PipelineConfig) -> dict:
             s.get("image_links_no_alt", 0),
         )
 
-    # 11.g) Organic search enrichment. Cache-first by default. GSC is the
+    # 11.f) Organic search enrichment. Cache-first by default. GSC is the
     # preferred first-party provider in auto mode; Ahrefs/DataForSEO remain
     # fallback proxy providers when GSC is unavailable.
     ahrefs_data: dict = {}
@@ -946,6 +941,61 @@ def run(config: PipelineConfig) -> dict:
             )
         elif search_meta:
             LOG.info("  %s search data: %s", provider_label, search_meta.get("status", "unavailable"))
+
+    competitive_data: dict = {}
+    competitive_targets = []
+    competitive_auto_meta: dict = {}
+    if config.competitive_pairs_file and config.competitive_pairs_file.is_file():
+        competitive_targets.extend(load_competitive_targets(config.competitive_pairs_file))
+    if config.competitive_auto:
+        auto_config = CompetitiveAutoConfig(
+            enabled=True,
+            max_clusters=config.competitive_auto_clusters,
+            keywords_per_cluster=config.competitive_auto_keywords_per_cluster,
+            results_per_keyword=config.competitive_auto_results_per_keyword,
+            min_position=config.competitive_auto_min_position,
+            max_position=config.competitive_auto_max_position,
+            min_relevance=config.competitive_auto_min_relevance,
+            product_seeds=config.competitive_auto_product_seeds,
+            allow_nonlatin=config.competitive_auto_allow_nonlatin,
+            refresh_serp=config.competitive_auto_refresh_serp,
+            location_code=config.dataforseo_location_code,
+            location_name=config.dataforseo_location_name,
+            language_code=config.dataforseo_language_code,
+            language_name=config.dataforseo_language_name,
+        )
+        auto_targets, competitive_auto_meta = build_auto_competitive_targets(
+            host,
+            ahrefs_data,
+            pages,
+            embedder,
+            cache_dir,
+            auto_config,
+        )
+        competitive_targets.extend(auto_targets)
+        auto_summary = competitive_auto_meta.get("summary") or {}
+        LOG.info(
+            "  competitive auto: %s · %d clusters · %d SERP targets",
+            competitive_auto_meta.get("status", "unknown"),
+            auto_summary.get("clusters", 0),
+            auto_summary.get("serp_targets", 0),
+        )
+    if competitive_targets:
+        LOG.info("  competitive: comparing against %d competitor URLs", len(competitive_targets))
+        competitive_data = compare_serp_targets(
+            competitive_targets, pages, embeddings, paragraph_records,
+            extracted_pages, embedder, http_cache,
+            user_agent=crawl_config.user_agent,
+        )
+        if competitive_auto_meta:
+            competitive_data["auto"] = competitive_auto_meta
+    elif competitive_auto_meta:
+        competitive_data = {
+            "summary": {"queries": 0, "competitor_urls": 0, "serp_clusters": 0},
+            "comparisons": [],
+            "serp_clusters": [],
+            "auto": competitive_auto_meta,
+        }
 
     structured_data_data = structured_data_payload(
         analyze_structured_data(extracted_pages, search_payload=ahrefs_data)

--- a/site_audit/report.py
+++ b/site_audit/report.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import csv
 import json
+import shutil
 from pathlib import Path
 from typing import Optional
 
@@ -42,6 +43,18 @@ def _write_csv(path: Path, rows: list[dict]) -> None:
 def _write_json(path: Path, payload) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, indent=2, ensure_ascii=False))
+
+
+def _copy_report_docs(output_dir: Path) -> None:
+    root = Path(__file__).resolve().parent.parent
+    docs = {
+        root / "docs" / "serp-paragraph-gap-analysis.md": output_dir / "serp-paragraph-gap-analysis.md",
+        root / "docs" / "report-sections.md": output_dir / "report-sections.md",
+    }
+    for source, target in docs.items():
+        if source.is_file():
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(source, target)
 
 
 def write_site_metrics(path: Path, result: AuditResult, model_name: str, domain: str) -> None:
@@ -298,7 +311,7 @@ def write_all(
     title_mismatch: Optional[list] = None,
     wrong_home: Optional[list] = None,
     page_improvement: Optional[list] = None,
-    competitive: Optional[list] = None,
+    competitive: Optional[dict | list] = None,
     recommendations: Optional[dict] = None,
     paragraph_density: Optional[dict] = None,
     header_analysis: Optional[dict] = None,
@@ -321,6 +334,7 @@ def write_all(
     history_snapshot: Optional[dict] = None,
 ) -> dict:
     output_dir.mkdir(parents=True, exist_ok=True)
+    _copy_report_docs(output_dir)
     write_site_metrics(output_dir / "site_metrics.json", result, model_name, domain)
     write_section_report(output_dir / "section_report.json", result)
     write_page_drift(output_dir / "page_drift.csv", result)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,6 +58,25 @@ def test_run_parser_accepts_crawl_filter_flags() -> None:
             "--no-trust-signals",
             "--no-conversion-balance",
             "--no-snapshot",
+            "--competitive-auto",
+            "--competitive-auto-clusters",
+            "5",
+            "--competitive-auto-keywords-per-cluster",
+            "2",
+            "--competitive-auto-results-per-keyword",
+            "4",
+            "--competitive-auto-min-relevance",
+            "0.42",
+            "--competitive-auto-min-position",
+            "3",
+            "--competitive-auto-max-position",
+            "15",
+            "--competitive-auto-product-seed",
+            "AI workflow automation",
+            "--competitive-auto-product-seed",
+            "AI agents",
+            "--competitive-auto-allow-nonlatin",
+            "--competitive-auto-refresh-serp",
         ]
     )
 
@@ -94,6 +113,16 @@ def test_run_parser_accepts_crawl_filter_flags() -> None:
     assert args.no_trust_signals is True
     assert args.no_conversion_balance is True
     assert args.no_snapshot is True
+    assert args.competitive_auto is True
+    assert args.competitive_auto_clusters == 5
+    assert args.competitive_auto_keywords_per_cluster == 2
+    assert args.competitive_auto_results_per_keyword == 4
+    assert args.competitive_auto_min_relevance == 0.42
+    assert args.competitive_auto_min_position == 3
+    assert args.competitive_auto_max_position == 15
+    assert args.competitive_auto_product_seed == ["AI workflow automation", "AI agents"]
+    assert args.competitive_auto_allow_nonlatin is True
+    assert args.competitive_auto_refresh_serp is True
 
 
 def test_history_parser_accepts_snapshot_and_compare_commands() -> None:

--- a/tests/test_report_docs.py
+++ b/tests/test_report_docs.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+import re
+
+from site_audit.report import _copy_report_docs
+
+
+def test_copy_report_docs_includes_serp_paragraph_gap_guide(tmp_path: Path) -> None:
+    _copy_report_docs(tmp_path)
+
+    guide = tmp_path / "serp-paragraph-gap-analysis.md"
+    sections = tmp_path / "report-sections.md"
+    assert guide.is_file()
+    assert sections.is_file()
+    text = guide.read_text(encoding="utf-8")
+    assert "SERP Paragraph Gap Analysis" in text
+    assert "Editorial Action Plan" in text
+    section_text = sections.read_text(encoding="utf-8")
+    assert "Report Section Guide" in section_text
+    assert '<a id="competitive-block"></a>' in section_text
+
+
+def test_report_template_links_serp_guide_to_github() -> None:
+    template = Path("ui/index.html").read_text(encoding="utf-8")
+    github_url = "https://github.com/vzeman/site-audit/blob/main/docs/serp-paragraph-gap-analysis.md"
+    sections_url = "https://github.com/vzeman/site-audit/blob/main/docs/report-sections.md"
+
+    assert github_url in template
+    assert sections_url in template
+    assert 'How to use this section' in template
+    assert 'href="serp-paragraph-gap-analysis.md"' not in template
+
+
+def test_report_section_doc_links_have_matching_blocks_and_anchors() -> None:
+    template = Path("ui/index.html").read_text(encoding="utf-8")
+    guide = Path("docs/report-sections.md").read_text(encoding="utf-8")
+    doc_blocks = template.split("const SECTION_DOC_BLOCKS = [", 1)[1].split("];", 1)[0]
+    block_ids = re.findall(r"'([a-z0-9-]+-block)'", doc_blocks)
+    html_ids = set(re.findall(r'id="([^"]+)"', template))
+    guide_ids = set(re.findall(r'<a id="([^"]+)"></a>', guide))
+
+    assert block_ids
+    assert [block_id for block_id in block_ids if block_id not in html_ids] == []
+    assert [block_id for block_id in block_ids if block_id not in guide_ids] == []

--- a/tests/test_serp_paragraph_gap.py
+++ b/tests/test_serp_paragraph_gap.py
@@ -1,0 +1,188 @@
+from pathlib import Path
+
+import numpy as np
+
+from site_audit.competitive_analysis import (
+    CompetitiveAutoConfig,
+    CompetitiveTarget,
+    CompetitorPage,
+    build_serp_paragraph_gap,
+    load_competitive_pairs,
+    load_competitive_targets,
+    select_competitive_auto_keywords,
+)
+from site_audit.analyzer import PageInfo
+
+
+def _norm(rows: list[list[float]]) -> np.ndarray:
+    arr = np.asarray(rows, dtype=np.float32)
+    denom = np.linalg.norm(arr, axis=1, keepdims=True)
+    denom[denom == 0] = 1.0
+    return arr / denom
+
+
+class DummyEmbedder:
+    def encode(self, texts, batch_size=32, show_progress=False):
+        vectors = []
+        for text in texts:
+            lowered = text.lower()
+            if "workflow" in lowered or "agent" in lowered or "automation" in lowered:
+                vectors.append([1.0, 0.0])
+            elif "lyrics" in lowered or "image" in lowered:
+                vectors.append([0.0, 1.0])
+            else:
+                vectors.append([0.7, 0.3])
+        return _norm(vectors)
+
+
+def test_load_competitive_targets_supports_cluster_headers_and_rank(tmp_path: Path) -> None:
+    path = tmp_path / "competitive.tsv"
+    path.write_text(
+        "\n".join([
+            "# AI agents",
+            "ai workflow automation\thttps://lindy.ai/ai-workflow-automation\t1",
+            "AI chatbots | ai chatbot platform | 2 | https://lindy.ai/ai-chatbot",
+        ]),
+        encoding="utf-8",
+    )
+
+    targets = load_competitive_targets(path)
+
+    assert targets[0] == CompetitiveTarget(
+        query="ai workflow automation",
+        competitor_url="https://lindy.ai/ai-workflow-automation",
+        cluster="AI agents",
+        rank=1,
+    )
+    assert targets[1] == CompetitiveTarget(
+        query="ai chatbot platform",
+        competitor_url="https://lindy.ai/ai-chatbot",
+        cluster="AI chatbots",
+        rank=2,
+    )
+    assert load_competitive_pairs(path)[0] == ("ai workflow automation", "https://lindy.ai/ai-workflow-automation")
+
+
+def test_build_serp_paragraph_gap_finds_missing_and_partial_topics() -> None:
+    competitor_pages = [
+        CompetitorPage(
+            target=CompetitiveTarget("ai workflow automation", "https://lindy.ai/a", "AI agents", 1),
+            title="Lindy A",
+            paragraphs=[
+                "AI workflow automation routes leads, summarizes calls, and updates CRM records.",
+                "Implementation usually starts by mapping triggers, approvals, and fallback rules.",
+            ],
+            paragraph_embeddings=_norm([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]),
+            structural_gaps=[],
+            answerability=80,
+            paragraph_count=2,
+        ),
+        CompetitorPage(
+            target=CompetitiveTarget("ai workflow automation", "https://lindy.ai/b", "AI agents", 2),
+            title="Lindy B",
+            paragraphs=[
+                "Pricing depends on task volume, team seats, and the number of automations running.",
+                "Implementation plans should define human review, escalation, and testing steps.",
+            ],
+            paragraph_embeddings=_norm([[0.0, 0.0, 1.0], [0.0, 0.95, 0.05]]),
+            structural_gaps=[],
+            answerability=78,
+            paragraph_count=2,
+        ),
+    ]
+    our_paragraphs = [
+        "Our AI automation platform routes leads and updates CRM records.",
+        "Teams can build automations visually without code.",
+    ]
+    our_embeddings = _norm([[0.96, 0.04, 0.0], [0.45, 0.55, 0.0]])
+
+    payload = build_serp_paragraph_gap(
+        query="ai workflow automation",
+        cluster="AI agents",
+        our_url="https://www.flowhunt.io/ai-workflow-automation/",
+        our_title="AI Workflow Automation",
+        our_paragraphs=our_paragraphs,
+        our_paragraph_embeddings=our_embeddings,
+        competitor_pages=competitor_pages,
+        missing_threshold=0.62,
+        covered_threshold=0.78,
+    )
+
+    assert payload["status"] == "ok"
+    assert payload["summary"]["missing"] >= 1
+    assert payload["summary"]["covered"] >= 1
+    missing = payload["missing_topics"]
+    assert any(topic["our_best_similarity"] < 0.62 for topic in missing)
+    assert payload["topics"][0]["priority"] in {"critical", "high", "medium"}
+
+
+def test_select_competitive_auto_keywords_filters_noise_and_caps_clusters() -> None:
+    pages = [
+        PageInfo(
+            url="https://flowhunt.io/services/ai-agents/",
+            title="AI Agents",
+            description="",
+            section="services",
+            word_count=800,
+            language="en",
+        ),
+        PageInfo(
+            url="https://flowhunt.io/glossary/chatgpt/",
+            title="ChatGPT glossary",
+            description="",
+            section="glossary",
+            word_count=300,
+            language="en",
+        ),
+    ]
+    payload = {
+        "organic_keywords": [
+            {
+                "keyword": "best ai workflow automation platform",
+                "position": 8,
+                "traffic": 100,
+                "volume": 1200,
+                "matched_url": pages[0].url,
+                "cluster_label": "AI workflow automation",
+                "intents": ["commercial"],
+            },
+            {
+                "keyword": "شات جي بي تي",
+                "position": 9,
+                "traffic": 500,
+                "volume": 3000,
+                "matched_url": pages[1].url,
+                "cluster_label": "ChatGPT glossary",
+                "intents": ["informational"],
+            },
+            {
+                "keyword": "free image generator",
+                "position": 6,
+                "traffic": 80,
+                "volume": 900,
+                "matched_url": pages[0].url,
+                "cluster_label": "AI tools",
+                "intents": ["informational"],
+            },
+        ]
+    }
+
+    selection = select_competitive_auto_keywords(
+        payload,
+        pages,
+        DummyEmbedder(),
+        CompetitiveAutoConfig(
+            enabled=True,
+            max_clusters=1,
+            keywords_per_cluster=1,
+            product_seeds=["AI workflow automation"],
+            min_relevance=0.35,
+        ),
+    )
+
+    assert selection["status"] == "ok"
+    assert selection["summary"]["selected_clusters"] == 1
+    assert selection["selected_keywords"][0]["keyword"] == "best ai workflow automation platform"
+    rejected_keywords = {row["keyword"] for row in selection["rejected"]}
+    assert "شات جي بي تي" in rejected_keywords
+    assert "free image generator" in rejected_keywords

--- a/ui/index.html
+++ b/ui/index.html
@@ -519,7 +519,7 @@
       </div>
     </div>
 
-    <div class="bg-white border border-gray-200 rounded-lg shadow-sm p-5 mb-8">
+    <div class="bg-white border border-gray-200 rounded-lg shadow-sm p-5 mb-8" id="link-addition-block">
       <h3 class="text-lg font-semibold mb-1">Top duplicate pairs (merge candidates)</h3>
       <p class="text-xs text-gray-500 mb-3">
         Page pairs with cosine similarity ≥ 0.92 (default). <strong>Sim ≥ 0.97</strong> = essentially the same page,
@@ -1611,11 +1611,17 @@
     <!-- Competitive analysis -->
     <div class="bg-white border border-gray-200 rounded-lg shadow-sm p-5 mb-8" id="competitive-block">
       <div class="flex items-center justify-between mb-3">
-        <h3 class="text-lg font-semibold">Competitor comparison: why they rank, why we don't</h3>
+        <div>
+          <h3 class="text-lg font-semibold">Competitor comparison: why they rank, why we don't</h3>
+          <div class="text-xs text-gray-500">
+            Read the action guide:
+            <a class="text-blue-600 hover:underline" href="https://github.com/vzeman/site-audit/blob/main/docs/serp-paragraph-gap-analysis.md" target="_blank" rel="noopener">SERP paragraph gap analysis</a>
+          </div>
+        </div>
         <span class="text-xs text-gray-500">supply <code>--competitive query.tsv</code> to populate</span>
       </div>
       <div id="audit-competitive" class="text-sm">
-        <div class="text-gray-500">Run with <code>--competitive my_targets.tsv</code> (one <code>query &lt;TAB&gt; competitor_url</code> per line).</div>
+        <div class="text-gray-500">Run with <code>--competitive my_targets.tsv</code> (one <code>query &lt;TAB&gt; competitor_url</code> per line). See <a class="text-blue-600 hover:underline" href="https://github.com/vzeman/site-audit/blob/main/docs/serp-paragraph-gap-analysis.md" target="_blank" rel="noopener">how to choose keywords and act on the gaps</a>.</div>
       </div>
     </div>
 
@@ -1837,6 +1843,24 @@
 <script>
 (function() {
   const basePath = '/data';
+  const REPORT_SECTION_GUIDE_URL = 'https://github.com/vzeman/site-audit/blob/main/docs/report-sections.md';
+  const SECTION_DOC_BLOCKS = [
+    'hist-block', 'action-plan-block', 'improvement-block', 'title-mismatch-block',
+    'headers-block', 'heading-impact-block', 'clusters-block', 'treemap-block',
+    'ahrefs-block', 'best-pages-block', 'paragraph-impact-block', 'weak-paragraphs-block',
+    'semantic-ablation-block', 'keyword-attribution-block', 'heatmap-block', 'coverage-block',
+    'indexability-block', 'structured-data-block', 'trust-signals-block', 'conversion-balance-block',
+    'metadata-quality-block', 'media-accessibility-block', 'page-types-block', 'template-patterns-block',
+    'entities-block', 'entity-coverage-block', 'information-gain-block', 'freshness-block',
+    'freshness-impact-block', 'performance-block', 'performance-explainer-block', 'conversion-block',
+    'answerability-block', 'answer-blocks-block', 'cannibalization-block', 'duplicate-fragments-block',
+    'linkgraph-block', 'linkflow-block', 'traffic-pagerank-block', 'high-demand-link-block',
+    'hub-bottleneck-block', 'link-removal-block', 'link-addition-block', 'linkbuilding-block',
+    'link-counts-block', 'para-density-block', 'para-links-block', 'wrong-home-block',
+    'para-clusters-block', 'fanout-block', 'competitive-block', 'hits-block', 'depth-block',
+    'cluster-auth-block', 'anchor-block', 'contextual-link-block', 'internal-link-patterns-block',
+    'external-block', 'broken-block'
+  ];
 
   function readInlined(id) {
     const el = document.getElementById(id);
@@ -1895,6 +1919,22 @@
         <div class="text-xs text-gray-500">${label}</div>
         ${hint ? `<div class="text-xs ${hintClass} mt-0.5">${hint}</div>` : ''}
       </div>`;
+  }
+
+  function addSectionDocLinks() {
+    SECTION_DOC_BLOCKS.forEach(id => {
+      const block = document.getElementById(id);
+      if (!block || block.querySelector('.section-doc-link')) return;
+      const heading = block.querySelector('h3');
+      if (!heading) return;
+      const link = document.createElement('a');
+      link.className = 'section-doc-link inline-flex items-center text-xs text-blue-600 hover:underline ml-2 align-middle';
+      link.href = `${REPORT_SECTION_GUIDE_URL}#${id}`;
+      link.target = '_blank';
+      link.rel = 'noopener';
+      link.textContent = 'How to use this section';
+      heading.appendChild(link);
+    });
   }
 
   async function boot() {
@@ -2189,6 +2229,7 @@
       renderParaClusters();
       renderFanout('all');
       renderCompetitive();
+      addSectionDocLinks();
       wireModeButtons();
       wireDatasetButtons();
       wireSemanticSearchInputs();
@@ -6859,9 +6900,109 @@
 
   function renderCompetitive() {
     const block = document.getElementById('competitive-block');
-    const rows = state.competitive || [];
-    if (!rows.length) return;  // keep the "Run with --competitive…" placeholder
-    document.getElementById('audit-competitive').innerHTML = rows.map(r => {
+    const payload = state.competitive || {};
+    const rows = Array.isArray(payload) ? payload : (payload.comparisons || []);
+    const serpClusters = Array.isArray(payload) ? [] : (payload.serp_clusters || []);
+    const auto = Array.isArray(payload) ? null : (payload.auto || null);
+    if (!rows.length && !serpClusters.length) return;  // keep the "Run with --competitive…" placeholder
+    const autoHtml = auto ? (() => {
+      const autoSummary = auto.summary || {};
+      const selected = (((auto.selection || {}).selected_keywords) || []).slice(0, 8).map(k => `
+        <tr class="border-t border-gray-100">
+          <td class="px-2 py-1.5">${escapeHtml(k.keyword || '')}<div class="text-gray-500">${escapeHtml(k.cluster || '')}</div></td>
+          <td class="px-2 py-1.5 text-right font-mono">${escapeHtml(String(k.position || 0))}</td>
+          <td class="px-2 py-1.5 text-right font-mono">${Number(k.traffic || 0).toLocaleString()}</td>
+          <td class="px-2 py-1.5 text-right font-mono">${escapeHtml(String(k.relevance || 0))}</td>
+        </tr>`).join('');
+      return `
+        <div class="border border-blue-100 bg-blue-50 rounded p-3 mb-4 text-xs">
+          <div class="font-semibold text-blue-900 mb-1">Auto-selected competitive targets</div>
+          <div class="text-blue-900 mb-2">status ${escapeHtml(auto.status || '')} · selected keywords ${autoSummary.selected_keywords || 0} · SERP targets ${autoSummary.serp_targets || 0} · clusters ${autoSummary.clusters || 0}</div>
+          ${selected ? `<div class="overflow-x-auto"><table class="min-w-full bg-white border border-blue-100"><thead class="text-gray-500"><tr><th class="px-2 py-1.5 text-left">Keyword</th><th class="px-2 py-1.5 text-right">Pos</th><th class="px-2 py-1.5 text-right">Traffic</th><th class="px-2 py-1.5 text-right">Fit</th></tr></thead><tbody>${selected}</tbody></table></div>` : ''}
+        </div>`;
+    })() : '';
+    const summary = payload.summary ? `
+      <div class="text-xs text-gray-600 mb-3">
+        Use this as a content brief, not a causal ranking proof. Confirm the target URL first, then add relevant missing topics, improve partial topics, and ignore irrelevant competitor topics.
+        <a class="text-blue-600 hover:underline" href="https://github.com/vzeman/site-audit/blob/main/docs/serp-paragraph-gap-analysis.md" target="_blank" rel="noopener">Open the action guide</a>.
+      </div>
+      <div class="grid md:grid-cols-4 gap-2 mb-4">
+        ${[
+          ['Queries', payload.summary.queries || 0],
+          ['Competitor URLs', payload.summary.competitor_urls || 0],
+          ['Critical gaps', payload.summary.critical_missing_topics || 0],
+          ['High-priority topics', payload.summary.high_priority_topics || 0],
+        ].map(([label, value]) => `<div class="border border-gray-200 rounded p-2"><div class="text-[11px] uppercase text-gray-500">${label}</div><div class="text-lg font-semibold">${value}</div></div>`).join('')}
+      </div>` : '';
+    const serpHtml = serpClusters.map(c => {
+      const s = c.summary || {};
+      const competitorUrls = Array.from(new Set((c.topics || []).flatMap(t => t.competitor_urls || []))).slice(0, 5);
+      const coverageClass = (coverage) => {
+        if (coverage === 'missing') return 'bg-red-100 text-red-800 border-red-200';
+        if (coverage === 'partial') return 'bg-amber-100 text-amber-800 border-amber-200';
+        if (coverage === 'covered') return 'bg-emerald-100 text-emerald-800 border-emerald-200';
+        return 'bg-gray-100 text-gray-700 border-gray-200';
+      };
+      const matrixRows = (c.topics || []).slice(0, 10).map(t => {
+        const seen = new Set(t.competitor_urls || []);
+        const cells = competitorUrls.map((url, idx) => `
+          <td class="px-1 py-1 text-center">
+            <span title="${escapeHtml(url)}" class="inline-block w-3 h-3 rounded-sm ${seen.has(url) ? 'bg-blue-600' : 'bg-gray-200'}"></span>
+          </td>`).join('');
+        const prevalence = Math.round(Number(t.competitor_prevalence || 0) * 100);
+        return `
+          <tr class="border-t border-gray-100">
+            <td class="px-2 py-1.5 align-top">
+              <div class="font-medium text-gray-900">${escapeHtml(t.label || '')}</div>
+              <div class="h-1.5 bg-gray-100 rounded mt-1 overflow-hidden"><div class="h-full bg-blue-500" style="width:${prevalence}%"></div></div>
+            </td>
+            <td class="px-2 py-1.5 align-top"><span class="inline-block border rounded px-1.5 py-0.5 ${coverageClass(t.coverage)}">${escapeHtml(t.coverage || '')}</span></td>
+            <td class="px-2 py-1.5 align-top text-right font-mono">${escapeHtml(String(t.our_best_similarity || 0))}</td>
+            ${cells}
+          </tr>`;
+      }).join('');
+      const matrix = matrixRows ? `
+        <div class="mt-3 overflow-x-auto">
+          <div class="text-xs font-semibold mb-1">Topic coverage matrix</div>
+          <table class="min-w-full text-xs border border-gray-200">
+            <thead class="bg-gray-50 text-gray-600">
+              <tr>
+                <th class="px-2 py-1.5 text-left">SERP topic / prevalence</th>
+                <th class="px-2 py-1.5 text-left">You</th>
+                <th class="px-2 py-1.5 text-right">Sim</th>
+                ${competitorUrls.map((url, idx) => `<th class="px-1 py-1.5 text-center" title="${escapeHtml(url)}">C${idx + 1}</th>`).join('')}
+              </tr>
+            </thead>
+            <tbody>${matrixRows}</tbody>
+          </table>
+          <div class="text-[11px] text-gray-500 mt-1">Blue competitor cells mean that URL contains the topic. Red/amber/green shows whether your selected page is missing, partial, or covered.</div>
+        </div>` : '';
+      const topics = (c.topics || []).filter(t => t.coverage !== 'covered').slice(0, 8).map(t => {
+        const examples = (t.examples || []).slice(0, 2).map(ex => `
+          <div class="text-xs text-gray-700 border-l-2 border-gray-200 pl-2 mt-1">
+            <a class="text-blue-600 hover:underline" href="${escapeHtml(ex.url || '#')}" target="_blank" rel="noopener">${escapeHtml(ex.title || ex.url || '')}</a>
+            ${ex.rank ? `<span class="text-gray-500"> · rank ${escapeHtml(String(ex.rank))}</span>` : ''}
+            <div class="italic">"${escapeHtml(ex.paragraph || '')}"</div>
+          </div>`).join('');
+        return `
+          <li class="mb-2">
+            <div><strong>${escapeHtml(t.label || '')}</strong> <span class="text-gray-500">${escapeHtml(t.coverage || '')} · ${escapeHtml(t.priority || '')} · seen on ${escapeHtml(String(t.competitor_coverage || 0))}/${escapeHtml(String(c.competitors || 0))} competitors · our sim ${escapeHtml(String(t.our_best_similarity || 0))}</span></div>
+            ${t.our_best_paragraph ? `<div class="text-xs text-gray-500">closest paragraph: "${escapeHtml(t.our_best_paragraph)}"</div>` : ''}
+            ${examples}
+          </li>`;
+      }).join('');
+      const offIntent = (c.off_intent_paragraphs || []).slice(0, 3).map(p => `
+        <li><span class="text-gray-500">sim ${escapeHtml(String(p.similarity_to_serp_topics || 0))}</span> "${escapeHtml(p.paragraph || '')}"</li>`).join('');
+      return `
+        <div class="py-4 border-b border-gray-100">
+          <div class="font-semibold">${escapeHtml(c.cluster || c.query || '')}</div>
+          <div class="text-xs text-gray-700 mb-2">query: ${escapeHtml(c.query || '')} · our page: <a class="text-blue-600 hover:underline" href="${escapeHtml(c.our_url || '#')}" target="_blank" rel="noopener">${escapeHtml(c.our_title || c.our_url || '')}</a> · topics ${s.topics || 0}, missing ${s.missing || 0}, partial ${s.partial || 0}</div>
+          ${matrix}
+          ${topics ? `<ul class="list-disc list-inside text-xs space-y-1">${topics}</ul>` : '<div class="text-xs text-gray-500">No missing or weak SERP topics found.</div>'}
+          ${offIntent ? `<div class="text-xs font-semibold mt-3 mb-1">Possible off-intent paragraphs:</div><ul class="list-disc list-inside text-xs text-gray-700">${offIntent}</ul>` : ''}
+        </div>`;
+    }).join('');
+    const legacyHtml = rows.map(r => {
       if (r.error) {
         return `<div class="py-2 border-b border-gray-100">
           <div class="font-medium">${escapeHtml(r.query)}</div>
@@ -6884,6 +7025,12 @@
           ${topics ? `<div class="text-xs font-semibold mt-3 mb-1">Sub-topics they cover, we don't:</div><ul class="list-disc list-inside text-xs space-y-1">${topics}</ul>` : ''}
         </div>`;
     }).join('');
+    document.getElementById('audit-competitive').innerHTML = `
+      ${summary}
+      ${autoHtml}
+      ${serpHtml ? `<div class="text-sm font-semibold mb-1">SERP paragraph gap model</div>${serpHtml}` : ''}
+      ${legacyHtml ? `<div class="text-sm font-semibold mt-4 mb-1">Individual competitor comparisons</div>${legacyHtml}` : ''}
+    `;
   }
 
   boot();


### PR DESCRIPTION
## Summary
- add grouped SERP paragraph gap analysis for repeated competitive query targets
- add opt-in auto mode that selects business-relevant search clusters, fetches live DataForSEO SERP URLs, and caps API spend
- render competitor topic coverage matrices, auto-selected keyword summaries, and GitHub-backed action-guide links in the report
- add report-section documentation and bundle docs into generated reports

## Tests
- PYTHONPATH=. .venv/bin/pytest tests/test_report_docs.py tests/test_serp_paragraph_gap.py tests/test_cli.py tests/test_compare_metrics.py

## Smoke test
- Ran capped Flowhunt auto mode with 1 cluster, 1 keyword, and 1 SERP result to verify DataForSEO target fetching and report generation.