### PR TITLE
Expand page indexability audit

### DIFF
--- a/site_audit/indexability.py
+++ b/site_audit/indexability.py
@@ -13,14 +13,101 @@ class IndexabilityReport:
     status_counts: dict[str, int]
     skipped: list[dict]
     noindex_pages: list[dict]
+    per_page: list[dict]
+    issues: list[dict]
+    issue_counts: dict[str, int]
+
+
+ACTION_BY_ISSUE = {
+    "noindex": "Confirm the page should be excluded from Google. If it is a strategic SEO page, remove the noindex directive and recrawl.",
+    "unusable": "Make the page return readable HTML with a crawlable title and body, or remove it from SEO crawl surfaces.",
+    "empty_embedding_text": "Add crawlable main content so the page can be evaluated for topical relevance and internal linking.",
+    "non_2xx_status": "Fix the HTTP response or update internal links and sitemaps so SEO pages resolve cleanly.",
+    "skipped": "Review why extraction skipped this URL and decide whether it should be part of the SEO corpus.",
+}
+
+
+def _clean(value) -> str:
+    if value is None:
+        return ""
+    return str(value)
+
+
+def _row_issue_keys(row: dict) -> list[str]:
+    keys: list[str] = []
+    reason = _clean(row.get("reason"))
+    status = _clean(row.get("status"))
+    http_status = int(row.get("http_status") or 0)
+    if reason == "noindex":
+        keys.append("noindex")
+    elif status != "analyzed":
+        keys.append(reason or "skipped")
+    if http_status and not 200 <= http_status < 400:
+        keys.append("non_2xx_status")
+    return list(dict.fromkeys(keys))
+
+
+def _indexability_status(row: dict) -> str:
+    if row.get("status") == "analyzed":
+        return "indexable"
+    if row.get("reason") == "noindex":
+        return "noindex"
+    return "not_analyzed"
+
+
+def _recommended_action(issue_keys: list[str]) -> str:
+    if not issue_keys:
+        return "No action needed for indexability based on the current crawl."
+    return ACTION_BY_ISSUE.get(issue_keys[0], ACTION_BY_ISSUE["skipped"])
 
 
 def analyze(fetched: Iterable, extraction_rows: list[dict], analyzed_urls: set[str]) -> IndexabilityReport:
     fetched_list = list(fetched)
     status_counts = Counter(str(getattr(row, "status", 0) or 0) for row in fetched_list)
+    fetched_by_url = {getattr(row, "url", ""): row for row in fetched_list}
     skipped = [row for row in extraction_rows if row.get("status") != "analyzed"]
     noindex_pages = [row for row in extraction_rows if row.get("reason") == "noindex"]
     extracted_ok = sum(1 for row in extraction_rows if row.get("status") in {"analyzed", "skipped"})
+    per_page: list[dict] = []
+    issues: list[dict] = []
+    issue_counts: Counter[str] = Counter()
+
+    for row in extraction_rows:
+        fetched_row = fetched_by_url.get(row.get("url", ""))
+        http_status = int(row.get("http_status") or getattr(fetched_row, "status", 0) or 0)
+        normalized = {
+            "url": row.get("url", ""),
+            "title": row.get("title", ""),
+            "http_status": http_status,
+            "content_type": row.get("content_type") or getattr(fetched_row, "content_type", ""),
+            "extraction_status": row.get("status", ""),
+            "reason": row.get("reason", ""),
+            "indexability_status": _indexability_status(row),
+            "canonical_url": row.get("canonical_url", ""),
+            "robots_content": row.get("robots_content", ""),
+            "x_robots_tag": row.get("x_robots_tag") or getattr(fetched_row, "x_robots_tag", ""),
+            "noindex_source": row.get("noindex_source") or row.get("source", ""),
+            "language": row.get("language", ""),
+            "word_count": row.get("word_count", ""),
+        }
+        issue_keys = _row_issue_keys({**row, "http_status": http_status})
+        normalized["issues"] = issue_keys
+        normalized["recommended_action"] = _recommended_action(issue_keys)
+        per_page.append(normalized)
+        for key in issue_keys:
+            issue_counts[key] += 1
+            issues.append({
+                "url": normalized["url"],
+                "title": normalized["title"],
+                "issue": key,
+                "http_status": http_status,
+                "indexability_status": normalized["indexability_status"],
+                "reason": normalized["reason"],
+                "canonical_url": normalized["canonical_url"],
+                "noindex_source": normalized["noindex_source"],
+                "x_robots_tag": normalized["x_robots_tag"],
+                "recommended_action": ACTION_BY_ISSUE.get(key, ACTION_BY_ISSUE["skipped"]),
+            })
 
     reason_counts = Counter(row.get("reason", "unknown") for row in skipped)
     total_fetched = len(fetched_list)
