### PR TITLE
Add technical SEO data model exports

### DIFF
--- a/site_audit/pipeline.py
+++ b/site_audit/pipeline.py
@@ -130,6 +130,7 @@ from .search_fusion import build_combined_search_analysis
 from .structured_data import analyze as analyze_structured_data
 from .structured_data import to_payload as structured_data_payload
 from .template_patterns import build_template_patterns
+from .technical_seo import build_technical_seo
 from .trust_signals import build_trust_signals
 from .weak_paragraphs import build_weak_paragraphs
 from .winning_paragraphs import build_winning_paragraphs
@@ -1594,6 +1595,21 @@ def run(config: PipelineConfig) -> dict:
         pe_summary.get("sample_size", 0),
         pe_summary.get("validation_r2", 0.0) or 0.0,
     )
+    technical_seo_data = build_technical_seo(
+        pages,
+        indexability=indexability_data,
+        metadata_quality=metadata_quality_data,
+        performance=performance_data,
+        search_payload=ahrefs_data,
+        page_types=page_types_data,
+    )
+    tech_summary = technical_seo_data.get("summary", {}) or {}
+    LOG.info(
+        "  technical SEO model: %d pages · %d issues · %d high",
+        tech_summary.get("total_pages", 0),
+        tech_summary.get("total_issues", 0),
+        tech_summary.get("high_issues", 0),
+    )
     history_snapshot_data = build_history_snapshot(
         host,
         pages,
@@ -1660,6 +1676,7 @@ def run(config: PipelineConfig) -> dict:
         best_pages=best_pages_data,
         performance_explainer=performance_explainer_data,
         history_snapshot=history_snapshot_data,
+        technical_seo=technical_seo_data,
     )
 
     template_path = Path(__file__).resolve().parent.parent / "ui" / "index.html"

