### PR TITLE
Add canonical consistency audit

### DIFF
--- a/site_audit/canonical_consistency.py
+++ b/site_audit/canonical_consistency.py
@@ -1,0 +1,157 @@
+"""Canonical URL consistency audit."""
+
+from __future__ import annotations
+
+from collections import Counter
+from urllib.parse import urlparse
+
+
+ACTION_BY_ISSUE = {
+    "missing_canonical": "Add a self-referencing canonical or the intended canonical target.",
+    "canonical_external_host": "Confirm the external canonical is intentional; otherwise point it to the canonical URL on this domain.",
+    "canonical_non_self": "Use a self-referencing canonical on unique SEO pages, or confirm this is a deliberate duplicate consolidation.",
+    "canonical_target_not_crawled": "Make sure the canonical target is crawlable and included in the audit scope.",
+    "canonical_target_non_indexable": "Point canonical tags only at indexable URLs or fix the target page indexability.",
+    "canonical_target_shared": "Review whether multiple pages should consolidate to the same canonical target.",
+}
+
+
+def analyze(extraction_rows: list[dict], indexability: dict | None = None) -> dict:
+    page_rows = [row for row in extraction_rows if row.get("url")]
+    urls = {row.get("url", "") for row in page_rows}
+    normalized_urls = {_normalize_url(url) for url in urls}
+    indexability_by_url = {
+        row.get("url", ""): row
+        for row in (indexability or {}).get("per_page", [])
+        if row.get("url")
+    }
+    indexability_by_normalized_url = {
+        _normalize_url(url): row
+        for url, row in indexability_by_url.items()
+    }
+    canonical_counts = Counter(
+        _normalize_url(row.get("canonical_url", ""))
+        for row in page_rows
+        if row.get("canonical_url")
+    )
+    rows: list[dict] = []
+    issues: list[dict] = []
+    issue_counts: Counter[str] = Counter()
+
+    for page in page_rows:
+        url = page.get("url", "")
+        canonical_url = page.get("canonical_url", "")
+        issue_keys = _issues_for_page(
+            url,
+            canonical_url,
+            normalized_urls,
+            indexability_by_url,
+            indexability_by_normalized_url,
+            canonical_counts,
+        )
+        issue_counts.update(issue_keys)
+        row = {
+            "url": url,
+            "title": page.get("title", ""),
+            "canonical_url": canonical_url,
+            "canonical_target_normalized": _normalize_url(canonical_url),
+            "http_status": page.get("http_status", ""),
+            "extraction_status": page.get("status", ""),
+            "indexability_status": (indexability_by_url.get(url) or {}).get("indexability_status", ""),
+            "canonical_status": "needs_review" if issue_keys else "ok",
+            "canonical_issue_count": len(issue_keys),
+            "issues": issue_keys,
+            "recommended_action": _recommended_action(issue_keys),
+        }
+        rows.append(row)
+        for issue in issue_keys:
+            issues.append({
+                "url": url,
+                "title": row["title"],
+                "issue": issue,
+                "canonical_url": canonical_url,
+                "http_status": row["http_status"],
+                "indexability_status": row["indexability_status"],
+                "recommended_action": ACTION_BY_ISSUE.get(issue, "Review canonical configuration."),
+            })
+
+    rows.sort(key=lambda row: (row["canonical_issue_count"], row["url"]), reverse=True)
+    total = len(rows)
+    pages_with_issues = sum(1 for row in rows if row["issues"])
+    return {
+        "summary": {
+            "status": "ok" if rows else "no_pages",
+            "total_pages": total,
+            "pages_with_canonical_issues": pages_with_issues,
+            "canonical_issue_share": pages_with_issues / total if total else 0.0,
+            "missing_canonical": issue_counts.get("missing_canonical", 0),
+            "canonical_external_host": issue_counts.get("canonical_external_host", 0),
+            "canonical_non_self": issue_counts.get("canonical_non_self", 0),
+            "canonical_target_not_crawled": issue_counts.get("canonical_target_not_crawled", 0),
+            "canonical_target_non_indexable": issue_counts.get("canonical_target_non_indexable", 0),
+            "canonical_target_shared": issue_counts.get("canonical_target_shared", 0),
+        },
+        "issue_counts": dict(issue_counts),
+        "rows": rows,
+        "issues": issues,
+        "interpretation": {
+            "why_it_matters": "Canonical tags tell search engines which URL should consolidate duplicate signals and rank. Incorrect canonicals can remove good pages from competition or point signals at weak targets.",
+            "how_to_use": "Fix missing and external canonicals first, then review non-self canonicals and shared canonical targets on important SEO pages.",
+        },
+    }
+
+
+def _issues_for_page(
+    url: str,
+    canonical_url: str,
+    normalized_crawled_urls: set[str],
+    indexability_by_url: dict[str, dict],
+    indexability_by_normalized_url: dict[str, dict],
+    canonical_counts: Counter[str],
+) -> list[str]:
+    if not canonical_url:
+        return ["missing_canonical"]
+    issues: list[str] = []
+    if not _same_host(url, canonical_url):
+        issues.append("canonical_external_host")
+    if _normalize_url(url) != _normalize_url(canonical_url):
+        issues.append("canonical_non_self")
+    normalized_canonical = _normalize_url(canonical_url)
+    if normalized_canonical not in normalized_crawled_urls:
+        issues.append("canonical_target_not_crawled")
+    target = indexability_by_url.get(canonical_url) or indexability_by_normalized_url.get(normalized_canonical)
+    if (
+        normalized_canonical != _normalize_url(url)
+        and target
+        and target.get("indexability_status")
+        and target.get("indexability_status") != "indexable"
+    ):
+        issues.append("canonical_target_non_indexable")
+    if canonical_counts.get(_normalize_url(canonical_url), 0) > 1 and _normalize_url(url) != _normalize_url(canonical_url):
+        issues.append("canonical_target_shared")
+    return list(dict.fromkeys(issues))
+
+
+def _recommended_action(issues: list[str]) -> str:
+    if not issues:
+        return "No canonical action needed based on the current crawl."
+    return ACTION_BY_ISSUE.get(issues[0], "Review canonical configuration.")
+
+
+def _same_host(url: str, canonical_url: str) -> bool:
+    parsed = urlparse(url)
+    canonical = urlparse(canonical_url)
+    if not canonical.netloc:
+        return True
+    left = parsed.netloc.lower().removeprefix("www.")
+    right = canonical.netloc.lower().removeprefix("www.")
+    return left == right
+
+
+def _normalize_url(url: str) -> str:
+    parsed = urlparse(url or "")
+    if not parsed.scheme or not parsed.netloc:
+        return (url or "").rstrip("/")
+    netloc = parsed.netloc.lower().removeprefix("www.")
+    path = (parsed.path or "/").rstrip("/") or "/"
+    return f"{parsed.scheme.lower()}://{netloc}{path}"

