### PR TITLE
Add sitemap coverage matrix

### DIFF
--- a/site_audit/crawler.py
+++ b/site_audit/crawler.py
@@ -145,6 +145,13 @@ class FetchResult:
     external_links: list = field(default_factory=list)   # cross-site (target_url, anchor_text)
 
 
+@dataclass
+class SitemapEntry:
+    url: str
+    source_sitemaps: list[str] = field(default_factory=list)
+    lastmod: str = ""
+
+
 def normalize_url(url: str) -> str:
     """Strip fragments and trailing slashes consistently."""
     url, _ = urldefrag(url)
@@ -170,6 +177,8 @@ class Crawler:
         self._sitemap_exclude_re = [re.compile(p) for p in config.sitemap_exclude_patterns]
         self._sitemap_lastmod_cutoff = self._lastmod_cutoff()
         self._robots: Optional[urllib.robotparser.RobotFileParser] = None
+        self.sitemap_entries: list[dict] = []
+        self.sitemap_urls_seen: list[str] = []
         if _HAS_CFFI:
             # impersonate a real Chrome to bypass TLS-fingerprint bot detection
             self._session = _cffi.Session(impersonate="chrome124")
@@ -285,7 +294,10 @@ class Crawler:
 
         seen_sitemaps: Set[str] = set()
         urls: Set[str] = set()
+        entries: dict[str, SitemapEntry] = {}
         queue = collections.deque(dict.fromkeys(sm for sm in candidates if self._sitemap_allowed(sm)))
+        self.sitemap_entries = []
+        self.sitemap_urls_seen = []
 
         while queue:
             sm = queue.popleft()
@@ -334,7 +346,21 @@ class Crawler:
                     url = normalize_url(loc_text)
                     if self._url_pattern_allowed(url) and self._lastmod_allowed(lastmod_text):
                         urls.add(url)
+                        entry = entries.setdefault(url, SitemapEntry(url=url))
+                        if sm not in entry.source_sitemaps:
+                            entry.source_sitemaps.append(sm)
+                        if lastmod_text and not entry.lastmod:
+                            entry.lastmod = lastmod_text
 
+        self.sitemap_urls_seen = sorted(seen_sitemaps)
+        self.sitemap_entries = [
+            {
+                "url": entry.url,
+                "source_sitemaps": sorted(entry.source_sitemaps),
+                "lastmod": entry.lastmod,
+            }
+            for entry in sorted(entries.values(), key=lambda item: item.url)
+        ]
         LOG.info("Sitemap discovery: %d URLs across %d sitemaps", len(urls), len(seen_sitemaps))
         return sorted(urls)
 

--- a/site_audit/pipeline.py
+++ b/site_audit/pipeline.py
@@ -129,6 +129,7 @@ from .semantic_ablation import build_semantic_ablation
 from .search_fusion import build_combined_search_analysis
 from .structured_data import analyze as analyze_structured_data
 from .structured_data import to_payload as structured_data_payload
+from .sitemap_coverage import analyze as analyze_sitemap_coverage
 from .template_patterns import build_template_patterns
 from .technical_seo import build_technical_seo
 from .trust_signals import build_trust_signals
@@ -432,12 +433,26 @@ def run(config: PipelineConfig) -> dict:
     indexability_data = indexability_payload(
         analyze_indexability(fetched, extraction_rows, {p.url for p in pages})
     )
+    sitemap_coverage_data = analyze_sitemap_coverage(
+        getattr(crawler, "sitemap_entries", []),
+        fetched,
+        extraction_rows,
+        indexability_data,
+    )
     ix_summary = indexability_data.get("summary", {}) or {}
     LOG.info(
         "  indexability: %.0f%% analyzed · %d noindex · %d skipped",
         (ix_summary.get("indexable_share", 0.0) or 0.0) * 100,
         ix_summary.get("noindex_pages", 0),
         ix_summary.get("skipped_pages", 0),
+    )
+    sc_summary = sitemap_coverage_data.get("summary", {}) or {}
+    LOG.info(
+        "  sitemap coverage: %d sitemap URLs · %d not fetched · %d non-indexable · %d crawled missing from sitemap",
+        sc_summary.get("total_sitemap_urls", 0),
+        sc_summary.get("sitemap_not_fetched", 0),
+        sc_summary.get("sitemap_non_indexable", 0),
+        sc_summary.get("crawled_not_in_sitemap", 0),
     )
 
     performance_data = performance_payload(analyze_performance(fetched))