--- a/site_audit/report.py
+++ b/site_audit/report.py
@@ -150,6 +150,40 @@ def write_internal_linkbuilding_csv(
     return rows
 
 
+def write_technical_seo_exports(output_dir: Path, technical_seo: dict) -> None:
+    pages = list((technical_seo or {}).get("pages") or [])
+    issues = list((technical_seo or {}).get("issues") or [])
+    page_payload = {
+        "summary": (technical_seo or {}).get("summary", {}),
+        "pages": pages,
+        "interpretation": (technical_seo or {}).get("interpretation", {}),
+    }
+    issue_payload = {
+        "summary": (technical_seo or {}).get("summary", {}),
+        "issue_counts": (technical_seo or {}).get("issue_counts", {}),
+        "category_counts": (technical_seo or {}).get("category_counts", {}),
+        "severity_counts": (technical_seo or {}).get("severity_counts", {}),
+        "issues": issues,
+        "interpretation": (technical_seo or {}).get("interpretation", {}),
+    }
+    _write_json(output_dir / "technical_pages.json", page_payload)
+    _write_json(output_dir / "technical_issues.json", issue_payload)
+    _write_csv(output_dir / "technical_pages.csv", [_csv_safe_row(row) for row in pages])
+    _write_csv(output_dir / "technical_issues.csv", [_csv_safe_row(row) for row in issues])
+
+
+def _csv_safe_row(row: dict) -> dict:
+    out = {}
+    for key, value in row.items():
+        if isinstance(value, list):
+            out[key] = ", ".join(str(item) for item in value)
+        elif isinstance(value, dict):
+            out[key] = json.dumps(value, ensure_ascii=False, sort_keys=True)
+        else:
+            out[key] = value
+    return out
+
+
 def _paid_keywords(search_payload: Optional[dict]) -> list[dict]:
     rows = []
     for row in (search_payload or {}).get("organic_keywords") or []:
@@ -502,6 +536,7 @@ def write_all(
     best_pages: Optional[dict] = None,
     performance_explainer: Optional[dict] = None,
     history_snapshot: Optional[dict] = None,
+    technical_seo: Optional[dict] = None,
 ) -> dict:
     output_dir.mkdir(parents=True, exist_ok=True)
     _copy_report_docs(output_dir)
@@ -611,4 +646,6 @@ def write_all(
         _write_json(output_dir / "performance_explainer.json", performance_explainer)
     if history_snapshot is not None:
         _write_json(output_dir / "history_snapshot.json", history_snapshot)
+    if technical_seo is not None:
+        write_technical_seo_exports(output_dir, technical_seo)
     return {"outliers": len(outliers), "duplicates": len(result.duplicate_pairs)}

--- a/site_audit/technical_seo.py
+++ b/site_audit/technical_seo.py
@@ -1,0 +1,260 @@
+"""Shared technical SEO page and issue model.
+
+This module does not run new audits by itself. It normalizes existing
+technical signals into stable per-page and per-issue exports that later
+technical SEO analyzers can extend.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Iterable
+
+
+_SEVERITY_WEIGHT = {"high": 100.0, "medium": 55.0, "low": 25.0}
+_METADATA_SEVERITY = {
+    "missing_title": "high",
+    "missing_canonical": "high",
+    "canonical_external_host": "high",
+    "missing_description": "medium",
+    "duplicate_title": "medium",
+    "duplicate_description": "medium",
+    "short_title": "low",
+    "long_title": "low",
+    "short_description": "low",
+    "long_description": "low",
+    "incomplete_open_graph": "low",
+    "missing_twitter_card": "low",
+    "noindex": "high",
+}
+
+
+def build_technical_seo(
+    pages: Iterable,
+    *,
+    indexability: dict | None = None,
+    metadata_quality: dict | None = None,
+    performance: dict | None = None,
+    search_payload: dict | None = None,
+    page_types: dict | None = None,
+) -> dict:
+    page_rows = [_base_page_row(page) for page in pages]
+    by_url = {row["url"]: row for row in page_rows if row.get("url")}
+    metadata = _lookup_rows((metadata_quality or {}).get("per_page") or [])
+    perf = _lookup_rows((performance or {}).get("per_page") or [])
+    search = _search_lookup(search_payload)
+    types = _lookup_rows((page_types or {}).get("per_page") or [])
+    skipped = _lookup_rows(((indexability or {}).get("skipped") or []) + ((indexability or {}).get("noindex_pages") or []))
+
+    for url, row in by_url.items():
+        _merge_page_signals(row, metadata.get(url), perf.get(url), search.get(url), types.get(url), skipped.get(url))
+
+    for url, skip in skipped.items():
+        if url in by_url:
+            continue
+        row = _base_skipped_row(skip)
+        _merge_page_signals(row, metadata.get(url), perf.get(url), search.get(url), types.get(url), skip)
+        by_url[url] = row
+
+    rows = list(by_url.values())
+    issues = []
+    for row in rows:
+        issues.extend(_issues_for_row(row))
+    issue_counts = Counter(issue["issue_type"] for issue in issues)
+    severity_counts = Counter(issue["severity"] for issue in issues)
+    category_counts = Counter(issue["category"] for issue in issues)
+    issue_urls = {issue["url"] for issue in issues}
+    for row in rows:
+        row_issues = [issue for issue in issues if issue["url"] == row["url"]]
+        row["technical_issue_count"] = len(row_issues)
+        row["technical_severity_score"] = round(sum(_SEVERITY_WEIGHT.get(issue["severity"], 0.0) * float(issue["confidence"] or 0.0) for issue in row_issues), 2)
+        row["technical_high_issues"] = sum(1 for issue in row_issues if issue["severity"] == "high")
+        row["technical_status"] = "needs_review" if row_issues else "clean"
+
+    rows.sort(key=lambda row: (float(row.get("technical_severity_score") or 0.0), _safe_int(row.get("traffic"))), reverse=True)
+    issues.sort(key=lambda issue: (float(issue.get("impact_score") or 0.0), _safe_int(issue.get("traffic"))), reverse=True)
+    total = len(rows)
+    return {
+        "summary": {
+            "status": "ok" if total else "no_pages",
+            "model": "technical_seo_v1",
+            "total_pages": total,
+            "pages_with_issues": len(issue_urls),
+            "issue_share": len(issue_urls) / total if total else 0.0,
+            "total_issues": len(issues),
+            "high_issues": severity_counts.get("high", 0),
+            "medium_issues": severity_counts.get("medium", 0),
+            "low_issues": severity_counts.get("low", 0),
+            "traffic_at_risk": sum(_safe_int(row.get("traffic")) for row in rows if row["url"] in issue_urls),
+        },
+        "issue_counts": dict(issue_counts),
+        "category_counts": dict(category_counts),
+        "severity_counts": dict(severity_counts),
+        "pages": rows,
+        "issues": issues,
+        "interpretation": {
+            "technical_severity_score": "Weighted count of technical SEO issues on the URL. High severity issues count more than medium/low issues.",
+            "impact_score": "Issue-level prioritization score combining severity, confidence, and search traffic where available.",
+        },
+    }
+
+
+def _base_page_row(page) -> dict:
+    return {
+        "url": getattr(page, "url", "") or "",
+        "title": getattr(page, "title", "") or "",
+        "section": getattr(page, "section", "") or "",
+        "word_count": _safe_int(getattr(page, "word_count", 0)),
+        "language": getattr(page, "language", "") or "",
+        "indexability_status": "indexable",
+        "http_status": "",
+        "canonical_url": "",
+        "robots_content": "",
+        "metadata_issues": [],
+        "traffic": 0,
+        "keywords": 0,
+        "top_keyword": "",
+        "page_type": "",
+        "template_family": "",
+        "template_signature": "",
+        "fix_scope": "page",
+    }
+
+
+def _base_skipped_row(row: dict) -> dict:
+    return {
+        "url": row.get("url") or "",
+        "title": row.get("title") or "",
+        "section": "",
+        "word_count": "",
+        "language": "",
+        "indexability_status": row.get("reason") or "skipped",
+        "http_status": row.get("http_status", ""),
+        "canonical_url": "",
+        "robots_content": "",
+        "metadata_issues": [],
+        "traffic": 0,
+        "keywords": 0,
+        "top_keyword": "",
+        "page_type": "",
+        "template_family": "",
+        "template_signature": "",
+        "fix_scope": "page",
+    }
+
+
+def _merge_page_signals(row: dict, metadata: dict | None, perf: dict | None, search: dict | None, page_type: dict | None, skipped: dict | None) -> None:
+    if metadata:
+        row["title"] = row.get("title") or metadata.get("title", "")
+        row["canonical_url"] = metadata.get("canonical_url", "")
+        row["robots_content"] = metadata.get("robots_content", "")
+        row["metadata_issues"] = list(metadata.get("issues") or [])
+    if perf:
+        row["http_status"] = perf.get("status", row.get("http_status", ""))
+        row["content_type"] = perf.get("content_type", "")
+        row["html_weight_bytes"] = perf.get("html_weight_bytes", "")
+        row["estimated_weight_bytes"] = perf.get("estimated_weight_bytes", "")
+        row["weight_bucket"] = perf.get("weight_bucket", "")
+        row["resource_tag_count"] = perf.get("resource_tag_count", "")
+        row["render_blocking_count"] = perf.get("render_blocking_count", "")
+        row["image_count"] = perf.get("image_count", "")
+        row["script_count"] = perf.get("script_count", "")
+    if search:
+        row["traffic"] = _safe_int(search.get("traffic"))
+        row["keywords"] = _safe_int(search.get("keywords"))
+        row["top_keyword"] = search.get("top_keyword", "")
+    if page_type:
+        row["page_type"] = page_type.get("page_type", "")
+        row["template_family"] = page_type.get("template_family", "")
+        row["template_signature"] = page_type.get("template_signature", "")
+        row["fix_scope"] = "template" if page_type.get("template_family") else "page"
+    if skipped:
+        reason = skipped.get("reason") or row.get("indexability_status") or "skipped"
+        row["indexability_status"] = "noindex" if reason == "noindex" else reason
+        row["http_status"] = skipped.get("http_status", row.get("http_status", ""))
+
+
+def _issues_for_row(row: dict) -> list[dict]:
+    issues: list[dict] = []
+    status = str(row.get("indexability_status") or "")
+    if status and status != "indexable":
+        issues.append(_issue(row, "indexability", status, "high", 0.95, _recommendation(status)))
+    for issue_type in row.get("metadata_issues") or []:
+        issues.append(_issue(row, "metadata", issue_type, _METADATA_SEVERITY.get(issue_type, "medium"), 0.9, _recommendation(issue_type)))
+    if row.get("weight_bucket") == "very_heavy":
+        issues.append(_issue(row, "performance", "very_heavy_page", "medium", 0.72, "Reduce page weight, heavy images, scripts, and fonts."))
+    elif row.get("weight_bucket") == "heavy":
+        issues.append(_issue(row, "performance", "heavy_page", "low", 0.68, "Review page weight and resource count."))
+    if _safe_int(row.get("render_blocking_count")) > 0:
+        issues.append(_issue(row, "performance", "render_blocking_resources", "low", 0.72, "Defer non-critical scripts and reduce blocking stylesheets."))
+    return issues
+
+
+def _issue(row: dict, category: str, issue_type: str, severity: str, confidence: float, recommendation: str) -> dict:
+    traffic = _safe_int(row.get("traffic"))
+    impact = _SEVERITY_WEIGHT.get(severity, 25.0) * confidence * (1.0 + min(3.0, traffic / 1000.0))
+    return {
+        "url": row.get("url", ""),
+        "title": row.get("title", ""),
+        "category": category,
+        "issue_type": issue_type,
+        "severity": severity,
+        "confidence": round(confidence, 2),
+        "traffic": traffic,
+        "keywords": _safe_int(row.get("keywords")),
+        "page_type": row.get("page_type", ""),
+        "template_family": row.get("template_family", ""),
+        "fix_scope": row.get("fix_scope", "page"),
+        "impact_score": round(impact, 2),
+        "recommendation": recommendation,
+    }
+
+
+def _recommendation(issue_type: str) -> str:
+    return {
+        "noindex": "Decide whether this URL should be indexed; remove noindex only when it is a canonical search landing page.",
+        "empty_embedding_text": "Add crawlable main content or remove the URL from SEO surfaces.",
+        "unusable": "Review extraction/crawlability and ensure the page has readable HTML main content.",
+        "missing_title": "Add a unique descriptive title.",
+        "short_title": "Expand the title to describe the primary topic.",
+        "long_title": "Shorten the title while preserving the primary query intent.",
+        "missing_description": "Add a concise meta description aligned with the page intent.",
+        "duplicate_title": "Rewrite the title so it is unique to this URL.",
+        "duplicate_description": "Rewrite the meta description so it is unique to this URL.",
+        "missing_canonical": "Add a self-referencing canonical or the correct canonical target.",
+        "canonical_external_host": "Verify that canonicalizing to an external host is intentional.",
+        "incomplete_open_graph": "Complete OpenGraph title and description for share previews.",
+        "missing_twitter_card": "Add Twitter/X card metadata if social previews matter.",
+    }.get(issue_type, "Review and fix this technical SEO issue.")
+
+
+def _lookup_rows(rows: list[dict]) -> dict[str, dict]:
+    out: dict[str, dict] = {}
+    for row in rows:
+        url = row.get("url") or row.get("matched_url")
+        if url:
+            out[str(url)] = row
+    return out
+
+
+def _search_lookup(payload: dict | None) -> dict[str, dict]:
+    out: dict[str, dict] = {}
+    for row in (payload or {}).get("top_pages") or []:
+        url = row.get("matched_url") or row.get("url")
+        if not url:
+            continue
+        out[str(url)] = {
+            "traffic": row.get("traffic", 0),
+            "keywords": row.get("keywords", 0),
+            "top_keyword": row.get("top_keyword", ""),
+        }
+    return out
+
+
+def _safe_int(value) -> int:
+    try:
+        if value in (None, ""):
+            return 0
+        return int(float(value))
+    except (TypeError, ValueError):
+        return 0

--- a/tests/test_technical_seo.py
+++ b/tests/test_technical_seo.py
@@ -1,0 +1,116 @@
+from types import SimpleNamespace
+
+from site_audit.report import write_technical_seo_exports
+from site_audit.technical_seo import build_technical_seo
+
+
+def test_technical_seo_model_merges_existing_page_signals() -> None:
+    pages = [
+        SimpleNamespace(
+            url="https://example.com/a",
+            title="A",
+            section="blog",
+            word_count=500,
+            language="en",
+        )
+    ]
+    indexability = {"skipped": [], "noindex_pages": []}
+    metadata = {
+        "per_page": [
+            {
+                "url": "https://example.com/a",
+                "title": "A",
+                "canonical_url": "",
+                "robots_content": "",
+                "issues": ["missing_canonical", "missing_description"],
+            }
+        ]
+    }
+    performance = {
+        "per_page": [
+            {
+                "url": "https://example.com/a",
+                "status": 200,
+                "weight_bucket": "very_heavy",
+                "html_weight_bytes": 700000,
+                "estimated_weight_bytes": 3500000,
+                "resource_tag_count": 90,
+                "render_blocking_count": 4,
+            }
+        ]
+    }
+    search = {
+        "top_pages": [
+            {"matched_url": "https://example.com/a", "traffic": 1200, "keywords": 9, "top_keyword": "example keyword"}
+        ]
+    }
+    page_types = {
+        "per_page": [
+            {
+                "url": "https://example.com/a",
+                "page_type": "article",
+                "template_family": "content_template",
+                "template_signature": "sig",
+            }
+        ]
+    }
+
+    payload = build_technical_seo(
+        pages,
+        indexability=indexability,
+        metadata_quality=metadata,
+        performance=performance,
+        search_payload=search,
+        page_types=page_types,
+    )
+
+    assert payload["summary"]["total_pages"] == 1
+    assert payload["summary"]["high_issues"] >= 1
+    page = payload["pages"][0]
+    assert page["url"] == "https://example.com/a"
+    assert page["traffic"] == 1200
+    assert page["page_type"] == "article"
+    assert page["fix_scope"] == "template"
+    assert page["technical_issue_count"] >= 4
+    issue_types = {row["issue_type"] for row in payload["issues"]}
+    assert "missing_canonical" in issue_types
+    assert "very_heavy_page" in issue_types
+    assert "render_blocking_resources" in issue_types
+
+
+def test_technical_seo_model_includes_skipped_pages() -> None:
+    payload = build_technical_seo(
+        [],
+        indexability={
+            "skipped": [
+                {
+                    "url": "https://example.com/noindex",
+                    "title": "Noindex",
+                    "reason": "noindex",
+                    "http_status": 200,
+                }
+            ],
+            "noindex_pages": [],
+        },
+    )
+
+    assert payload["summary"]["total_pages"] == 1
+    assert payload["pages"][0]["indexability_status"] == "noindex"
+    assert payload["issues"][0]["category"] == "indexability"
+
+
+def test_write_technical_seo_exports_writes_json_and_csv(tmp_path) -> None:
+    payload = build_technical_seo(
+        [SimpleNamespace(url="https://example.com/a", title="A", section="", word_count=100, language="en")],
+        metadata_quality={"per_page": [{"url": "https://example.com/a", "issues": ["missing_title"]}]},
+    )
+
+    write_technical_seo_exports(tmp_path, payload)
+
+    assert (tmp_path / "technical_pages.json").is_file()
+    assert (tmp_path / "technical_issues.json").is_file()
+    assert (tmp_path / "technical_pages.csv").is_file()
+    assert (tmp_path / "technical_issues.csv").is_file()
+    csv_text = (tmp_path / "technical_pages.csv").read_text(encoding="utf-8")
+    assert "technical_severity_score" in csv_text
+    assert "missing_title" in csv_text


### PR DESCRIPTION
## Summary
- add a shared technical SEO aggregation model built from existing indexability, metadata, performance, search, and page-type signals
- emit technical_pages.json, technical_issues.json, technical_pages.csv, and technical_issues.csv from every report run
- add tests for signal merging, skipped-page handling, and export writing

## Tests
- .venv/bin/pytest
- smoke: .venv/bin/site-audit run example.com --projects-root /tmp/site-audit-tech-smoke --max-pages 5 --workers 2 --no-search-data --no-scatterplot --no-cluster-labels --no-keyword-coverage --no-answerability --no-snapshot