--- a/site_audit/pipeline.py
+++ b/site_audit/pipeline.py
@@ -41,6 +41,7 @@ from .answerability import to_payload as answerability_payload
 from .best_pages import build_best_page_explainers
 from .cache import EmbeddingCache, HttpCache, ParagraphEmbeddingCache, content_hash, domain_slug
 from .cannibalization import build_cannibalization
+from .canonical_consistency import analyze as analyze_canonical_consistency
 from .duplicate_fragments import build_duplicate_fragments
 from .cluster_labels import cluster_overlap_matrix, label_clusters
 from .competitive_analysis import (
@@ -439,6 +440,10 @@ def run(config: PipelineConfig) -> dict:
         extraction_rows,
         indexability_data,
     )
+    canonical_consistency_data = analyze_canonical_consistency(
+        extraction_rows,
+        indexability_data,
+    )
     ix_summary = indexability_data.get("summary", {}) or {}
     LOG.info(
         "  indexability: %.0f%% analyzed · %d noindex · %d skipped",
@@ -453,6 +458,14 @@ def run(config: PipelineConfig) -> dict:
         sc_summary.get("sitemap_not_fetched", 0),
         sc_summary.get("sitemap_non_indexable", 0),
         sc_summary.get("crawled_not_in_sitemap", 0),
+    )
+    cc_summary = canonical_consistency_data.get("summary", {}) or {}
+    LOG.info(
+        "  canonical consistency: %d pages with issues · %d missing · %d external · %d non-self",
+        cc_summary.get("pages_with_canonical_issues", 0),
+        cc_summary.get("missing_canonical", 0),
+        cc_summary.get("canonical_external_host", 0),
+        cc_summary.get("canonical_non_self", 0),
     )
 
     performance_data = performance_payload(analyze_performance(fetched))
@@ -1710,6 +1723,7 @@ def run(config: PipelineConfig) -> dict:
         conversion=conversion_data,
         indexability=indexability_data,
         sitemap_coverage=sitemap_coverage_data,
+        canonical_consistency=canonical_consistency_data,
         performance=performance_data,
         ahrefs=ahrefs_data,
         best_pages=best_pages_data,

--- a/site_audit/report.py
+++ b/site_audit/report.py
@@ -183,6 +183,12 @@ def write_sitemap_coverage_exports(output_dir: Path, sitemap_coverage: dict) -> 
     _write_csv(output_dir / "sitemap_coverage_issues.csv", [_csv_safe_row(row) for row in (sitemap_coverage or {}).get("issues", [])])
 
 
+def write_canonical_consistency_exports(output_dir: Path, canonical_consistency: dict) -> None:
+    _write_json(output_dir / "canonical_consistency.json", canonical_consistency)
+    _write_csv(output_dir / "canonical_consistency.csv", [_csv_safe_row(row) for row in (canonical_consistency or {}).get("rows", [])])
+    _write_csv(output_dir / "canonical_consistency_issues.csv", [_csv_safe_row(row) for row in (canonical_consistency or {}).get("issues", [])])
+
+
 def _csv_safe_row(row: dict) -> dict:
     out = {}
     for key, value in row.items():