@@ -35,12 +122,20 @@ def analyze(fetched: Iterable, extraction_rows: list[dict], analyzed_urls: set[s
         "noindex_share": len(noindex_pages) / total_fetched if total_fetched else 0.0,
         "unusable_pages": reason_counts.get("unusable", 0),
         "empty_embedding_pages": reason_counts.get("empty_embedding_text", 0),
+        "indexable_pages": analyzed_count,
+        "non_indexable_pages": len(skipped),
+        "pages_with_indexability_issues": sum(1 for row in per_page if row.get("issues")),
+        "issue_count": sum(issue_counts.values()),
     }
+    per_page.sort(key=lambda row: (0 if row.get("issues") else 1, row.get("url", "")))
     return IndexabilityReport(
         summary=summary,
         status_counts=dict(status_counts),
         skipped=skipped[:500],
         noindex_pages=noindex_pages[:500],
+        per_page=per_page,
+        issues=issues,
+        issue_counts=dict(issue_counts),
     )
 
 
@@ -50,4 +145,11 @@ def to_payload(report: IndexabilityReport) -> dict:
         "status_counts": report.status_counts,
         "skipped": report.skipped,
         "noindex_pages": report.noindex_pages,
+        "per_page": report.per_page,
+        "issues": report.issues,
+        "issue_counts": report.issue_counts,
+        "interpretation": {
+            "why_it_matters": "Indexability issues explain which crawled URLs were excluded from the semantic SEO corpus and why Google may not be able to rank them.",
+            "how_to_use": "Start with pages marked noindex or non-2xx. Keep intentional exclusions, but fix strategic landing pages before judging content gaps or competitor coverage.",
+        },
     }

--- a/site_audit/pipeline.py
+++ b/site_audit/pipeline.py
@@ -346,6 +346,8 @@ def run(config: PipelineConfig) -> dict:
                 "status": "skipped",
                 "reason": "unusable",
                 "http_status": getattr(r, "status", 0),
+                "content_type": getattr(r, "content_type", ""),
+                "x_robots_tag": getattr(r, "x_robots_tag", ""),
             })
             continue
         if ext.noindex:
@@ -362,6 +364,13 @@ def run(config: PipelineConfig) -> dict:
                 "reason": "noindex",
                 "source": ext.noindex_source,
                 "http_status": getattr(r, "status", 0),
+                "content_type": getattr(r, "content_type", ""),
+                "canonical_url": ext.canonical_url,
+                "robots_content": ext.robots_content,
+                "x_robots_tag": getattr(r, "x_robots_tag", ""),
+                "noindex_source": ext.noindex_source,
+                "language": ext.language or "",
+                "word_count": ext.word_count,
             })
             continue
         section = section_for_url(r.url)
@@ -373,6 +382,13 @@ def run(config: PipelineConfig) -> dict:
                 "status": "skipped",
                 "reason": "empty_embedding_text",
                 "http_status": getattr(r, "status", 0),
+                "content_type": getattr(r, "content_type", ""),
+                "canonical_url": ext.canonical_url,
+                "robots_content": ext.robots_content,
+                "x_robots_tag": getattr(r, "x_robots_tag", ""),
+                "noindex_source": ext.noindex_source,
+                "language": ext.language or "",
+                "word_count": ext.word_count,
             })
             continue
         page = PageInfo(
@@ -394,6 +410,13 @@ def run(config: PipelineConfig) -> dict:
             "status": "analyzed",
             "reason": "",
             "http_status": getattr(r, "status", 0),
+            "content_type": getattr(r, "content_type", ""),
+            "canonical_url": ext.canonical_url,
+            "robots_content": ext.robots_content,
+            "x_robots_tag": getattr(r, "x_robots_tag", ""),
+            "noindex_source": ext.noindex_source,
+            "language": ext.language or "",
+            "word_count": ext.word_count,
         })
         if idx % 500 == 0 or idx == fetched_total:
             LOG.info("  extracted %d / %d fetched pages (%d usable)", idx, fetched_total, len(pages))

--- a/site_audit/report.py
+++ b/site_audit/report.py
@@ -172,6 +172,11 @@ def write_technical_seo_exports(output_dir: Path, technical_seo: dict) -> None:
     _write_csv(output_dir / "technical_issues.csv", [_csv_safe_row(row) for row in issues])
 
 
+def write_indexability_issues_csv(output_dir: Path, indexability: dict) -> None:
+    issues = list((indexability or {}).get("issues") or [])
+    _write_csv(output_dir / "indexability_issues.csv", [_csv_safe_row(row) for row in issues])
+
+
 def _csv_safe_row(row: dict) -> dict:
     out = {}
     for key, value in row.items():