@@ -1694,6 +1709,7 @@ def run(config: PipelineConfig) -> dict:
         freshness=freshness_data,
         conversion=conversion_data,
         indexability=indexability_data,
+        sitemap_coverage=sitemap_coverage_data,
         performance=performance_data,
         ahrefs=ahrefs_data,
         best_pages=best_pages_data,

--- a/site_audit/report.py
+++ b/site_audit/report.py
@@ -177,6 +177,12 @@ def write_indexability_issues_csv(output_dir: Path, indexability: dict) -> None:
     _write_csv(output_dir / "indexability_issues.csv", [_csv_safe_row(row) for row in issues])
 
 
+def write_sitemap_coverage_exports(output_dir: Path, sitemap_coverage: dict) -> None:
+    _write_json(output_dir / "sitemap_coverage.json", sitemap_coverage)
+    _write_csv(output_dir / "sitemap_coverage.csv", [_csv_safe_row(row) for row in (sitemap_coverage or {}).get("rows", [])])
+    _write_csv(output_dir / "sitemap_coverage_issues.csv", [_csv_safe_row(row) for row in (sitemap_coverage or {}).get("issues", [])])
+
+
 def _csv_safe_row(row: dict) -> dict:
     out = {}
     for key, value in row.items():
@@ -536,6 +542,7 @@ def write_all(
     freshness: Optional[dict] = None,
     conversion: Optional[dict] = None,
     indexability: Optional[dict] = None,
+    sitemap_coverage: Optional[dict] = None,
     performance: Optional[dict] = None,
     ahrefs: Optional[dict] = None,
     best_pages: Optional[dict] = None,
@@ -638,6 +645,8 @@ def write_all(
     if indexability is not None:
         _write_json(output_dir / "indexability.json", indexability)
         write_indexability_issues_csv(output_dir, indexability)
+    if sitemap_coverage is not None:
+        write_sitemap_coverage_exports(output_dir, sitemap_coverage)
     if performance is not None:
         _write_json(output_dir / "performance.json", performance)
     if ahrefs is not None:

--- a/site_audit/sitemap_coverage.py
+++ b/site_audit/sitemap_coverage.py
@@ -1,0 +1,109 @@
+"""Sitemap coverage matrix for crawled and analyzed URLs."""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Iterable
+
+
+ACTION_BY_STATUS = {
+    "sitemap_indexable": "No sitemap action needed for this URL.",
+    "sitemap_not_fetched": "Increase crawl limits or inspect robots/rules if this sitemap URL should be audited.",
+    "sitemap_non_indexable": "Remove non-indexable URLs from XML sitemaps or fix indexability when the page should rank.",
+    "crawled_not_in_sitemap": "Add this indexable URL to the XML sitemap if it is an SEO landing page.",
+}
+
+
+def analyze(
+    sitemap_entries: Iterable[dict],
+    fetched: Iterable,
+    extraction_rows: list[dict],
+    indexability: dict | None = None,
+) -> dict:
+    sitemap_by_url = {row.get("url", ""): row for row in sitemap_entries if row.get("url")}
+    fetched_by_url = {getattr(row, "url", ""): row for row in fetched}
+    extraction_by_url = {row.get("url", ""): row for row in extraction_rows if row.get("url")}
+    indexability_by_url = {
+        row.get("url", ""): row
+        for row in (indexability or {}).get("per_page", [])
+        if row.get("url")
+    }
+    urls = sorted(set(sitemap_by_url) | set(fetched_by_url))
+    rows: list[dict] = []
+    issues: list[dict] = []
+    status_counts: Counter[str] = Counter()
+
+    for url in urls:
+        sitemap_row = sitemap_by_url.get(url, {})
+        fetched_row = fetched_by_url.get(url)
+        extraction_row = extraction_by_url.get(url, {})
+        indexability_row = indexability_by_url.get(url, {})
+        in_sitemap = url in sitemap_by_url
+        crawled = fetched_row is not None
+        indexability_status = indexability_row.get("indexability_status") or (
+            "indexable" if extraction_row.get("status") == "analyzed" else extraction_row.get("reason", "")
+        )
+        coverage_status = _coverage_status(in_sitemap, crawled, indexability_status)
+        status_counts[coverage_status] += 1
+        row = {
+            "url": url,
+            "title": extraction_row.get("title") or indexability_row.get("title", ""),
+            "in_sitemap": in_sitemap,
+            "source_sitemaps": sitemap_row.get("source_sitemaps", []),
+            "lastmod": sitemap_row.get("lastmod", ""),
+            "crawled": crawled,
+            "http_status": extraction_row.get("http_status") or getattr(fetched_row, "status", ""),
+            "extraction_status": extraction_row.get("status", ""),
+            "indexability_status": indexability_status,
+            "coverage_status": coverage_status,
+            "indexability_issues": indexability_row.get("issues", []),
+            "recommended_action": ACTION_BY_STATUS.get(coverage_status, "Review sitemap coverage for this URL."),
+        }
+        rows.append(row)
+        if coverage_status != "sitemap_indexable":
+            issues.append({
+                "url": url,
+                "title": row["title"],
+                "issue": coverage_status,
+                "in_sitemap": in_sitemap,
+                "crawled": crawled,
+                "http_status": row["http_status"],
+                "indexability_status": indexability_status,
+                "source_sitemaps": row["source_sitemaps"],
+                "recommended_action": row["recommended_action"],
+            })
+
+    sitemap_total = len(sitemap_by_url)
+    fetched_sitemap = sum(1 for row in rows if row["in_sitemap"] and row["crawled"])
+    indexable_sitemap = status_counts.get("sitemap_indexable", 0)
+    return {
+        "summary": {
+            "status": "ok" if rows else "no_urls",
+            "total_sitemap_urls": sitemap_total,
+            "total_crawled_urls": len(fetched_by_url),
+            "fetched_sitemap_urls": fetched_sitemap,
+            "sitemap_not_fetched": status_counts.get("sitemap_not_fetched", 0),
+            "sitemap_non_indexable": status_counts.get("sitemap_non_indexable", 0),
+            "sitemap_indexable": indexable_sitemap,
+            "crawled_not_in_sitemap": status_counts.get("crawled_not_in_sitemap", 0),
+            "sitemap_fetch_coverage_share": fetched_sitemap / sitemap_total if sitemap_total else 0.0,
+            "sitemap_indexable_share": indexable_sitemap / sitemap_total if sitemap_total else 0.0,
+        },
+        "status_counts": dict(status_counts),
+        "rows": rows,
+        "issues": issues,
+        "interpretation": {
+            "why_it_matters": "XML sitemaps should point search engines at canonical, indexable URLs. Gaps show wasted crawl hints or important pages missing from sitemap coverage.",
+            "how_to_use": "First remove or fix non-indexable sitemap URLs, then add valuable crawled indexable pages that are missing from sitemaps.",
+        },
+    }
+
+
+def _coverage_status(in_sitemap: bool, crawled: bool, indexability_status: str) -> str:
+    if in_sitemap and not crawled:
+        return "sitemap_not_fetched"
+    if in_sitemap and indexability_status and indexability_status != "indexable":
+        return "sitemap_non_indexable"
+    if in_sitemap:
+        return "sitemap_indexable"
+    return "crawled_not_in_sitemap"

--- a/tests/test_crawler_filters.py
+++ b/tests/test_crawler_filters.py
@@ -137,6 +137,13 @@ def test_sitemap_lastmod_after_filters_urlset_entries() -> None:
     )
 
     assert crawler._discover_via_sitemaps() == ["https://example.com/recent"]
+    assert crawler.sitemap_entries == [
+        {
+            "url": "https://example.com/recent",
+            "source_sitemaps": ["https://example.com/sitemap.xml"],
+            "lastmod": "2026-05-04T10:00:00+00:00",
+        }
+    ]
 
 
 def test_sitemap_only_keeps_outlinks_but_does_not_enqueue_them() -> None:

--- a/tests/test_sitemap_coverage.py
+++ b/tests/test_sitemap_coverage.py
@@ -1,0 +1,95 @@
+from dataclasses import dataclass
+
+from site_audit.report import write_sitemap_coverage_exports
+from site_audit.sitemap_coverage import analyze
+
+
+@dataclass
+class _Fetched:
+    url: str
+    status: int = 200
+
+
+def test_sitemap_coverage_classifies_matrix_and_actions() -> None:
+    payload = analyze(
+        [
+            {
+                "url": "https://example.com/",
+                "source_sitemaps": ["https://example.com/sitemap.xml"],
+                "lastmod": "2026-05-01",
+            },
+            {
+                "url": "https://example.com/noindex",
+                "source_sitemaps": ["https://example.com/sitemap.xml"],
+                "lastmod": "2026-05-02",
+            },
+            {
+                "url": "https://example.com/not-fetched",
+                "source_sitemaps": ["https://example.com/sitemap.xml"],
+                "lastmod": "2026-05-03",
+            },
+        ],
+        [
+            _Fetched("https://example.com/"),
+            _Fetched("https://example.com/noindex"),
+            _Fetched("https://example.com/crawled-only"),
+        ],
+        [
+            {"url": "https://example.com/", "title": "Home", "status": "analyzed", "http_status": 200},
+            {
+                "url": "https://example.com/noindex",
+                "title": "Noindex",
+                "status": "skipped",
+                "reason": "noindex",
+                "http_status": 200,
+            },
+            {
+                "url": "https://example.com/crawled-only",
+                "title": "Crawled Only",
+                "status": "analyzed",
+                "http_status": 200,
+            },
+        ],
+        {
+            "per_page": [
+                {"url": "https://example.com/", "indexability_status": "indexable", "issues": []},
+                {"url": "https://example.com/noindex", "indexability_status": "noindex", "issues": ["noindex"]},
+                {"url": "https://example.com/crawled-only", "indexability_status": "indexable", "issues": []},
+            ]
+        },
+    )
+
+    assert payload["summary"]["total_sitemap_urls"] == 3
+    assert payload["summary"]["fetched_sitemap_urls"] == 2
+    assert payload["summary"]["sitemap_not_fetched"] == 1
+    assert payload["summary"]["sitemap_non_indexable"] == 1
+    assert payload["summary"]["sitemap_indexable"] == 1
+    assert payload["summary"]["crawled_not_in_sitemap"] == 1
+    assert payload["summary"]["sitemap_fetch_coverage_share"] == 2 / 3
+    assert payload["summary"]["sitemap_indexable_share"] == 1 / 3
+    by_url = {row["url"]: row for row in payload["rows"]}
+    assert by_url["https://example.com/"]["coverage_status"] == "sitemap_indexable"
+    assert by_url["https://example.com/noindex"]["coverage_status"] == "sitemap_non_indexable"
+    assert by_url["https://example.com/noindex"]["indexability_issues"] == ["noindex"]
+    assert by_url["https://example.com/not-fetched"]["coverage_status"] == "sitemap_not_fetched"
+    assert by_url["https://example.com/crawled-only"]["coverage_status"] == "crawled_not_in_sitemap"
+    assert "Remove non-indexable" in by_url["https://example.com/noindex"]["recommended_action"]
+    assert {issue["issue"] for issue in payload["issues"]} == {
+        "sitemap_non_indexable",
+        "sitemap_not_fetched",
+        "crawled_not_in_sitemap",
+    }
+
+
+def test_sitemap_coverage_exports_json_and_csv(tmp_path) -> None:
+    payload = {
+        "summary": {"total_sitemap_urls": 1},
+        "rows": [{"url": "https://example.com/", "source_sitemaps": ["https://example.com/sitemap.xml"]}],
+        "issues": [{"url": "https://example.com/noindex", "issue": "sitemap_non_indexable"}],
+    }
+
+    write_sitemap_coverage_exports(tmp_path, payload)
+
+    assert (tmp_path / "sitemap_coverage.json").exists()
+    assert "https://example.com/" in (tmp_path / "sitemap_coverage.csv").read_text(encoding="utf-8")
+    assert "sitemap_non_indexable" in (tmp_path / "sitemap_coverage_issues.csv").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- capture sitemap URL metadata during crawler discovery, including source sitemap and lastmod
- add a sitemap coverage analyzer that compares sitemap URLs with fetched/extracted/indexability state
- export sitemap_coverage.json, sitemap_coverage.csv, and sitemap_coverage_issues.csv from generated reports

## Tests
- .venv/bin/pytest tests/test_sitemap_coverage.py tests/test_crawler_filters.py tests/test_indexability.py
- .venv/bin/python -m compileall site_audit/sitemap_coverage.py site_audit/crawler.py site_audit/pipeline.py site_audit/report.py
- .venv/bin/pytest
- .venv/bin/site-audit run example.com --projects-root /tmp/site-audit-sitemap-smoke --max-pages 5 --workers 2 --no-search-data --no-scatterplot --no-cluster-labels --no-keyword-coverage --no-answerability --no-snapshot