@@ -543,6 +549,7 @@ def write_all(
     conversion: Optional[dict] = None,
     indexability: Optional[dict] = None,
     sitemap_coverage: Optional[dict] = None,
+    canonical_consistency: Optional[dict] = None,
     performance: Optional[dict] = None,
     ahrefs: Optional[dict] = None,
     best_pages: Optional[dict] = None,
@@ -647,6 +654,8 @@ def write_all(
         write_indexability_issues_csv(output_dir, indexability)
     if sitemap_coverage is not None:
         write_sitemap_coverage_exports(output_dir, sitemap_coverage)
+    if canonical_consistency is not None:
+        write_canonical_consistency_exports(output_dir, canonical_consistency)
     if performance is not None:
         _write_json(output_dir / "performance.json", performance)
     if ahrefs is not None:

--- a/tests/test_canonical_consistency.py
+++ b/tests/test_canonical_consistency.py
@@ -1,0 +1,89 @@
+from site_audit.canonical_consistency import analyze
+from site_audit.report import write_canonical_consistency_exports
+
+
+def test_canonical_consistency_flags_missing_external_non_self_and_bad_targets() -> None:
+    payload = analyze(
+        [
+            {
+                "url": "https://example.com/",
+                "title": "Home",
+                "status": "analyzed",
+                "http_status": 200,
+                "canonical_url": "https://example.com/",
+            },
+            {
+                "url": "https://example.com/missing",
+                "title": "Missing",
+                "status": "analyzed",
+                "http_status": 200,
+                "canonical_url": "",
+            },
+            {
+                "url": "https://example.com/external",
+                "title": "External",
+                "status": "analyzed",
+                "http_status": 200,
+                "canonical_url": "https://other.example/external",
+            },
+            {
+                "url": "https://example.com/variant",
+                "title": "Variant",
+                "status": "analyzed",
+                "http_status": 200,
+                "canonical_url": "https://example.com/",
+            },
+            {
+                "url": "https://example.com/to-noindex",
+                "title": "Target Noindex",
+                "status": "analyzed",
+                "http_status": 200,
+                "canonical_url": "https://example.com/noindex",
+            },
+            {
+                "url": "https://example.com/noindex",
+                "title": "Noindex",
+                "status": "skipped",
+                "reason": "noindex",
+                "http_status": 200,
+                "canonical_url": "https://example.com/noindex",
+            },
+        ],
+        {
+            "per_page": [
+                {"url": "https://example.com/", "indexability_status": "indexable"},
+                {"url": "https://example.com/noindex", "indexability_status": "noindex"},
+            ]
+        },
+    )
+
+    assert payload["summary"]["total_pages"] == 6
+    assert payload["summary"]["pages_with_canonical_issues"] == 4
+    assert payload["summary"]["missing_canonical"] == 1
+    assert payload["summary"]["canonical_external_host"] == 1
+    assert payload["summary"]["canonical_non_self"] == 3
+    assert payload["summary"]["canonical_target_not_crawled"] == 1
+    assert payload["summary"]["canonical_target_non_indexable"] == 1
+    assert payload["summary"]["canonical_target_shared"] == 2
+    by_url = {row["url"]: row for row in payload["rows"]}
+    assert by_url["https://example.com/"]["canonical_status"] == "ok"
+    assert by_url["https://example.com/missing"]["issues"] == ["missing_canonical"]
+    assert "canonical_external_host" in by_url["https://example.com/external"]["issues"]
+    assert "canonical_target_not_crawled" in by_url["https://example.com/external"]["issues"]
+    assert "canonical_target_shared" in by_url["https://example.com/variant"]["issues"]
+    assert "canonical_target_non_indexable" in by_url["https://example.com/to-noindex"]["issues"]
+    assert payload["interpretation"]["how_to_use"]
+
+
+def test_canonical_consistency_exports_json_and_csv(tmp_path) -> None:
+    payload = {
+        "summary": {"total_pages": 1},
+        "rows": [{"url": "https://example.com/", "issues": []}],
+        "issues": [{"url": "https://example.com/missing", "issue": "missing_canonical"}],
+    }
+
+    write_canonical_consistency_exports(tmp_path, payload)
+
+    assert (tmp_path / "canonical_consistency.json").exists()
+    assert "https://example.com/" in (tmp_path / "canonical_consistency.csv").read_text(encoding="utf-8")
+    assert "missing_canonical" in (tmp_path / "canonical_consistency_issues.csv").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add a canonical consistency analyzer for missing, external, non-self, uncrawled target, non-indexable target, and shared target issues
- wire canonical consistency into the pipeline logs and report exports
- export canonical_consistency.json, canonical_consistency.csv, and canonical_consistency_issues.csv

## Tests
- .venv/bin/pytest tests/test_canonical_consistency.py tests/test_metadata_quality.py tests/test_sitemap_coverage.py
- .venv/bin/python -m compileall site_audit/canonical_consistency.py site_audit/pipeline.py site_audit/report.py
- .venv/bin/pytest
- .venv/bin/site-audit run example.com --projects-root /tmp/site-audit-canonical-smoke --max-pages 5 --workers 2 --no-search-data --no-scatterplot --no-cluster-labels --no-keyword-coverage --no-answerability --no-snapshot