@@ -632,6 +637,7 @@ def write_all(
         _write_json(output_dir / "conversion.json", conversion)
     if indexability is not None:
         _write_json(output_dir / "indexability.json", indexability)
+        write_indexability_issues_csv(output_dir, indexability)
     if performance is not None:
         _write_json(output_dir / "performance.json", performance)
     if ahrefs is not None:

--- a/tests/test_indexability.py
+++ b/tests/test_indexability.py
@@ -3,34 +3,52 @@ from pathlib import Path
 
 from site_audit.compare import build_payload
 from site_audit.indexability import analyze, to_payload
+from site_audit.report import write_indexability_issues_csv
 
 
 @dataclass
 class _Fetched:
     url: str
     status: int = 200
+    content_type: str = "text/html"
+    x_robots_tag: str = ""
 
 
 def test_indexability_payload_counts_funnel_and_reasons() -> None:
     fetched = [
         _Fetched("https://example.com/"),
-        _Fetched("https://example.com/noindex"),
-        _Fetched("https://example.com/bad"),
+        _Fetched("https://example.com/noindex", x_robots_tag="noindex"),
+        _Fetched("https://example.com/bad", status=500),
     ]
     rows = [
-        {"url": "https://example.com/", "status": "analyzed", "reason": "", "http_status": 200},
+        {
+            "url": "https://example.com/",
+            "title": "Home",
+            "status": "analyzed",
+            "reason": "",
+            "http_status": 200,
+            "canonical_url": "https://example.com/",
+            "robots_content": "index,follow",
+            "word_count": 400,
+        },
         {
             "url": "https://example.com/noindex",
+            "title": "Noindex",
             "status": "skipped",
             "reason": "noindex",
             "source": "meta",
             "http_status": 200,
+            "canonical_url": "https://example.com/noindex",
+            "robots_content": "noindex",
+            "noindex_source": "meta",
+            "word_count": 120,
         },
         {
             "url": "https://example.com/bad",
+            "title": "Bad",
             "status": "skipped",
             "reason": "unusable",
-            "http_status": 200,
+            "http_status": 500,
         },
     ]
 
@@ -43,8 +61,44 @@ def test_indexability_payload_counts_funnel_and_reasons() -> None:
     assert payload["summary"]["indexable_share"] == 1 / 3
     assert payload["summary"]["noindex_share"] == 1 / 3
     assert payload["summary"]["unusable_pages"] == 1
-    assert payload["status_counts"] == {"200": 3}
+    assert payload["summary"]["indexable_pages"] == 1
+    assert payload["summary"]["non_indexable_pages"] == 2
+    assert payload["summary"]["pages_with_indexability_issues"] == 2
+    assert payload["summary"]["issue_count"] == 3
+    assert payload["status_counts"] == {"200": 2, "500": 1}
     assert payload["noindex_pages"][0]["url"] == "https://example.com/noindex"
+    assert payload["issue_counts"] == {"noindex": 1, "unusable": 1, "non_2xx_status": 1}
+    by_url = {row["url"]: row for row in payload["per_page"]}
+    assert by_url["https://example.com/"]["indexability_status"] == "indexable"
+    assert by_url["https://example.com/"]["canonical_url"] == "https://example.com/"
+    assert by_url["https://example.com/noindex"]["indexability_status"] == "noindex"
+    assert by_url["https://example.com/noindex"]["x_robots_tag"] == "noindex"
+    assert by_url["https://example.com/noindex"]["issues"] == ["noindex"]
+    assert by_url["https://example.com/bad"]["issues"] == ["unusable", "non_2xx_status"]
+    assert "remove the noindex" in by_url["https://example.com/noindex"]["recommended_action"]
+    assert payload["interpretation"]["how_to_use"]
+
+
+def test_indexability_issue_csv_export(tmp_path: Path) -> None:
+    payload = {
+        "issues": [
+            {
+                "url": "https://example.com/noindex",
+                "title": "Noindex",
+                "issue": "noindex",
+                "http_status": 200,
+                "issues": ["noindex"],
+                "recommended_action": "Review.",
+            }
+        ]
+    }
+
+    write_indexability_issues_csv(tmp_path, payload)
+
+    csv_text = (tmp_path / "indexability_issues.csv").read_text(encoding="utf-8")
+    assert "url,title,issue,http_status,issues,recommended_action" in csv_text
+    assert "https://example.com/noindex" in csv_text
+    assert "noindex" in csv_text
 
 
 def test_compare_leaderboard_includes_indexability_metrics(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add per-page indexability rows with canonical, robots, X-Robots-Tag, language, word count, issue keys, and recommended actions
- add flattened indexability issue rows and issue counts while preserving the existing indexability summary contract
- export indexability_issues.csv from generated reports

## Tests
- .venv/bin/pytest tests/test_indexability.py tests/test_technical_seo.py
- .venv/bin/python -m compileall site_audit/indexability.py site_audit/report.py site_audit/pipeline.py
- .venv/bin/pytest
- .venv/bin/site-audit run example.com --projects-root /tmp/site-audit-indexability-smoke --max-pages 5 --workers 2 --no-search-data --no-scatterplot --no-cluster-labels --no-keyword-coverage --no-answerability --no-snapshot