### PR TITLE
Skip self links in internal recommendations

### DIFF
--- a/site_audit/linkgraph.py
+++ b/site_audit/linkgraph.py
@@ -487,9 +487,11 @@ def link_recommendations(
     sims, idxs = index.search(embeddings.astype(np.float32), k)
 
     edge_set: set[tuple[str, str]] = set()
+    canonical_edge_set: set[tuple[str, str]] = set()
     for src, outs in graph.items():
         for tgt in outs:
             edge_set.add((src, tgt))
+            canonical_edge_set.add((_canonical_url(src), _canonical_url(tgt)))
 
     seen_pairs: set[tuple[int, int]] = set()
     recs: list[dict] = []
@@ -505,7 +507,13 @@ def link_recommendations(
             seen_pairs.add(key)
             url_a = pages[i].url
             url_b = pages[j].url
+            canonical_a = _canonical_url(url_a)
+            canonical_b = _canonical_url(url_b)
+            if canonical_a == canonical_b:
+                continue
             if (url_a, url_b) in edge_set or (url_b, url_a) in edge_set:
+                continue
+            if (canonical_a, canonical_b) in canonical_edge_set or (canonical_b, canonical_a) in canonical_edge_set:
                 continue
             recs.append({
                 "url_a": url_a,

--- a/site_audit/paragraph_links.py
+++ b/site_audit/paragraph_links.py
@@ -37,6 +37,7 @@ import re
 from collections import Counter, defaultdict
 from dataclasses import dataclass
 from typing import Iterable
+from urllib.parse import urlparse
 
 import numpy as np
 
@@ -75,12 +76,25 @@ class ParagraphLinkRec:
 
 
 def _is_nav_url(url: str) -> bool:
-    from urllib.parse import urlparse
     try:
         path = urlparse(url).path or "/"
     except Exception:
         return False
     return bool(_NAV_PATH_RE.match(path))
+
+
+def _canonical_url(url: str) -> str:
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return str(url or "").rstrip("/")
+    path = parsed.path or "/"
+    if path != "/":
+        path = path.rstrip("/")
+    netloc = parsed.netloc.lower()
+    if netloc.startswith("www."):
+        netloc = netloc[4:]
+    return f"{parsed.scheme.lower() or 'https'}://{netloc}{path}".rstrip("/") or str(url or "").rstrip("/")
 
 
 def _tokenize(text: str) -> list[str]:
@@ -159,6 +173,10 @@ def recommend(
         page_avg_sims[page_i] = sims[para_idxs].mean(axis=0)
 
     existing_links = _existing_link_targets_for_page(pages_with_outlinks)
+    canonical_existing_links = {
+        _canonical_url(src): {_canonical_url(tgt) for tgt in targets}
+        for src, targets in existing_links.items()
+    }
 
     # answerability filter: low-quality target pages get skipped
     drop_target_idx: set[int] = set()
@@ -199,7 +217,13 @@ def recommend(
                 continue
             src_url = pages[page_i].url
             tgt_url = pages[tgt_i].url
+            canonical_src = _canonical_url(src_url)
+            canonical_tgt = _canonical_url(tgt_url)
+            if canonical_src == canonical_tgt:
+                continue
             if tgt_url in existing_links.get(src_url, set()):
+                continue
+            if canonical_tgt in canonical_existing_links.get(canonical_src, set()):
                 continue
             if (page_i, tgt_i) in page_target_seen:
                 continue

--- a/site_audit/report.py
+++ b/site_audit/report.py
@@ -24,6 +24,7 @@ import re
 import shutil
 from pathlib import Path
 from typing import Optional
+from urllib.parse import urlparse
 
 import numpy as np
 
@@ -105,6 +106,8 @@ def write_internal_linkbuilding_csv(
         source_url = rec.get("source_url") or ""
         target_url = rec.get("target_url") or ""
         suggested_anchor = rec.get("suggested_anchor") or rec.get("anchor") or ""
+        if _canonical_url(source_url) == _canonical_url(target_url):
+            continue
         paid_candidate = _best_paid_anchor_candidate(
             paid_keywords,
             rec.get("paragraph_excerpt") or "",
@@ -221,6 +224,20 @@ def _paid_keywords(search_payload: Optional[dict]) -> list[dict]:
 
 def _normalize_anchor(anchor: str) -> str:
     return re.sub(r"\s+", " ", str(anchor or "").strip().lower())
+
+
+def _canonical_url(url: str) -> str:
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return str(url or "").rstrip("/")
+    path = parsed.path or "/"
+    if path != "/":
+        path = path.rstrip("/")
+    netloc = parsed.netloc.lower()
+    if netloc.startswith("www."):
+        netloc = netloc[4:]
+    return f"{parsed.scheme.lower() or 'https'}://{netloc}{path}".rstrip("/") or str(url or "").rstrip("/")
 
 
 def _best_paid_anchor_candidate(

--- a/tests/test_link_flow.py
+++ b/tests/test_link_flow.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from site_audit.analyzer import PageInfo
-from site_audit.linkgraph import analyze, high_demand_low_link_payload, hub_bottleneck_payload, link_flow_payload, link_removal_simulation_payload, traffic_weighted_pagerank_payload
+from site_audit.linkgraph import analyze, high_demand_low_link_payload, hub_bottleneck_payload, link_flow_payload, link_recommendations, link_removal_simulation_payload, traffic_weighted_pagerank_payload
 
 
 def test_link_flow_payload_keeps_traffic_nodes_and_weighted_edges() -> None:
@@ -49,6 +49,33 @@ def test_link_flow_payload_keeps_traffic_nodes_and_weighted_edges() -> None:
     assert target_edge["target_cluster"] == "guides"
     assert target_edge["target_page_type"] == "article"
     assert "guide" in target_edge["anchor_samples"]
+
+
+def test_link_recommendations_skip_canonical_self_link_variants() -> None:
+    pages = [
+        PageInfo(url="https://www.example.com/source/", title="Source", description="", section="root", word_count=100, language="en"),
+        PageInfo(url="https://example.com/source", title="Source Duplicate", description="", section="root", word_count=100, language="en"),
+        PageInfo(url="https://example.com/target", title="Target", description="", section="root", word_count=100, language="en"),
+    ]
+    embeddings = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [0.99, 0.01, 0.0],
+            [0.0, 1.0, 0.0],
+        ],
+        dtype=np.float32,
+    )
+
+    recs = link_recommendations(
+        pages,
+        embeddings,
+        graph={},
+        similarity_threshold=0.1,
+        knn=3,
+        top_k=10,
+    )
+
+    assert all({rec["url_a"], rec["url_b"]} != {pages[0].url, pages[1].url} for rec in recs)
 
 
 def test_link_removal_simulation_ranks_contextual_and_template_links() -> None:

--- a/tests/test_paragraph_links.py
+++ b/tests/test_paragraph_links.py
@@ -95,6 +95,44 @@ def test_recommend_dedupes_same_anchor_in_same_paragraph() -> None:
     assert len(recs) == len(keys)
 
 
+def test_recommend_skips_canonical_self_link_variants() -> None:
+    pages = [
+        SimpleNamespace(url="https://www.example.com/source/", title="Source"),
+        SimpleNamespace(url="https://example.com/source", title="Source canonical duplicate"),
+        SimpleNamespace(url="https://example.com/target", title="Target"),
+    ]
+    page_embeddings = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [0.99, 0.01, 0.0],
+            [0.0, 1.0, 0.0],
+        ],
+        dtype=np.float32,
+    )
+    paragraph_records = [
+        (
+            0,
+            1,
+            "This paragraph strongly matches source duplicate content.",
+            np.array([0.99, 0.01, 0.0], dtype=np.float32),
+        )
+    ]
+
+    recs = recommend(
+        pages,
+        page_embeddings,
+        paragraph_records,
+        pages_with_outlinks=[],
+        embedder=CountingEmbedder(),
+        similarity_floor=0.1,
+        lift_floor=-1.0,
+        top_k_per_page=3,
+        top_k_total=10,
+    )
+
+    assert all(r.source_url != "https://www.example.com/source/" or r.target_url != "https://example.com/source" for r in recs)
+
+
 def test_addition_simulation_scores_components_and_density_cap() -> None:
     pages = [
         SimpleNamespace(url="https://example.com/source", title="Source", section="blog"),
@@ -220,6 +258,37 @@ def test_internal_linkbuilding_csv_dedupes_same_anchor_in_same_paragraph(tmp_pat
             "target_title": pages[2].title,
             "suggested_anchor": "Target   Topics",
             "expected_benefit_score": 70,
+        },
+    ]
+
+    rows = write_internal_linkbuilding_csv(tmp_path / "links.csv", result, recs)
+
+    assert len(rows) == 1
+    assert rows[0]["destination_url"] == pages[1].url
+
+
+def test_internal_linkbuilding_csv_skips_canonical_self_links(tmp_path) -> None:
+    pages = [
+        SimpleNamespace(url="https://www.example.com/source/", title="Source", description=""),
+        SimpleNamespace(url="https://example.com/target", title="Target", description=""),
+    ]
+    result = SimpleNamespace(pages=pages)
+    recs = [
+        {
+            "source_url": "https://www.example.com/source/",
+            "paragraph_index": 1,
+            "paragraph_excerpt": "Self link should not be exported.",
+            "target_url": "https://example.com/source",
+            "target_title": "Source",
+            "suggested_anchor": "source page",
+        },
+        {
+            "source_url": pages[0].url,
+            "paragraph_index": 2,
+            "paragraph_excerpt": "Valid target link.",
+            "target_url": pages[1].url,
+            "target_title": pages[1].title,
+            "suggested_anchor": "target page",
         },
     ]
 


### PR DESCRIPTION
## Summary
- skip canonical self-pairs in Page A/Page B internal-link recommendations
- skip canonical self-targets in paragraph-level internal-link recommendations
- defensively omit canonical self-links from internal linkbuilding CSV exports

## Tests
- .venv/bin/pytest tests/test_paragraph_links.py tests/test_link_flow.py
- .venv/bin/python -m compileall site_audit/linkgraph.py site_audit/paragraph_links.py site_audit/report.py
- .venv/bin/pytest

## Report refresh
- Filtered existing flowhunt.io and lindy.ai linkgraph recommendations in generated report JSON/HTML so the local UI no longer shows self-pairs.