### PR TITLE
Add OpenRouter AI agent to SERP gap

### DIFF
--- a/README.md
+++ b/README.md
@@ -840,6 +840,16 @@ Before running SERP gap analysis, run the normal audit once so
 site-audit run www.liveagent.com --search-provider all
 ```
 
+Prefer the guided CLI menu when you do not want to remember every flag:
+
+```bash
+site-audit serp-gap --menu
+```
+
+The menu asks for the audited domain, target URL or URL pattern, keyword mode,
+SERP provider, country/language, dry-run choice, and optional advanced toggles.
+Each prompt includes a short description of what the feature does.
+
 ### Common SERP gap examples
 
 Single URL with manual keywords:
@@ -895,6 +905,30 @@ site-audit serp-gap www.liveagent.com \
   --language en
 ```
 
+Run URL-only with the AI agent. The agent uses OpenRouter to infer target
+keywords from the page and then writes paragraph-level TODO markdown after the
+SERP gap analysis:
+
+`.env` content:
+
+```dotenv
+OPENROUTER_API_KEY="sk-or-v1-..."
+OPENROUTER_MODEL="deepseek/deepseek-v4-pro"
+```
+
+```bash
+site-audit serp-gap www.liveagent.com \
+  --url https://www.liveagent.com/blog/ai-support-paradox/ \
+  --provider dataforseo \
+  --country 2840 \
+  --language en
+```
+
+Use `--no-ai-agent` to skip OpenRouter/Harnext calls, or
+`--ai-agent-refresh` to ignore cached AI prompts and completions. The AI agent
+is cache-first and stores prompts/completions under
+`projects/<domain>/cache/serp_gap/ai_agent/`.
+
 Enrich keyword demand with Ahrefs traffic and volume when configured:
 
 ```bash
@@ -935,6 +969,10 @@ projects/www.liveagent.com/serp_gap/report/blog-ai-support-paradox/index.html
 
 The report is action-first: it opens with page content briefs, prioritized
 content tasks, paragraph rules, acceptance criteria, and AI-agent prompts.
+When `OPENROUTER_API_KEY` is configured, it also includes an AI-authored TODO
+brief per analyzed URL with keep/rewrite/move/merge/remove decisions, missing
+sections to add, recommended paragraph order, draft copy, and acceptance
+criteria. The same brief is written to `serp_gap_todo.md`.
 The diagnostic evidence is still available behind expandable sections:
 keyword-level semantic scatterplots, domain-colored competitor points,
 topic clusters, missing/partial topic tables, top ranking URLs, keyword/API

--- a/docs/report-sections.md
+++ b/docs/report-sections.md
@@ -353,6 +353,27 @@ Groups paragraphs across the site by topic.
 
 Action: identify duplicated themes, missing hubs, scattered topics, and paragraphs that should be consolidated.
 
+<a id="para-treemap-block"></a>
+## Paragraph topic mass treemap
+
+Shows which paragraph clusters take up the most content space.
+
+Action: inspect oversized or fragmented clusters and decide whether to consolidate, split, or strengthen those topic areas.
+
+<a id="para-heatmap-block"></a>
+## Paragraph topic overlap heatmap
+
+Compares semantic similarity between paragraph-cluster centroids.
+
+Action: merge or clarify clusters that are strongly overlapping, and keep clearly separated topics on distinct pages or sections.
+
+<a id="para-relations-block"></a>
+## Paragraph topic relation views
+
+Shows paragraph-cluster relationships as network, hierarchy, centroid, chord, and section-flow views.
+
+Action: use these views to find topic families, isolated themes, and site sections that carry the same paragraph-level topics.
+
 <a id="fanout-block"></a>
 ## Query to paragraph fanout
 

--- a/docs/serp-gap-command.md
+++ b/docs/serp-gap-command.md
@@ -15,6 +15,16 @@ site-audit run www.example.com --search-provider all
 Then run SERP gap analysis for a page or URL pattern:
 
 ```bash
+site-audit serp-gap --menu
+```
+
+The guided CLI menu explains each option, asks for the audited domain, target
+URL or URL pattern, keyword mode, SERP provider, country/language, and optional
+advanced toggles, then prints the equivalent command before executing it.
+
+Direct command example:
+
+```bash
 site-audit serp-gap www.example.com \
   --url https://www.example.com/live-chat-software/ \
   --keyword-source file \
@@ -118,6 +128,53 @@ file
 
 Use `--keyword-source file` when you pass `--keyword` or
 `--keywords-file` and want those explicit keywords to drive the run.
+
+### AI-Agent Keyword Selection And TODO Briefs
+
+By default, `serp-gap` enables an OpenRouter-backed AI-agent layer. Existing
+keyword sources still run first. If a selected URL has no usable keyword rows,
+the agent inspects the page title, H1, headings, paragraphs, and any existing
+search rows to infer target keywords before SERP analysis begins.
+
+Configure OpenRouter in `.env` or through `site-audit settings`:
+
+```bash
+OPENROUTER_API_KEY="sk-or-v1-..."
+OPENROUTER_MODEL="deepseek/deepseek-v4-pro"
+```
+
+The `.env` file is ignored by git. In an interactive terminal, `serp-gap` can
+also prompt for `OPENROUTER_API_KEY` on first execution and write it to `.env`.
+
+URL-only example:
+
+```bash
+site-audit serp-gap www.liveagent.com \
+  --url https://www.liveagent.com/blog/ai-support-paradox/ \
+  --provider dataforseo \
+  --country 2840 \
+  --language en
+```
+
+After analysis, the agent generates a page-specific markdown brief with:
+
+- exact keep, rewrite, move, merge, or remove decisions for weak paragraphs
+- missing sections to add when competitors consistently cover them
+- recommended content order based on semantic path evidence
+- original draft copy for new or rewritten sections
+- acceptance criteria for an editor or AI coding/content agent
+
+Prompts and completions are cached under:
+
+```text
+projects/<domain>/cache/serp_gap/ai_agent/
+```
+
+Use `--ai-agent-provider openrouter` to bypass the Harnext SDK wrapper,
+`--no-ai-agent` to disable AI calls, and `--ai-agent-refresh` to regenerate
+cached prompts/completions. If `OPENROUTER_API_KEY` is absent, the report states
+that the provider is missing and uses title/H1 fallback keywords instead of
+fabricating demand metrics.
 
 To expand explicit keywords with SERP-discovered related questions and
 searches, enable:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ dependencies = [
 dev = [
   "pytest>=8.0.0",
 ]
+agent = [
+  "harnext",
+]
 
 [project.urls]
 Homepage = "https://github.com/vzeman/site-audit"

--- a/site_audit/ai_agent.py
+++ b/site_audit/ai_agent.py
@@ -1,0 +1,477 @@
+"""AI-agent helpers for report-to-edit workflows.
+
+The module keeps provider details outside the analysis pipeline. OpenRouter is
+the required runtime provider; Harnext is attempted as an optional orchestration
+SDK when selected, with a direct OpenRouter fallback so existing installs keep
+working before the optional package is installed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+import requests
+
+from .cache import content_hash
+from .config_env import load_dotenv
+
+
+DEFAULT_OPENROUTER_MODEL = "deepseek/deepseek-v4-pro"
+OPENROUTER_CHAT_URL = "https://openrouter.ai/api/v1/chat/completions"
+
+
+class MissingOpenRouterKey(RuntimeError):
+    """Raised when an agent call is requested without an OpenRouter key."""
+
+
+class AgentClient(Protocol):
+    provider: str
+
+    def complete(
+        self,
+        messages: list[dict[str, str]],
+        *,
+        model: str,
+        temperature: float = 0.2,
+        timeout: int = 120,
+    ) -> "AgentCompletion":
+        ...
+
+
+@dataclass
+class AgentCompletion:
+    text: str
+    provider: str
+    model: str
+    cache_status: str = "miss"
+    fallback_from: str = ""
+    raw: dict[str, Any] | None = None
+
+
+class OpenRouterClient:
+    provider = "openrouter"
+
+    def __init__(self, api_key: str | None = None) -> None:
+        self.api_key = api_key or openrouter_api_key()
+
+    def complete(
+        self,
+        messages: list[dict[str, str]],
+        *,
+        model: str,
+        temperature: float = 0.2,
+        timeout: int = 120,
+    ) -> AgentCompletion:
+        if not self.api_key:
+            raise MissingOpenRouterKey("Set OPENROUTER_API_KEY in .env or the environment.")
+        payload = {
+            "model": model,
+            "messages": messages,
+            "temperature": temperature,
+        }
+        response = requests.post(
+            OPENROUTER_CHAT_URL,
+            headers={
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json",
+                "HTTP-Referer": "https://github.com/vzeman/site-audit",
+                "X-Title": "site-audit",
+            },
+            json=payload,
+            timeout=timeout,
+        )
+        if response.status_code >= 400:
+            message = response.text[:500]
+            raise RuntimeError(f"OpenRouter request failed with HTTP {response.status_code}: {message}")
+        data = response.json()
+        choices = data.get("choices") or []
+        text = ""
+        if choices:
+            message = choices[0].get("message") or {}
+            text = str(message.get("content") or "").strip()
+        if not text:
+            raise RuntimeError("OpenRouter returned an empty completion.")
+        return AgentCompletion(text=text, provider=self.provider, model=model, raw=data)
+
+
+class HarnextOpenRouterClient:
+    provider = "harnext"
+
+    def __init__(self, api_key: str | None = None) -> None:
+        self.api_key = api_key or openrouter_api_key()
+
+    def complete(
+        self,
+        messages: list[dict[str, str]],
+        *,
+        model: str,
+        temperature: float = 0.2,
+        timeout: int = 120,
+    ) -> AgentCompletion:
+        if not self.api_key:
+            raise MissingOpenRouterKey("Set OPENROUTER_API_KEY in .env or the environment.")
+        try:
+            completion = self._complete_with_harnext(messages, model=model, temperature=temperature, timeout=timeout)
+            completion.provider = self.provider
+            return completion
+        except Exception as exc:
+            fallback = OpenRouterClient(api_key=self.api_key).complete(
+                messages,
+                model=model,
+                temperature=temperature,
+                timeout=timeout,
+            )
+            fallback.fallback_from = f"harnext: {exc.__class__.__name__}"
+            return fallback
+
+    def _complete_with_harnext(
+        self,
+        messages: list[dict[str, str]],
+        *,
+        model: str,
+        temperature: float,
+        timeout: int,
+    ) -> AgentCompletion:
+        from harnext import Harnext  # type: ignore
+
+        prompt = messages_to_prompt(messages)
+        agent = Harnext(
+            provider="openrouter",
+            model=model,
+            api_key=self.api_key,
+            temperature=temperature,
+            timeout=timeout,
+        )
+        result = agent.run(prompt)
+        text = _completion_text(result)
+        if not text:
+            raise RuntimeError("Harnext returned an empty completion.")
+        return AgentCompletion(text=text, provider=self.provider, model=model, raw={"result": text})
+
+
+def openrouter_api_key() -> str:
+    load_dotenv()
+    return os.getenv("OPENROUTER_API_KEY", "").strip()
+
+
+def openrouter_model(default: str = DEFAULT_OPENROUTER_MODEL) -> str:
+    load_dotenv()
+    return os.getenv("OPENROUTER_MODEL", "").strip() or default
+
+
+def build_agent_client(provider: str = "harnext", api_key: str | None = None) -> AgentClient:
+    normalized = (provider or "harnext").strip().lower()
+    if normalized == "openrouter":
+        return OpenRouterClient(api_key=api_key)
+    if normalized == "harnext":
+        return HarnextOpenRouterClient(api_key=api_key)
+    raise ValueError(f"Unsupported AI agent provider: {provider}")
+
+
+def messages_to_prompt(messages: list[dict[str, str]]) -> str:
+    parts = []
+    for message in messages:
+        role = str(message.get("role") or "user").upper()
+        content = str(message.get("content") or "").strip()
+        if content:
+            parts.append(f"{role}:\n{content}")
+    return "\n\n".join(parts)
+
+
+def cached_completion(
+    cache_dir: Path,
+    *,
+    kind: str,
+    messages: list[dict[str, str]],
+    client: AgentClient,
+    model: str,
+    refresh: bool = False,
+    temperature: float = 0.2,
+    timeout: int = 120,
+) -> AgentCompletion:
+    root = cache_dir / "ai_agent" / _safe_name(kind)
+    root.mkdir(parents=True, exist_ok=True)
+    key = content_hash(json.dumps({"kind": kind, "model": model, "messages": messages}, sort_keys=True))
+    prompt_path = root / f"{key}.prompt.json"
+    output_path = root / f"{key}.completion.json"
+    prompt_path.write_text(
+        json.dumps(
+            {
+                "kind": kind,
+                "model": model,
+                "provider": getattr(client, "provider", ""),
+                "messages": messages,
+                "created_at": time.time(),
+            },
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    if output_path.is_file() and not refresh:
+        payload = json.loads(output_path.read_text(encoding="utf-8"))
+        return AgentCompletion(
+            text=str(payload.get("text") or ""),
+            provider=str(payload.get("provider") or getattr(client, "provider", "")),
+            model=str(payload.get("model") or model),
+            cache_status="hit",
+            fallback_from=str(payload.get("fallback_from") or ""),
+            raw=payload.get("raw") if isinstance(payload.get("raw"), dict) else None,
+        )
+    completion = client.complete(messages, model=model, temperature=temperature, timeout=timeout)
+    completion.cache_status = "miss"
+    output_path.write_text(
+        json.dumps(
+            {
+                "text": completion.text,
+                "provider": completion.provider,
+                "model": completion.model,
+                "fallback_from": completion.fallback_from,
+                "raw": completion.raw or {},
+                "created_at": time.time(),
+            },
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return completion
+
+
+def build_keyword_messages(page: dict, *, max_keywords: int = 5) -> list[dict[str, str]]:
+    page_payload = {
+        "url": page.get("url", ""),
+        "title": page.get("title", ""),
+        "h1": page.get("h1", ""),
+        "description": page.get("description", ""),
+        "section": page.get("section", ""),
+        "headers": (page.get("headers") or [])[:20],
+        "paragraphs": (page.get("paragraphs") or [])[:12],
+        "known_search_rows": (page.get("search_rows") or [])[:20],
+    }
+    return [
+        {
+            "role": "system",
+            "content": (
+                "You select search keywords for a single URL before SERP gap analysis. "
+                "Use only evidence from the page and supplied search rows. Prefer phrases with clear intent. "
+                "Do not invent demand metrics. Return compact JSON only."
+            ),
+        },
+        {
+            "role": "user",
+            "content": (
+                f"Pick up to {max_keywords} target keywords for this URL. "
+                "Prioritize terms the page can realistically rank for and that match the main intent. "
+                "Return exactly this JSON shape: "
+                '{"keywords":[{"keyword":"phrase","intent":"why this matches","priority":1}]}\n\n'
+                f"Evidence:\n{json.dumps(page_payload, ensure_ascii=False, indent=2)}"
+            ),
+        },
+    ]
+
+
+def parse_keyword_candidates(text: str, *, limit: int = 5) -> list[str]:
+    candidates: list[str] = []
+    payload = _extract_json(text)
+    if isinstance(payload, dict):
+        raw_items = payload.get("keywords") or payload.get("queries") or payload.get("terms") or []
+    elif isinstance(payload, list):
+        raw_items = payload
+    else:
+        raw_items = []
+    for item in raw_items:
+        if isinstance(item, dict):
+            value = item.get("keyword") or item.get("query") or item.get("term")
+        else:
+            value = item
+        _append_keyword_candidate(candidates, str(value or ""), limit)
+    if not candidates:
+        for line in str(text or "").splitlines():
+            stripped = re.sub(r"^\s*[-*0-9.)]+\s*", "", line).strip()
+            if ":" in stripped:
+                stripped = stripped.split(":", 1)[-1].strip()
+            _append_keyword_candidate(candidates, stripped, limit)
+            if len(candidates) >= limit:
+                break
+    return candidates[:limit]
+
+
+def fallback_keyword_candidates(page: dict, *, limit: int = 5) -> list[str]:
+    values = [
+        page.get("h1"),
+        page.get("title"),
+        page.get("section"),
+    ]
+    values.extend(page.get("headers") or [])
+    out: list[str] = []
+    for value in values:
+        text = re.sub(r"\s+[-|:]\s+.*$", "", str(value or "")).strip()
+        text = re.sub(r"\s+", " ", text)
+        _append_keyword_candidate(out, text, limit)
+        if len(out) >= limit:
+            break
+    return out[:limit]
+
+
+def build_editor_brief_messages(page: dict) -> list[dict[str, str]]:
+    payload = _editor_prompt_payload(page)
+    return [
+        {
+            "role": "system",
+            "content": (
+                "You are a senior SEO editor writing implementation instructions for one analyzed URL. "
+                "Be precise, evidence-led, and URL-specific. No generic SEO advice, no ballast, no duplicate tasks, "
+                "and no copied competitor wording. Do not copy competitor wording. Separate evidence, actions, and draft copy."
+            ),
+        },
+        {
+            "role": "user",
+            "content": (
+                "Create a markdown TODO brief for an AI coding/content agent. "
+                "Use this exact structure and keep each bullet actionable:\n"
+                "# AI Agent TODO\n"
+                "## Evidence\n"
+                "## Paragraph Decisions\n"
+                "## Sections To Add Or Expand\n"
+                "## Recommended Content Order\n"
+                "## Draft Copy\n"
+                "## Acceptance Criteria\n\n"
+                "For existing paragraphs, say keep, rewrite, move, merge, or remove. "
+                "For missing competitor-covered topics, write the actual original draft copy that should be added. "
+                "If impressions, clicks, traffic, or volume are absent, say demand metrics absent instead of guessing. "
+                "Do not repeat the same instruction in multiple sections.\n\n"
+                f"Evidence JSON:\n{json.dumps(payload, ensure_ascii=False, indent=2)}"
+            ),
+        },
+    ]
+
+
+def _editor_prompt_payload(page: dict) -> dict:
+    actions = sorted(page.get("action_points") or [], key=lambda row: -float(row.get("impact_score") or 0))[:18]
+    analyses = []
+    for analysis in page.get("analyses") or []:
+        keyword = analysis.get("keyword") or {}
+        topics = [
+            {
+                "label": topic.get("label"),
+                "coverage": topic.get("coverage"),
+                "priority": topic.get("priority"),
+                "competitor_coverage": topic.get("competitor_coverage"),
+                "our_best_similarity": topic.get("our_best_similarity"),
+                "example_url": ((topic.get("examples") or [{}])[0]).get("url", ""),
+                "example_paragraph": ((topic.get("examples") or [{}])[0]).get("paragraph", "")[:320],
+            }
+            for topic in (analysis.get("topics") or [])[:12]
+        ]
+        paragraph_rows = []
+        for row in (analysis.get("paragraph_match_heatmap") or {}).get("rows") or []:
+            paragraph_rows.append({
+                "paragraph_index": row.get("paragraph_index"),
+                "best_similarity": row.get("max_similarity"),
+                "paragraph": str(row.get("paragraph") or "")[:320],
+                "best_competitor_url": row.get("best_competitor_url", ""),
+                "best_competitor_paragraph": str(row.get("best_competitor_paragraph") or "")[:320],
+            })
+        analyses.append({
+            "keyword": keyword.get("keyword") or analysis.get("query", ""),
+            "keyword_metrics": {
+                "source": keyword.get("source", ""),
+                "position": keyword.get("position", 0),
+                "impressions": keyword.get("impressions", 0),
+                "clicks": keyword.get("clicks", 0),
+                "traffic": keyword.get("traffic", 0),
+                "volume": keyword.get("volume", 0),
+                "metrics_source": keyword.get("metrics_source", ""),
+            },
+            "visual_summary": analysis.get("visual_summary") or [],
+            "summary": analysis.get("summary") or {},
+            "topics": topics,
+            "content_order_path": (analysis.get("content_order_path") or {}).get("summary", {}),
+            "paragraph_review": paragraph_rows[:10],
+        })
+    return {
+        "url": page.get("url", ""),
+        "title": page.get("title", ""),
+        "h1": page.get("h1", ""),
+        "keywords": page.get("keywords") or [],
+        "content_brief": page.get("content_brief") or {},
+        "actions": [
+            {
+                "priority": action.get("priority", ""),
+                "type": action.get("type", ""),
+                "keyword": action.get("keyword", ""),
+                "topic": action.get("topic", ""),
+                "task_summary": action.get("task_summary", ""),
+                "instruction": action.get("instruction", ""),
+                "placement": action.get("placement", ""),
+                "acceptance_criteria": action.get("acceptance_criteria") or [],
+                "evidence": action.get("evidence") or {},
+            }
+            for action in actions
+        ],
+        "analyses": analyses,
+    }
+
+
+def _extract_json(text: str) -> Any:
+    raw = str(text or "").strip()
+    if not raw:
+        return None
+    for candidate in [raw, _slice_between(raw, "{", "}"), _slice_between(raw, "[", "]")]:
+        if not candidate:
+            continue
+        try:
+            return json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+    return None
+
+
+def _slice_between(text: str, start: str, end: str) -> str:
+    left = text.find(start)
+    right = text.rfind(end)
+    if left < 0 or right < left:
+        return ""
+    return text[left:right + 1]
+
+
+def _append_keyword_candidate(out: list[str], value: str, limit: int) -> None:
+    normalized = re.sub(r"\s+", " ", value).strip().strip("\"'`.,;:")
+    normalized = re.sub(r"\s+-\s+.*$", "", normalized).strip()
+    if not normalized or "://" in normalized or len(normalized) > 90:
+        return
+    if len(normalized.split()) > 9:
+        return
+    key = normalized.lower()
+    if key in {item.lower() for item in out}:
+        return
+    out.append(normalized)
+    if len(out) > limit:
+        del out[limit:]
+
+
+def _completion_text(result: Any) -> str:
+    if isinstance(result, str):
+        return result.strip()
+    for attr in ("text", "output", "content", "message"):
+        value = getattr(result, attr, None)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    if isinstance(result, dict):
+        for key in ("text", "output", "content", "message"):
+            value = result.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return str(result or "").strip()
+
+
+def _safe_name(value: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9_.-]+", "-", str(value or "").strip().lower()).strip("-")
+    return slug or "completion"

--- a/site_audit/cli.py
+++ b/site_audit/cli.py
@@ -11,10 +11,12 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import shlex
 import sys
 from pathlib import Path
 
 from . import __version__
+from .ai_agent import DEFAULT_OPENROUTER_MODEL, openrouter_model
 from . import compare as _compare
 from .cache import domain_slug
 from .config_env import apply_env_defaults
@@ -235,9 +237,13 @@ def _compare_command(args: argparse.Namespace) -> int:
 
 
 def _serp_gap_command(args: argparse.Namespace) -> int:
+    if getattr(args, "menu", False):
+        if not _run_serp_gap_menu(args):
+            return 0
     if not args.domain:
         print("serp-gap needs a domain.")
         return 1
+    _maybe_prompt_openrouter_key(args)
     config = SerpGapConfig(
         domain=args.domain,
         projects_root=Path(args.projects_root),
@@ -274,6 +280,10 @@ def _serp_gap_command(args: argparse.Namespace) -> int:
         refresh_competitors=args.refresh_competitors,
         budget_usd=args.budget_usd,
         dry_run=args.dry_run,
+        ai_agent=args.ai_agent,
+        ai_agent_provider=args.ai_agent_provider,
+        ai_agent_model=_resolved_ai_agent_model(args.ai_agent_model),
+        ai_agent_refresh=args.ai_agent_refresh,
     )
     payload = run_serp_gap(config)
     status = payload.get("status", "unknown")
@@ -295,7 +305,14 @@ def _serp_gap_command(args: argparse.Namespace) -> int:
     print(f"  URLs downloaded:     {summary.get('urls_downloaded', 0)}")
     print(f"  competitor URLs est: {summary.get('competitor_urls_estimated', 0)}")
     print(f"  missing topics:      {summary.get('missing_topics', 0)}")
+    agent = payload.get("ai_agent") or {}
+    if agent.get("enabled"):
+        print(
+            f"  AI agent:            {agent.get('status', '')} · "
+            f"{agent.get('provider', '')} · {agent.get('editor_briefs', 0)} editor brief(s)"
+        )
     print(f"  report JSON:         {out_dir / 'serp_gap.json'}")
+    print(f"  TODO markdown:       {out_dir / 'serp_gap_todo.md'}")
     print(f"  HTML report:         {out_dir / 'index.html'}")
     return 0 if status in {"ok", "dry_run"} else 1
 
@@ -320,6 +337,341 @@ def _serve_command(args: argparse.Namespace) -> int:
         port=args.port,
     )
     return 0
+
+
+def _maybe_prompt_openrouter_key(args: argparse.Namespace) -> None:
+    if not getattr(args, "ai_agent", False) or getattr(args, "dry_run", False):
+        return
+    if not getattr(args, "ai_agent_interactive_setup", True):
+        return
+    if not (sys.stdin.isatty() and sys.stdout.isatty()):
+        return
+    import getpass
+    import os
+
+    from .config_env import load_dotenv, update_env_file
+
+    load_dotenv()
+    if os.getenv("OPENROUTER_API_KEY", "").strip():
+        return
+    print("OPENROUTER_API_KEY is required for AI-authored serp-gap keyword selection and editor briefs.")
+    key = getpass.getpass("Paste OpenRouter API key (hidden, leave empty to skip AI calls): ").strip()
+    if not key:
+        return
+    env_file = Path(".env")
+    updates = {"OPENROUTER_API_KEY": key}
+    model = _resolved_ai_agent_model(getattr(args, "ai_agent_model", DEFAULT_OPENROUTER_MODEL))
+    if model:
+        updates["OPENROUTER_MODEL"] = model
+    update_env_file(env_file, updates)
+    os.environ["OPENROUTER_API_KEY"] = key
+    if updates.get("OPENROUTER_MODEL"):
+        os.environ["OPENROUTER_MODEL"] = updates["OPENROUTER_MODEL"]
+    print(f"Saved OpenRouter settings to {env_file}.")
+
+
+def _resolved_ai_agent_model(value: str) -> str:
+    if value == DEFAULT_OPENROUTER_MODEL:
+        return openrouter_model(DEFAULT_OPENROUTER_MODEL)
+    return value
+
+
+def _run_serp_gap_menu(args: argparse.Namespace) -> bool:
+    print("\nSERP Gap guided setup")
+    print("Answer the prompts below. Press Enter to keep the shown default.\n")
+
+    args.domain = _menu_text(
+        "Audited domain",
+        "Domain with an existing projects/<domain>/report/pages.json. Run `site-audit run` first.",
+        args.domain or "",
+        required=True,
+    )
+    if not args.domain:
+        print("No domain selected.")
+        return False
+
+    scope = _menu_choice(
+        "Target scope",
+        "Choose whether to analyze one exact URL or a group of audited URLs.",
+        [
+            ("url", "Exact URL", "Best for page-level recommendations and URL-specific TODO markdown."),
+            ("pattern", "URL pattern", "Use a path glob/regex such as /features/* to analyze multiple audited pages."),
+        ],
+        default="url" if not args.url_include else "pattern",
+    )
+    if scope == "url":
+        url_default = args.url[0] if args.url else ""
+        url = _menu_text("Exact URL", "Full URL to analyze. The report directory is based on this path.", url_default, required=True)
+        args.url = [url] if url else []
+        args.url_include = []
+        args.url_exclude = []
+    else:
+        include_default = args.url_include[0] if args.url_include else ""
+        exclude_default = args.url_exclude[0] if args.url_exclude else ""
+        include = _menu_text("URL include pattern", "Path glob or regex, for example /features/*.", include_default, required=True)
+        exclude = _menu_text("URL exclude pattern", "Optional path glob/regex to skip unwanted URLs.", exclude_default)
+        args.url = []
+        args.url_include = [include] if include else []
+        args.url_exclude = [exclude] if exclude else []
+
+    keyword_mode = _menu_choice(
+        "Keyword selection",
+        "Controls which search terms drive SERP fetching and competitor comparison.",
+        [
+            ("ai", "AI auto keywords", "Recommended for URL-only runs. Uses page content/search rows, then OpenRouter agent if available."),
+            ("manual", "Manual keywords", "Use when you already know the exact terms the page should rank for."),
+            ("search", "Existing search data", "Use GSC/Ahrefs/DataForSEO/Google Ads rows from the base audit."),
+            ("h1", "Title/H1 only", "Cheap fallback using the page title or H1 as a synthetic keyword."),
+        ],
+        default="ai" if args.ai_agent else "search",
+    )
+    if keyword_mode == "ai":
+        args.keyword_source = "auto"
+        args.keyword = []
+        args.ai_agent = True
+    elif keyword_mode == "manual":
+        args.keyword_source = "file"
+        args.keyword = _menu_list(
+            "Manual keywords",
+            "Enter comma-separated keywords. Keep this focused; each keyword triggers SERP and competitor work.",
+            args.keyword,
+            required=True,
+        )
+    elif keyword_mode == "search":
+        args.keyword_source = _menu_choice(
+            "Search data source",
+            "Pick a specific source or keep auto to use the best available rows.",
+            [
+                ("auto", "Auto", "Use any available search rows."),
+                ("gsc", "Google Search Console", "Uses impressions/clicks/position from GSC exports."),
+                ("ahrefs", "Ahrefs", "Uses organic keyword rows when Ahrefs is configured."),
+                ("dataforseo", "DataForSEO", "Uses DataForSEO keyword rows from the base audit."),
+                ("google_ads", "Google Ads", "Uses paid query rows from the base audit."),
+            ],
+            default=args.keyword_source if args.keyword_source in {"auto", "gsc", "ahrefs", "dataforseo", "google_ads"} else "auto",
+        )
+        args.keyword = []
+    else:
+        args.keyword_source = "h1"
+        args.keyword = []
+        args.use_h1_keyword = True
+
+    args.provider = _menu_choice(
+        "SERP provider",
+        "Provider used to fetch live Google results for selected keywords.",
+        [
+            ("auto", "Auto", "Use Serper if configured, otherwise DataForSEO."),
+            ("dataforseo", "DataForSEO", "Best when you need country/location codes and reliable SERP payloads."),
+            ("serper", "Serper", "Simple Google SERP API when SERPER_API_KEY is configured."),
+        ],
+        default=args.provider,
+    )
+    args.country = _menu_text(
+        "Country / location",
+        "Optional. For DataForSEO use a location code such as 2840 for United States.",
+        args.country or ("2840" if args.provider == "dataforseo" else ""),
+    ) or None
+    args.language = _menu_text("Language", "Optional SERP language code, for example en.", args.language or "en") or None
+
+    args.dry_run = _menu_bool(
+        "Dry run",
+        "Writes selected pages/keywords and cost plan without calling SERP providers or fetching competitors.",
+        args.dry_run,
+    )
+
+    advanced = _menu_bool(
+        "Show advanced options",
+        "Enable this to tune limits, keyword expansion, Ahrefs metrics, cache refresh, and AI-provider settings.",
+        False,
+    )
+    if advanced:
+        args.keywords_per_page = _menu_int(
+            "Keywords per page",
+            "Caps analysis cost and keeps each page focused on the strongest target terms.",
+            args.keywords_per_page,
+        )
+        args.results_per_keyword = _menu_int(
+            "Results per keyword",
+            "How many top organic competitors to fetch and compare for each keyword.",
+            args.results_per_keyword,
+        )
+        args.max_pages = _menu_int(
+            "Max selected pages",
+            "Safety limit for URL pattern runs.",
+            args.max_pages,
+        )
+        args.max_competitor_pages = _menu_int(
+            "Max competitor pages",
+            "Global cap on external competitor pages downloaded in one run.",
+            args.max_competitor_pages,
+        )
+        args.include_serp_keyword_suggestions = _menu_bool(
+            "Add SERP keyword suggestions",
+            "Also analyze People Also Ask/Search suggestions. Useful for topic discovery, but increases cost.",
+            args.include_serp_keyword_suggestions,
+        )
+        args.use_ahrefs_metrics = _menu_bool(
+            "Use Ahrefs metrics",
+            "Attaches Ahrefs position, traffic, and volume when AHREFS_API_KEY is configured.",
+            args.use_ahrefs_metrics,
+        )
+        if args.use_ahrefs_metrics:
+            args.ahrefs_country = _menu_text("Ahrefs country", "Optional country database such as US, GB, or SK.", args.ahrefs_country or "") or None
+            args.ahrefs_refresh = _menu_bool("Refresh Ahrefs cache", "Fetch a fresh Ahrefs snapshot instead of reusing compatible cache.", args.ahrefs_refresh)
+        args.ai_agent = _menu_bool(
+            "Enable AI agent",
+            "Infers URL keywords and writes paragraph-level markdown TODO briefs with draft copy.",
+            args.ai_agent,
+        )
+        if args.ai_agent:
+            args.ai_agent_provider = _menu_choice(
+                "AI agent provider",
+                "Harnext uses the SDK wrapper; OpenRouter direct skips the wrapper. Both require OPENROUTER_API_KEY.",
+                [
+                    ("harnext", "Harnext", "Default orchestration wrapper with direct OpenRouter fallback."),
+                    ("openrouter", "OpenRouter direct", "Call OpenRouter chat completions directly."),
+                ],
+                default=args.ai_agent_provider,
+            )
+            args.ai_agent_model = _menu_text(
+                "AI agent model",
+                "OpenRouter model that writes keyword and paragraph-level recommendations.",
+                args.ai_agent_model or DEFAULT_OPENROUTER_MODEL,
+            )
+            args.ai_agent_refresh = _menu_bool(
+                "Refresh AI completions",
+                "Ignore cached agent completions and request new output from the provider.",
+                args.ai_agent_refresh,
+            )
+        args.refresh_serp = _menu_bool("Refresh SERP cache", "Call the SERP provider even when cached SERP payloads exist.", args.refresh_serp)
+        args.refresh_competitors = _menu_bool("Refresh competitor pages", "Refetch competitor HTML instead of reusing cached copies.", args.refresh_competitors)
+        args.budget_usd = _menu_float("Budget cap USD", "Optional estimated SERP API budget cap. Leave empty for no cap.", args.budget_usd)
+
+    print("\nEquivalent CLI command:")
+    print("  " + _serp_gap_command_preview(args))
+    return _menu_bool("Run now", "Executes the command with the settings above.", True)
+
+
+def _menu_text(label: str, description: str, default: str = "", *, required: bool = False) -> str:
+    print(f"\n{label}")
+    print(f"  {description}")
+    while True:
+        suffix = f" [{default}]" if default else ""
+        value = input(f"  Value{suffix}: ").strip() or default
+        if value or not required:
+            return value
+        print("  This value is required.")
+
+
+def _menu_list(label: str, description: str, default: list[str] | None = None, *, required: bool = False) -> list[str]:
+    current = ", ".join(default or [])
+    raw = _menu_text(label, description, current, required=required)
+    return [part.strip() for part in raw.replace("\n", ",").split(",") if part.strip()]
+
+
+def _menu_choice(label: str, description: str, choices: list[tuple[str, str, str]], *, default: str) -> str:
+    print(f"\n{label}")
+    print(f"  {description}")
+    default_index = next((i for i, item in enumerate(choices, start=1) if item[0] == default), 1)
+    for index, (_, name, help_text) in enumerate(choices, start=1):
+        marker = "*" if index == default_index else " "
+        print(f"  {index}. [{marker}] {name} - {help_text}")
+    while True:
+        raw = input(f"  Choose 1-{len(choices)} [{default_index}]: ").strip()
+        if not raw:
+            return choices[default_index - 1][0]
+        try:
+            index = int(raw)
+        except ValueError:
+            index = 0
+        if 1 <= index <= len(choices):
+            return choices[index - 1][0]
+        print("  Enter a valid number.")
+
+
+def _menu_bool(label: str, description: str, default: bool) -> bool:
+    state = "[x]" if default else "[ ]"
+    print(f"\n{state} {label}")
+    print(f"  {description}")
+    raw = input(f"  Enable? [{'Y/n' if default else 'y/N'}]: ").strip().lower()
+    if not raw:
+        return default
+    return raw in {"1", "y", "yes", "true", "on"}
+
+
+def _menu_int(label: str, description: str, default: int) -> int:
+    while True:
+        raw = _menu_text(label, description, str(default))
+        try:
+            return int(raw)
+        except ValueError:
+            print("  Enter an integer.")
+
+
+def _menu_float(label: str, description: str, default: float | None) -> float | None:
+    raw = _menu_text(label, description, "" if default is None else str(default))
+    if not raw:
+        return None
+    try:
+        return float(raw)
+    except ValueError:
+        print("  Invalid number; leaving budget cap empty.")
+        return None
+
+
+def _serp_gap_command_preview(args: argparse.Namespace) -> str:
+    parts = ["site-audit", "serp-gap", args.domain or ""]
+    for url in args.url or []:
+        parts.extend(["--url", url])
+    for pattern in args.url_include or []:
+        parts.extend(["--url-include", pattern])
+    for pattern in args.url_exclude or []:
+        parts.extend(["--url-exclude", pattern])
+    parts.extend(["--keyword-source", args.keyword_source])
+    for keyword in args.keyword or []:
+        parts.extend(["--keyword", keyword])
+    parts.extend(["--provider", args.provider])
+    if args.country:
+        parts.extend(["--country", args.country])
+    if args.language:
+        parts.extend(["--language", args.language])
+    if args.keywords_per_page != 3:
+        parts.extend(["--keywords-per-page", str(args.keywords_per_page)])
+    if args.results_per_keyword != 5:
+        parts.extend(["--results-per-keyword", str(args.results_per_keyword)])
+    if args.max_pages != 20:
+        parts.extend(["--max-pages", str(args.max_pages)])
+    if args.max_competitor_pages != 100:
+        parts.extend(["--max-competitor-pages", str(args.max_competitor_pages)])
+    if args.use_h1_keyword:
+        parts.append("--use-h1-keyword")
+    if args.use_ahrefs_metrics:
+        parts.append("--use-ahrefs-metrics")
+    if args.ahrefs_refresh:
+        parts.append("--ahrefs-refresh")
+    if args.ahrefs_country:
+        parts.extend(["--ahrefs-country", args.ahrefs_country])
+    if args.include_serp_keyword_suggestions:
+        parts.append("--include-serp-keyword-suggestions")
+        if args.max_serp_keyword_suggestions != 8:
+            parts.extend(["--max-serp-keyword-suggestions", str(args.max_serp_keyword_suggestions)])
+    if not args.ai_agent:
+        parts.append("--no-ai-agent")
+    elif args.ai_agent_provider != "harnext":
+        parts.extend(["--ai-agent-provider", args.ai_agent_provider])
+    if args.ai_agent and args.ai_agent_model != DEFAULT_OPENROUTER_MODEL:
+        parts.extend(["--ai-agent-model", args.ai_agent_model])
+    if args.dry_run:
+        parts.append("--dry-run")
+    if args.budget_usd is not None:
+        parts.extend(["--budget-usd", str(args.budget_usd)])
+    if args.refresh_serp:
+        parts.append("--refresh-serp")
+    if args.refresh_competitors:
+        parts.append("--refresh-competitors")
+    if args.ai_agent_refresh:
+        parts.append("--ai-agent-refresh")
+    return " ".join(shlex.quote(str(part)) for part in parts if str(part))
 
 
 def _settings_command(args: argparse.Namespace) -> int:
@@ -572,8 +924,10 @@ def build_parser() -> argparse.ArgumentParser:
     cmp_p.set_defaults(func=_compare_command)
 
     serp_p = sub.add_parser("serp-gap", help="Analyze selected audited pages against live SERP competitors")
-    serp_p.add_argument("domain", help="Domain with an existing site-audit report")
+    serp_p.add_argument("domain", nargs="?", help="Domain with an existing site-audit report")
     serp_p.add_argument("--projects-root", default="projects")
+    serp_p.add_argument("--menu", action="store_true",
+                        help="Open an interactive terminal menu that explains and fills common SERP gap options")
     serp_p.add_argument("--model", default=DEFAULT_MODEL, help=f"Embedding model (default: {DEFAULT_MODEL})")
     serp_p.add_argument("--url", action="append", default=[],
                         help="Exact page URL to analyze even if it was not in pages.json; repeat for multiple URLs")
@@ -626,6 +980,17 @@ def build_parser() -> argparse.ArgumentParser:
     serp_p.add_argument("--budget-usd", type=float, default=None)
     serp_p.add_argument("--dry-run", action="store_true",
                         help="Write a plan without calling SERP providers or fetching competitors")
+    serp_p.add_argument("--ai-agent", action=argparse.BooleanOptionalAction, default=True,
+                        help="Use the OpenRouter-backed AI agent for URL-only keyword inference and editor TODO briefs")
+    serp_p.add_argument("--ai-agent-provider", default="harnext", choices=["harnext", "openrouter"],
+                        help="AI agent provider wrapper (default: harnext, with direct OpenRouter fallback)")
+    serp_p.add_argument("--ai-agent-model", default=DEFAULT_OPENROUTER_MODEL,
+                        help=f"OpenRouter model for AI-agent tasks (default: {DEFAULT_OPENROUTER_MODEL})")
+    serp_p.add_argument("--ai-agent-refresh", action="store_true",
+                        help="Ignore cached AI-agent prompts/completions and call the provider again")
+    serp_p.add_argument("--no-ai-agent-interactive-setup", dest="ai_agent_interactive_setup", action="store_false",
+                        help="Do not prompt for OPENROUTER_API_KEY in interactive runs")
+    serp_p.set_defaults(ai_agent_interactive_setup=True)
     serp_p.set_defaults(func=_serp_gap_command)
 
     serve_p = sub.add_parser("serve", help="Serve the local viewer for a previously-generated report")

--- a/site_audit/config_env.py
+++ b/site_audit/config_env.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 from pathlib import Path
 from typing import Any
 
@@ -37,7 +38,8 @@ def env_names(command: str | None, dest: str) -> list[str]:
     key = dest.upper()
     names = []
     if command:
-        names.append(f"SITE_AUDIT_{command.upper()}_{key}")
+        command_key = re.sub(r"[^A-Z0-9]+", "_", command.upper()).strip("_")
+        names.append(f"SITE_AUDIT_{command_key}_{key}")
     names.append(f"SITE_AUDIT_{key}")
     return names
 

--- a/site_audit/serp_gap.py
+++ b/site_audit/serp_gap.py
@@ -22,6 +22,17 @@ from urllib.parse import urlparse
 import numpy as np
 import requests
 
+from .ai_agent import (
+    DEFAULT_OPENROUTER_MODEL,
+    MissingOpenRouterKey,
+    build_agent_client,
+    build_editor_brief_messages,
+    build_keyword_messages,
+    cached_completion,
+    fallback_keyword_candidates,
+    openrouter_api_key,
+    parse_keyword_candidates,
+)
 from .analyzer import PageInfo, section_for_url
 from .cache import HttpCache, content_hash, domain_slug
 from .competitive_analysis import (
@@ -93,6 +104,10 @@ class SerpGapConfig:
     refresh_competitors: bool = False
     budget_usd: float | None = None
     dry_run: bool = False
+    ai_agent: bool = True
+    ai_agent_provider: str = "harnext"
+    ai_agent_model: str = DEFAULT_OPENROUTER_MODEL
+    ai_agent_refresh: bool = False
 
 
 def run(config: SerpGapConfig) -> dict:
@@ -110,6 +125,8 @@ def run(config: SerpGapConfig) -> dict:
 
     cache_dir = project_dir / "cache" / "serp_gap"
     cache_dir.mkdir(parents=True, exist_ok=True)
+    own_cache = HttpCache(project_dir / "cache" / "http.sqlite")
+    ai_agent = _ai_agent_state(config)
 
     selected_pages, skipped_pages = _select_pages(pages, config)
     report_root = project_dir / "serp_gap" / "report"
@@ -128,6 +145,26 @@ def run(config: SerpGapConfig) -> dict:
         manual_keywords,
         config,
     )
+    ai_keyword_rows, ai_keyword_skips = _ai_agent_keyword_rows(
+        selected_pages,
+        keyword_rows,
+        search_payload,
+        own_cache,
+        cache_dir,
+        config,
+        ai_agent,
+    )
+    if ai_keyword_rows:
+        generated_urls = {row.get("url", "") for row in ai_keyword_rows}
+        skipped_keywords = [
+            row for row in skipped_keywords
+            if not (
+                row.get("reason") == "no ranking keywords"
+                and any(_same_url(row.get("url", ""), url) for url in generated_urls)
+            )
+        ]
+        keyword_rows.extend(ai_keyword_rows)
+    skipped_keywords.extend(ai_keyword_skips)
     _enrich_keyword_rows(keyword_rows, keyword_metrics)
     plan = _plan(keyword_rows, cache_dir, config)
     if plan.get("budget_status") == "over_budget":
@@ -139,6 +176,7 @@ def run(config: SerpGapConfig) -> dict:
             "selected_keywords": keyword_rows,
             "skipped_pages": skipped_pages,
             "skipped_keywords": skipped_keywords,
+            "ai_agent": _ai_agent_payload(ai_agent, []),
         }
         _write_outputs(payload, report_dir)
         return payload
@@ -151,6 +189,7 @@ def run(config: SerpGapConfig) -> dict:
             "selected_keywords": keyword_rows,
             "skipped_pages": skipped_pages,
             "skipped_keywords": skipped_keywords,
+            "ai_agent": _ai_agent_payload(ai_agent, []),
         }
         _write_outputs(payload, report_dir)
         return payload
@@ -164,7 +203,6 @@ def run(config: SerpGapConfig) -> dict:
         }
 
     embedder = Embedder(config.model)
-    own_cache = HttpCache(project_dir / "cache" / "http.sqlite")
     competitor_cache = HttpCache(cache_dir / "competitors.sqlite")
 
     page_results: list[dict] = []
@@ -368,6 +406,7 @@ def run(config: SerpGapConfig) -> dict:
         })
 
     aggregate_action_points = _attach_action_points(page_results)
+    _attach_ai_editor_briefs(page_results, cache_dir, config, ai_agent)
     payload = {
         "status": "ok",
         "domain": config.domain,
@@ -377,6 +416,7 @@ def run(config: SerpGapConfig) -> dict:
         "selected_keywords": keyword_rows,
         "skipped_pages": skipped_pages,
         "skipped_keywords": skipped_keywords,
+        "ai_agent": _ai_agent_payload(ai_agent, page_results),
         "ahrefs": {
             "meta": ahrefs_payload.get("meta", {}) if ahrefs_payload else {},
             "summary": ahrefs_payload.get("summary", {}) if ahrefs_payload else {},
@@ -428,6 +468,8 @@ def _select_pages(pages: list[PageInfo], config: SerpGapConfig) -> tuple[list[Pa
         ))
         if len(selected) >= config.max_pages:
             return selected, skipped
+    if config.urls:
+        return selected, skipped
     for page in pages:
         if any(_same_url(page.url, p.url) for p in selected):
             continue
@@ -622,6 +664,158 @@ def _load_manual_keywords(config: SerpGapConfig) -> dict[str, list[str]]:
             elif parts:
                 out.setdefault("*", []).append(parts[0])
     return out
+
+
+def _ai_agent_state(config: SerpGapConfig) -> dict:
+    state = {
+        "enabled": bool(config.ai_agent),
+        "provider": config.ai_agent_provider,
+        "model": config.ai_agent_model,
+        "status": "disabled",
+        "keyword_prompts": 0,
+        "keyword_fallbacks": 0,
+        "editor_briefs": 0,
+        "cache_hits": 0,
+        "notes": [],
+        "errors": [],
+    }
+    if not config.ai_agent:
+        return state
+    if config.dry_run:
+        state["status"] = "dry_run"
+        state["notes"].append("AI agent calls are skipped during --dry-run; deterministic title/H1 fallbacks may still be used.")
+        return state
+    if not openrouter_api_key():
+        state["status"] = "missing_openrouter_api_key"
+        state["notes"].append("Set OPENROUTER_API_KEY in .env to enable AI-authored keyword selection and editor briefs.")
+        return state
+    state["status"] = "ready"
+    return state
+
+
+def _ai_agent_payload(state: dict, page_results: list[dict]) -> dict:
+    payload = {k: v for k, v in state.items() if not k.startswith("_")}
+    payload["editor_briefs"] = sum(1 for page in page_results if (page.get("ai_editor_brief") or {}).get("status") == "ok")
+    payload["editor_brief_errors"] = sum(1 for page in page_results if (page.get("ai_editor_brief") or {}).get("status") == "error")
+    return payload
+
+
+def _ai_agent_keyword_rows(
+    pages: list[PageInfo],
+    existing_rows: list[dict],
+    search_payload: dict,
+    own_cache: HttpCache,
+    cache_dir: Path,
+    config: SerpGapConfig,
+    state: dict,
+) -> tuple[list[dict], list[dict]]:
+    if not config.ai_agent:
+        return [], []
+    out: list[dict] = []
+    skipped: list[dict] = []
+    search_rows = list(search_payload.get("organic_keywords") or [])
+    client = None
+    if state.get("status") == "ready":
+        try:
+            client = build_agent_client(config.ai_agent_provider)
+        except Exception as exc:
+            state["status"] = "error"
+            state.setdefault("errors", []).append(f"AI agent client init failed: {exc}")
+    for page in pages:
+        if any(_same_url(row.get("url", ""), page.url) for row in existing_rows):
+            continue
+        evidence = _agent_page_evidence(page, search_rows)
+        source = "ai_agent_fallback"
+        keywords: list[str] = []
+        if client is not None:
+            extracted = _fetch_and_extract(page.url, own_cache, refresh=False)
+            if extracted is not None:
+                evidence = _agent_page_evidence(page, search_rows, extracted)
+            messages = build_keyword_messages(evidence, max_keywords=config.keywords_per_page)
+            try:
+                completion = cached_completion(
+                    cache_dir,
+                    kind=f"keyword-selection-{_url_report_slug(page.url)}",
+                    messages=messages,
+                    client=client,
+                    model=config.ai_agent_model,
+                    refresh=config.ai_agent_refresh,
+                    temperature=0.1,
+                    timeout=120,
+                )
+                state["keyword_prompts"] += 1
+                if completion.cache_status == "hit":
+                    state["cache_hits"] += 1
+                if completion.fallback_from:
+                    state.setdefault("notes", []).append(
+                        f"Keyword selection for {page.url} used {completion.provider} after {completion.fallback_from}."
+                    )
+                keywords = parse_keyword_candidates(completion.text, limit=config.keywords_per_page)
+                source = "ai_agent"
+            except MissingOpenRouterKey:
+                state["status"] = "missing_openrouter_api_key"
+                state.setdefault("notes", []).append(f"Keyword selection skipped for {page.url}: missing OpenRouter key.")
+            except Exception as exc:
+                skipped.append({"url": page.url, "reason": f"AI keyword selection failed: {exc}"})
+                state.setdefault("errors", []).append(f"Keyword selection failed for {page.url}: {exc}")
+        if not keywords:
+            keywords = fallback_keyword_candidates(evidence, limit=config.keywords_per_page)
+            source = "ai_agent_fallback"
+            state["keyword_fallbacks"] += 1
+        if not keywords:
+            skipped.append({"url": page.url, "reason": "AI agent could not infer target keywords"})
+            continue
+        for keyword in keywords[:config.keywords_per_page]:
+            row = _keyword_row(page, keyword, source, synthetic=True)
+            if source == "ai_agent_fallback":
+                row["metrics_source"] = "fallback title/H1 suggestion; no API demand metric match"
+            else:
+                row["metrics_source"] = "AI agent suggestion; no API demand metric match"
+            out.append(row)
+    return _dedupe_keywords(out), skipped
+
+
+def _agent_page_evidence(page: PageInfo, search_rows: list[dict], extracted: ExtractedPage | None = None) -> dict:
+    matched_rows = []
+    for row in search_rows:
+        matched = row.get("matched_url") or row.get("url") or ""
+        if not matched or not _same_url(matched, page.url):
+            continue
+        matched_rows.append({
+            "keyword": row.get("keyword") or row.get("query") or "",
+            "provider": row.get("provider", ""),
+            "position": row.get("position", 0),
+            "impressions": row.get("impressions", 0),
+            "clicks": row.get("clicks", 0),
+            "traffic": row.get("traffic", 0),
+            "volume": row.get("volume", 0),
+        })
+    if extracted is None:
+        return {
+            "url": page.url,
+            "title": page.title,
+            "h1": "",
+            "description": page.description,
+            "section": page.section,
+            "headers": [],
+            "paragraphs": [],
+            "search_rows": matched_rows,
+        }
+    headers = [
+        f"H{header.get('level')}: {header.get('text')}"
+        for header in (extracted.headers_rich or [])[:30]
+        if str(header.get("text") or "").strip()
+    ]
+    return {
+        "url": page.url,
+        "title": extracted.title or page.title,
+        "h1": extracted.h1,
+        "description": extracted.description or page.description,
+        "section": page.section,
+        "headers": headers,
+        "paragraphs": [p for p in extracted.paragraphs[:18] if str(p).strip()],
+        "search_rows": matched_rows,
+    }
 
 
 def _select_keywords(
@@ -2187,6 +2381,86 @@ def _attach_action_points(page_results: list[dict]) -> list[dict]:
     return out
 
 
+def _attach_ai_editor_briefs(
+    page_results: list[dict],
+    cache_dir: Path,
+    config: SerpGapConfig,
+    state: dict,
+) -> None:
+    if not config.ai_agent:
+        return
+    if state.get("status") != "ready":
+        for page in page_results:
+            page["ai_editor_brief"] = {
+                "status": state.get("status", "disabled"),
+                "message": "; ".join(state.get("notes") or []) or "AI editor brief was not generated.",
+            }
+        return
+    try:
+        client = build_agent_client(config.ai_agent_provider)
+    except Exception as exc:
+        state["status"] = "error"
+        state.setdefault("errors", []).append(f"AI editor client init failed: {exc}")
+        for page in page_results:
+            page["ai_editor_brief"] = {"status": "error", "message": str(exc)}
+        return
+    for page in page_results:
+        messages = build_editor_brief_messages(page)
+        try:
+            completion = cached_completion(
+                cache_dir,
+                kind=f"editor-brief-{_url_report_slug(page.get('url', ''))}",
+                messages=messages,
+                client=client,
+                model=config.ai_agent_model,
+                refresh=config.ai_agent_refresh,
+                temperature=0.2,
+                timeout=180,
+            )
+            if completion.cache_status == "hit":
+                state["cache_hits"] += 1
+            if completion.fallback_from:
+                state.setdefault("notes", []).append(
+                    f"Editor brief for {page.get('url', '')} used {completion.provider} after {completion.fallback_from}."
+                )
+            page["ai_editor_brief"] = {
+                "status": "ok",
+                "provider": completion.provider,
+                "model": completion.model,
+                "cache_status": completion.cache_status,
+                "fallback_from": completion.fallback_from,
+                "markdown": _clean_ai_markdown(completion.text),
+            }
+            state["editor_briefs"] += 1
+        except MissingOpenRouterKey:
+            state["status"] = "missing_openrouter_api_key"
+            message = "Set OPENROUTER_API_KEY in .env to generate the AI editor brief."
+            page["ai_editor_brief"] = {"status": "missing_openrouter_api_key", "message": message}
+        except Exception as exc:
+            state.setdefault("errors", []).append(f"Editor brief failed for {page.get('url', '')}: {exc}")
+            page["ai_editor_brief"] = {"status": "error", "message": str(exc)}
+
+
+def _clean_ai_markdown(text: str) -> str:
+    raw = str(text or "").strip()
+    if raw.startswith("```"):
+        raw = re.sub(r"^```[a-zA-Z0-9_-]*\s*", "", raw)
+        raw = re.sub(r"\s*```$", "", raw).strip()
+    out: list[str] = []
+    seen: set[str] = set()
+    for line in raw.splitlines():
+        stripped = line.rstrip()
+        key = _line_key(stripped)
+        if key and not stripped.lstrip().startswith(("#", "-", "*", "1.", "2.", "3.", "4.", "5.", "6.")):
+            if key in seen:
+                continue
+            seen.add(key)
+        if not stripped and out and not out[-1]:
+            continue
+        out.append(stripped)
+    return "\n".join(out).strip()
+
+
 def _scatter(
     keyword: dict,
     own_ext: ExtractedPage,
@@ -2503,6 +2777,7 @@ def _summary(page_results: list[dict], selected_pages: list[PageInfo], keyword_r
         "review_paragraphs": review_paragraphs,
         "action_points": sum(len(a.get("action_points") or []) for a in analyses if a.get("status") == "ok"),
         "content_briefs": sum(1 for p in page_results if p.get("content_brief")),
+        "ai_agent_briefs": sum(1 for p in page_results if (p.get("ai_editor_brief") or {}).get("status") == "ok"),
     }
 
 
@@ -2628,6 +2903,38 @@ def _paragraph_todo_rows(page: dict, limit: int = 10) -> list[dict]:
     return rows[:limit]
 
 
+def _append_ai_editor_brief_markdown(lines: list[str], seen: set[str], brief: dict) -> None:
+    if not brief:
+        return
+    _append_unique(lines, seen, "### AI Agent TODO")
+    status = brief.get("status", "")
+    if status == "ok" and brief.get("markdown"):
+        meta = [
+            brief.get("provider") and f"provider: {brief.get('provider')}",
+            brief.get("model") and f"model: {brief.get('model')}",
+            brief.get("cache_status") and f"cache: {brief.get('cache_status')}",
+            brief.get("fallback_from") and f"fallback: {brief.get('fallback_from')}",
+        ]
+        if any(meta):
+            _append_unique(lines, seen, f"- Agent run: {'; '.join(str(item) for item in meta if item)}")
+            _append_unique(lines, seen)
+        local_seen: set[str] = set()
+        for raw_line in _clean_ai_markdown(str(brief.get("markdown") or "")).splitlines():
+            line = raw_line.rstrip()
+            key = _line_key(line)
+            if key and key in local_seen:
+                continue
+            if key:
+                local_seen.add(key)
+            lines.append(line)
+        _append_unique(lines, seen)
+        return
+    message = brief.get("message") or "AI editor brief was not generated."
+    _append_unique(lines, seen, f"- Not generated: {status or 'disabled'}")
+    _append_unique(lines, seen, f"- Reason: {message}")
+    _append_unique(lines, seen)
+
+
 def _todo_markdown(payload: dict) -> str:
     lines: list[str] = []
     seen: set[str] = set()
@@ -2668,6 +2975,8 @@ def _todo_markdown(payload: dict) -> str:
         if keywords:
             _append_unique(lines, seen, f"- Target keywords: {', '.join(keywords[:12])}")
         _append_unique(lines, seen)
+
+        _append_ai_editor_brief_markdown(lines, seen, page.get("ai_editor_brief") or {})
 
         if rules:
             _append_unique(lines, seen, "### Writing Rules")
@@ -3960,7 +4269,7 @@ function domainColor(domain){return domainPalette[hashString(domain)%domainPalet
 function urlDomain(url){try{return new URL(url).hostname;}catch(_){return '';}}
 function pointDomain(p){return p.domain||urlDomain(p.url||'');}
 function sourceColor(p){if(p.entity_type==='keyword'||p.entity_type==='keyword_centroid')return colors.keyword;const domain=pointDomain(p);if(domain)return domainColor(domain);if(p.entity_type==='title')return colors.title;if(/^h[1-6]$/.test(p.entity_type||''))return colors.h1;if(p.entity_type==='header')return colors.header;return colors.competitor;}
-function metrics(){const s=data.summary||{};return [['Pages',s.pages_analyzed||0],['Keywords',s.keywords_selected||0],['Actions',s.action_points||0],['Content briefs',s.content_briefs||0],['Missing topics',s.missing_topics||0],['Partial topics',s.partial_topics||0],['Review paragraphs',s.review_paragraphs ?? s.off_intent_paragraphs ?? 0],['SERP calls',s.serp_api_calls_after_cache ?? s.serp_api_calls ?? 0]];}
+function metrics(){const s=data.summary||{};return [['Pages',s.pages_analyzed||0],['Keywords',s.keywords_selected||0],['Actions',s.action_points||0],['AI briefs',s.ai_agent_briefs||0],['Content briefs',s.content_briefs||0],['Missing topics',s.missing_topics||0],['Partial topics',s.partial_topics||0],['Review paragraphs',s.review_paragraphs ?? s.off_intent_paragraphs ?? 0],['SERP calls',s.serp_api_calls_after_cache ?? s.serp_api_calls ?? 0]];}
 statusEl.textContent = `${data.domain || ''} · ${data.provider || ''} · ${data.status || ''}`;
 summaryEl.innerHTML = metrics().map(([label,value])=>`<div class="metric"><b>${n(value)}</b><span>${esc(label)}</span></div>`).join('');
 function pointLabel(d){if(d.type==='keyword_centroid')return 'Keyword centroid';if(d.type==='keyword')return 'Keyword';if(d.type==='url'&&d.source==='ours')return `${ownDomain} URL`;if(d.type==='url'&&d.source==='competitor')return 'Competitor URL';if(d.type==='url')return 'URL';if(d.type==='title')return 'Page title';if(/^h[1-6]$/.test(d.type||''))return `${String(d.type).toUpperCase()} heading`;if(d.type==='header')return 'Header';if(d.source==='ours')return `${ownDomain} paragraph`;if(d.source==='competitor')return 'Competitor paragraph';return d.type||'Point';}
@@ -4002,6 +4311,8 @@ function actionEvidenceHtml(row){const ev=row.evidence||{};const profile=ev.qual
 function actionList(rows,limit=12){if(!rows||!rows.length)return '<div class="empty">No content action points were generated. The analyzed page already covers the main detected SERP topics closely enough for these thresholds.</div>';return `<div class="action-list">${rows.slice(0,limit).map((row,index)=>{const brief=row.content_brief||{};const terms=(row.suggested_terms||[]).map(term=>`<span class="chip">${esc(term)}</span>`).join('');const plan=brief.paragraph_plan||brief.paragraph_rules||[];const acceptance=row.acceptance_criteria||brief.acceptance_criteria||[];return `<div class="action-card"><strong>${n(row.global_order||index+1)}. ${esc(row.task_summary||row.action||row.type)} <span class="chip ${actionPriorityClass(row.priority)}">${esc(row.priority||'medium')}</span></strong><div class="mini">${esc(row.keyword||'')} · ${urlLink(row.target_url)}</div><div class="instruction">${esc(row.instruction||'')}</div>${row.placement?`<div class="brief-label">Placement</div><div class="mini">${esc(row.placement)}</div>`:''}${terms?`<div class="action-meta">${terms}</div>`:''}${plan.length?`<div class="brief-label">Paragraph plan</div>${listHtml(plan,'ol')}`:''}${acceptance.length?`<div class="brief-label">Acceptance criteria</div>${listHtml(acceptance)}`:''}${promptBox(row.ai_agent_prompt||brief.ai_agent_prompt)}${actionEvidenceHtml(row)}</div>`;}).join('')}</div>`;}
 function pageBriefCard(brief,index){const actions=brief.next_actions||[];const keywords=(brief.primary_keywords||[]).map(k=>`<span class="chip">${esc(k)}</span>`).join('');return `<div class="brief-card"><h5>${index+1}. ${esc(brief.title||brief.target_url||'Page brief')}</h5><div class="mini">${urlLink(brief.target_url)}</div><div class="action-meta"><span class="chip missing">${n(brief.high_priority_actions||0)} high priority</span><span class="chip">${n(brief.total_actions||0)} tasks</span><span class="chip">score ${esc(brief.priority_score||0)}</span></div>${keywords?`<div class="action-meta">${keywords}</div>`:''}<div class="brief-label">Next tasks</div>${actions.length?`<ol>${actions.slice(0,5).map(a=>`<li><b>${esc(a.priority||'')}</b> ${esc(a.task_summary||a.type||'Task')} ${a.keyword?`<span class="mini">(${esc(a.keyword)})</span>`:''}</li>`).join('')}</ol>`:'<div class="mini">No page-level tasks generated.</div>'}${promptBox(brief.ai_agent_prompt)}</div>`;}
 function contentBriefsSection(){const rows=data.content_briefs||[];if(!rows.length)return '';return collapsiblePanel('Page Content Briefs',`${sectionNote('The shortest path from analysis to work: each page brief groups priority tasks, target keywords, paragraph rules, and an AI-agent prompt.')}<div class="brief-grid">${rows.map(pageBriefCard).join('')}</div>`,{meta:`${n(rows.length)} brief${rows.length===1?'':'s'}`});}
+function aiAgentStatusSection(){const agent=data.ai_agent||{};if(!agent.enabled)return '';const notes=(agent.notes||[]).concat(agent.errors||[]);const statusRows=[['Status',agent.status||''],['Provider',agent.provider||''],['Model',agent.model||''],['Keyword prompts',agent.keyword_prompts||0],['Keyword fallbacks',agent.keyword_fallbacks||0],['Editor briefs',agent.editor_briefs||0],['Cache hits',agent.cache_hits||0]];return collapsiblePanel('AI Agent Status',`${sectionNote('OpenRouter-backed agent layer for keyword inference and paragraph-level editor briefs. Missing API keys are reported here; metrics are never fabricated.')}<table><tbody>${statusRows.map(([k,v])=>`<tr><th>${esc(k)}</th><td>${esc(v)}</td></tr>`).join('')}</tbody></table>${notes.length?`<div class="brief-label">Notes</div>${listHtml(notes)}`:''}`,{meta:agent.status||'',open:agent.status&&agent.status!=='ready'&&agent.status!=='disabled'});}
+function aiEditorBriefSection(page){const brief=page.ai_editor_brief||{};if(!brief.status)return '';if(brief.status==='ok'){const meta=[brief.provider,brief.cache_status].filter(Boolean).join(' · ');return collapsiblePanel('AI Agent TODO',`${sectionNote('Generated markdown instructions for an AI coding/content agent. It should be treated as the implementation brief; deterministic task cards remain below as supporting evidence.')}<div class="prompt-box">${esc(brief.markdown||'')}</div>`,{meta,open:false});}return collapsiblePanel('AI Agent TODO',`<div class="empty">${esc(brief.message||'AI editor brief was not generated.')}</div>`,{meta:brief.status||'not generated',open:false});}
 function paragraphRulesSection(){const rules=(data.editorial_guidelines||{}).paragraph_rules||[];if(!rules.length)return '';return collapsiblePanel('AI Paragraph Rules',listHtml(rules),{meta:`${n(rules.length)} rule${rules.length===1?'':'s'}`});}
 function aggregateActionsSection(){const rows=data.action_points||[];return collapsiblePanel('Content Action Plan For AI Agents',`${sectionNote('Prioritized instructions for editors or an AI agent. Each card includes what to change, where to place it, how paragraphs should be structured, and when the task is done.')} ${actionList(rows,18)}`,{meta:`${n(rows.length)} task${rows.length===1?'':'s'}`});}
 function competitorList(rows){if(!rows||!rows.length)return '<div class="empty">No competitors fetched.</div>';return '<ol class="competitors">'+rows.map(c=>`<li>${urlLink(c.url,c.title||c.url)}<div class="mini">Rank ${esc(c.rank||'')} · Paragraphs ${esc(c.paragraph_count||0)}${c.error?' · '+esc(c.error):''}</div></li>`).join('')+'</ol>';}
@@ -4071,9 +4382,9 @@ function semanticScatterSection(a){const points=a.scatter?.points||[];return `<d
 function visualComparisonSection(a){const hasComparison=a.content_comparison||a.topic_coverage_matrix||a.paragraph_match_heatmap||a.content_order_path;if(!hasComparison)return '';return `<div class="panel content-comparison" style="margin-top:14px"><h4>Why These Edits Matter</h4><div class="panel-body">${sectionNote('Top ranking page differences show why the recommended edits matter: compare topic coverage, paragraph depth, heading structure, content order, and which SERP pages cover each missing or partial topic.')} ${visualReasonList(a)}<div class="visual-grid"><div class="visual-card"><h5>SERP rank vs content coverage</h5>${contentComparisonRows(a)}</div><div class="visual-card"><h5>Top ranking page differences</h5>${contentDeltaBoxes(a)}</div></div><div class="visual-card coverage-heatmap-card" style="margin-top:14px"><h5>Topic coverage heatmap</h5>${topicCoverageHeatmap(a)}</div><div class="visual-card paragraph-match-card" style="margin-top:14px"><h5>Paragraph match heatmap</h5>${paragraphMatchHeatmap(a)}</div><div class="visual-card content-path-card" style="margin-top:14px"><h5>Content order semantic path</h5>${contentOrderPathSection(a)}</div></div></div>`;}
 function keywordChartsSection(a){return `${semanticScatterSection(a)}${visualComparisonSection(a)}`;}
 function keywordId(pageIndex, keywordIndex){return `keyword-${pageIndex}-${keywordIndex}`;}
-function overviewSection(){const points=data.overview_scatter?.points||[];const rankings=data.serp_url_rankings||[];const serpEvidence=`<div class="panel"><h4>Top-10 URLs Across Selected Keywords</h4><div class="panel-body">${sectionNote('Repeated winners show which URLs and intents Google currently rewards for the selected keywords.')} ${serpUrlGraph(rankings)}${serpRankingChart(rankings)}${urlDemandMetricsSection(rankings)}${serpRankingList(rankings)}</div></div>${keywordMetricsSection()}`;const semanticEvidence=`${keywordParagraphRidgelineSection(points)}<div class="panel" style="margin-top:14px"><h4>All Keywords, URLs, and Content</h4><div class="panel-body">${sectionNote('Vector-space chart for keywords, URLs, titles, headings, and paragraphs across the selected SERP set.')} ${scatterSvg(points)}</div></div>${keywordFrequencySection(points)}<div class="panel" style="margin-top:14px"><h4>Topic Traffic Impact</h4><div class="panel-body">${sectionNote('Directional demand by aggregate semantic cluster. Use it to decide which topic groups deserve editing effort first.')} ${clusterImpactChart(points)}</div></div><div class="panel" style="margin-top:14px"><h4>Aggregate Semantic Clusters</h4><div class="panel-body">${sectionNote('Broad topic groups across selected keywords and processed URLs.')} ${clusterCards(points)}</div></div>`;return `<section class="page-section" id="overview-section"><div class="page-head"><h2>SERP Content Task Board</h2><div class="mini">Charts first, then tasks: validate SERP and vector-space evidence before editing.</div></div><div class="keyword-card">${serpEvidence}${semanticEvidence}${contentBriefsSection()}${aggregateActionsSection()}${paragraphRulesSection()}</div></section>`;}
+function overviewSection(){const points=data.overview_scatter?.points||[];const rankings=data.serp_url_rankings||[];const serpEvidence=`<div class="panel"><h4>Top-10 URLs Across Selected Keywords</h4><div class="panel-body">${sectionNote('Repeated winners show which URLs and intents Google currently rewards for the selected keywords.')} ${serpUrlGraph(rankings)}${serpRankingChart(rankings)}${urlDemandMetricsSection(rankings)}${serpRankingList(rankings)}</div></div>${keywordMetricsSection()}`;const semanticEvidence=`${keywordParagraphRidgelineSection(points)}<div class="panel" style="margin-top:14px"><h4>All Keywords, URLs, and Content</h4><div class="panel-body">${sectionNote('Vector-space chart for keywords, URLs, titles, headings, and paragraphs across the selected SERP set.')} ${scatterSvg(points)}</div></div>${keywordFrequencySection(points)}<div class="panel" style="margin-top:14px"><h4>Topic Traffic Impact</h4><div class="panel-body">${sectionNote('Directional demand by aggregate semantic cluster. Use it to decide which topic groups deserve editing effort first.')} ${clusterImpactChart(points)}</div></div><div class="panel" style="margin-top:14px"><h4>Aggregate Semantic Clusters</h4><div class="panel-body">${sectionNote('Broad topic groups across selected keywords and processed URLs.')} ${clusterCards(points)}</div></div>`;return `<section class="page-section" id="overview-section"><div class="page-head"><h2>SERP Content Task Board</h2><div class="mini">Charts first, then tasks: validate SERP and vector-space evidence before editing.</div></div><div class="keyword-card">${serpEvidence}${semanticEvidence}${aiAgentStatusSection()}${contentBriefsSection()}${aggregateActionsSection()}${paragraphRulesSection()}</div></section>`;}
 function keywordCard(a, pageIndex, keywordIndex){const s=a.summary||{};const reviewRows=(a.off_intent_paragraphs&&a.off_intent_paragraphs.length)?a.off_intent_paragraphs:a.own_paragraphs_to_review;const semanticEvidence=`<div class="tables"><div class="panel"><h4>Semantic Clusters</h4><div class="panel-body">${sectionNote('Clusters show where competitors cover nearby themes more deeply than the selected domain.')} ${clusterCards(a.scatter?.points||[])}</div></div><div class="panel"><h4>Competitor SERP</h4><div class="panel-body">${sectionNote('Ranking pages fetched for this keyword after ignored hosts are skipped.')} ${competitorList(a.competitor_pages)}</div></div></div>`;const actionRows=a.action_points||[];const actionsPanel=collapsiblePanel('Keyword Content Actions',`${sectionNote('Edit these after reviewing the charts. Each task describes paragraph structure, placement, and completion criteria.')} ${actionList(actionRows,10)}`,{meta:`${n(actionRows.length)} task${actionRows.length===1?'':'s'}`});const topicPanel=collapsiblePanel('Topic Relations',`${sectionNote('Missing and partial topics are the source evidence for the content tasks above.')} ${topicChart(a.topics)}<table><thead><tr><th>Coverage</th><th>Priority</th><th>Topic and Example</th><th>Seen</th><th>${esc(ownDomain)} sim</th><th>Example URL</th></tr></thead><tbody>${topicRows(a.topics,18)}</tbody></table>`,{meta:`${n((a.topics||[]).length)} topics`,style:''});const reviewPanel=collapsiblePanel(`${ownDomain} Paragraphs To Review`,`${sectionNote('Review candidates for intent drift, thinness, or filler. Keep useful facts, but rewrite, move, merge, or remove weak paragraphs.')} ${reviewList(reviewRows)}`,{meta:`${n((reviewRows||[]).length)} paragraph${(reviewRows||[]).length===1?'':'s'}`,style:''});return `<div class="keyword-card" id="${keywordId(pageIndex, keywordIndex)}"><div class="keyword-head"><div><h3>${esc(a.query || a.keyword?.keyword || '')}</h3><div class="mini">Status ${esc(a.status)} · Competitors ${esc(a.competitors||a.competitor_pages?.length||0)} · Scatter points ${esc(a.scatter?.shown||0)}</div></div><div class="chips"><span class="chip missing">Missing ${n(s.missing||0)}</span><span class="chip partial">Partial ${n(s.partial||0)}</span><span class="chip covered">Covered ${n(s.covered||0)}</span></div></div>${keywordChartsSection(a)}${actionsPanel}<div class="two-col" style="margin-top:14px">${topicPanel}${reviewPanel}</div>${diagnosticDetails('Raw semantic evidence for this keyword',semanticEvidence,false)}</div>`;}
-function pageSection(page, index){return `<section class="page-section" id="page-${index}"><div class="page-head"><h2>${index+1}. ${esc(page.title || page.url)}</h2><div class="url">${urlLink(page.url)}</div>${page.h1?`<div class="mini">H1: ${esc(page.h1)}</div>`:''}</div>${(page.analyses||[]).map((analysis, keywordIndex)=>keywordCard(analysis, index, keywordIndex)).join('') || '<div class="empty">No keyword analyses for this page.</div>'}</section>`;}
+function pageSection(page, index){const aiBrief=aiEditorBriefSection(page);return `<section class="page-section" id="page-${index}"><div class="page-head"><h2>${index+1}. ${esc(page.title || page.url)}</h2><div class="url">${urlLink(page.url)}</div>${page.h1?`<div class="mini">H1: ${esc(page.h1)}</div>`:''}</div>${aiBrief?`<div class="keyword-card">${aiBrief}</div>`:''}${(page.analyses||[]).map((analysis, keywordIndex)=>keywordCard(analysis, index, keywordIndex)).join('') || '<div class="empty">No keyword analyses for this page.</div>'}</section>`;}
 function buildNav(){if(!navEl)return;navEl.innerHTML=`<button type="button" class="report-nav-button" data-target="overview-section"><span class="report-nav-label">Task board</span></button>`+(data.pages||[]).map((page,pageIndex)=>`<button type="button" class="report-nav-button" data-target="page-${pageIndex}"><span class="report-nav-label">${esc(page.title||page.url||`Page ${pageIndex+1}`)}</span></button>${(page.analyses||[]).map((analysis,keywordIndex)=>`<button type="button" class="report-nav-button nav-keyword" data-target="${keywordId(pageIndex,keywordIndex)}"><span class="report-nav-label">${esc(analysis.query||analysis.keyword?.keyword||`Keyword ${keywordIndex+1}`)}</span></button>`).join('')}`).join('');const buttons=[...navEl.querySelectorAll('.report-nav-button')];const sections=buttons.map(button=>document.getElementById(button.dataset.target||'')).filter(Boolean);buttons.forEach(button=>button.addEventListener('click',()=>{const target=document.getElementById(button.dataset.target||'');if(target)target.scrollIntoView({block:'start',behavior:'smooth'});}));function update(){let active=0;for(let i=0;i<sections.length;i++){if(sections[i].getBoundingClientRect().top<160)active=i;}buttons.forEach((button,i)=>{const selected=i===active;button.classList.toggle('is-active',selected);button.setAttribute('aria-current',selected?'page':'false');});}document.addEventListener('scroll',update,{passive:true});update();}
 
 function bindSerpUrlGraphInteractions(){document.querySelectorAll('.serp-url-graph-wrap').forEach(wrap=>{const tooltip=wrap.querySelector('.graph-tooltip');const clear=()=>{wrap.classList.remove('has-active');wrap.querySelectorAll('.is-active').forEach(el=>el.classList.remove('is-active'));tooltip?.classList.remove('open');};function show(el,event){let detail={};try{detail=JSON.parse(el.getAttribute('data-graph-detail')||'{}');}catch(_){}wrap.classList.add('has-active');wrap.querySelectorAll('.is-active').forEach(active=>active.classList.remove('is-active'));el.classList.add('is-active');if(el.matches('[data-graph-node]')){const index=el.getAttribute('data-node-index');wrap.querySelectorAll(`[data-graph-edge][data-nodes*=",${index},"]`).forEach(edge=>edge.classList.add('is-active'));}else if(el.matches('[data-graph-edge]')){(el.getAttribute('data-nodes')||'').split(',').filter(Boolean).forEach(index=>wrap.querySelector(`[data-graph-node][data-node-index="${index}"]`)?.classList.add('is-active'));}if(tooltip){tooltip.innerHTML=graphTooltipHtml(detail);tooltip.classList.add('open');position(event);}}function position(event){if(!tooltip||!event)return;const rect=wrap.getBoundingClientRect();const x=Math.min(Math.max(10,event.clientX-rect.left+14),Math.max(10,rect.width-380));const y=Math.min(Math.max(10,event.clientY-rect.top+14),Math.max(10,rect.height-190));tooltip.style.left=`${x}px`;tooltip.style.top=`${y}px`;}wrap.querySelectorAll('[data-graph-node],[data-graph-edge]').forEach(el=>{el.addEventListener('mouseenter',event=>show(el,event));el.addEventListener('mousemove',position);el.addEventListener('focus',event=>show(el,event));el.addEventListener('mouseleave',clear);el.addEventListener('blur',clear);});});}

--- a/site_audit/settings_ui.py
+++ b/site_audit/settings_ui.py
@@ -128,6 +128,24 @@ FIELD_DETAILS = {
         "format": "Secret token.",
         "example": "ahrefs_xxx",
     },
+    "OPENROUTER_API_KEY": {
+        "what": "OpenRouter API key.",
+        "why": "Enables AI-agent keyword inference and paragraph-level SERP gap TODO briefs.",
+        "format": "Secret token stored in local .env, which is ignored by git.",
+        "example": "sk-or-v1-...",
+    },
+    "OPENROUTER_MODEL": {
+        "what": "Default OpenRouter model for AI-agent work.",
+        "why": "Controls which model writes keyword recommendations and editor briefs.",
+        "format": "OpenRouter model id.",
+        "example": "deepseek/deepseek-v4-pro",
+    },
+    "HARNEXT_API_KEY": {
+        "what": "Optional Harnext API key.",
+        "why": "Reserved for Harnext SDK workflows when a Harnext account requires its own key.",
+        "format": "Secret token, if required by the SDK/account.",
+        "example": "harnext_xxx",
+    },
     "DATAFORSEO_LOGIN": {
         "what": "DataForSEO API login.",
         "why": "Required for DataForSEO keyword and SERP requests.",
@@ -191,6 +209,9 @@ EXTRA_SETTINGS = [
     {"command": "credentials", "env_key": "GOOGLE_ADS_REFRESH_TOKEN", "flag": "Google Ads refresh token", "default": "", "help": "Refresh token with the adwords OAuth scope.", "choices": [], "kind": "secret"},
     {"command": "credentials", "env_key": "GOOGLE_ADS_CUSTOMER_ID", "flag": "Google Ads customer ID", "default": "", "help": "Client account ID to query.", "choices": [], "kind": "text"},
     {"command": "credentials", "env_key": "GOOGLE_ADS_LOGIN_CUSTOMER_ID", "flag": "Google Ads manager ID", "default": "", "help": "Optional manager account ID for login-customer-id.", "choices": [], "kind": "text"},
+    {"command": "credentials", "env_key": "OPENROUTER_API_KEY", "flag": "OpenRouter API key", "default": "", "help": "Required for AI-agent keyword inference and editor TODO briefs.", "choices": [], "kind": "secret"},
+    {"command": "credentials", "env_key": "OPENROUTER_MODEL", "flag": "OpenRouter model", "default": "deepseek/deepseek-v4-pro", "help": "Default model for AI-agent tasks.", "choices": [], "kind": "text"},
+    {"command": "credentials", "env_key": "HARNEXT_API_KEY", "flag": "Harnext API key", "default": "", "help": "Optional Harnext SDK account key if your setup requires one.", "choices": [], "kind": "secret"},
 ]
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,4 @@
-from site_audit.cli import build_parser
+from site_audit.cli import _run_serp_gap_menu, build_parser
 
 
 def test_run_parser_accepts_crawl_filter_flags() -> None:
@@ -173,6 +173,12 @@ def test_serp_gap_parser_accepts_budget_and_keyword_options() -> None:
             "25",
             "--ahrefs-keywords-limit",
             "50",
+            "--ai-agent-provider",
+            "openrouter",
+            "--ai-agent-model",
+            "deepseek/deepseek-v4-pro",
+            "--ai-agent-refresh",
+            "--no-ai-agent-interactive-setup",
             "--dry-run",
         ]
     )
@@ -194,6 +200,51 @@ def test_serp_gap_parser_accepts_budget_and_keyword_options() -> None:
     assert args.ahrefs_mode == "domain"
     assert args.ahrefs_top_pages_limit == 25
     assert args.ahrefs_keywords_limit == 50
+    assert args.ai_agent is True
+    assert args.ai_agent_provider == "openrouter"
+    assert args.ai_agent_model == "deepseek/deepseek-v4-pro"
+    assert args.ai_agent_refresh is True
+    assert args.ai_agent_interactive_setup is False
+    assert args.dry_run is True
+
+
+def test_serp_gap_parser_can_disable_ai_agent() -> None:
+    args = build_parser().parse_args(["serp-gap", "example.com", "--no-ai-agent"])
+
+    assert args.ai_agent is False
+
+
+def test_serp_gap_parser_accepts_interactive_menu_without_domain() -> None:
+    args = build_parser().parse_args(["serp-gap", "--menu"])
+
+    assert args.menu is True
+    assert args.domain is None
+
+
+def test_serp_gap_menu_fills_common_options(monkeypatch) -> None:
+    args = build_parser().parse_args(["serp-gap", "--menu"])
+    answers = iter([
+        "example.com",
+        "1",
+        "https://www.example.com/blog/ai-support-paradox/",
+        "1",
+        "2",
+        "2840",
+        "",
+        "y",
+        "n",
+        "y",
+    ])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
+
+    assert _run_serp_gap_menu(args) is True
+    assert args.domain == "example.com"
+    assert args.url == ["https://www.example.com/blog/ai-support-paradox/"]
+    assert args.keyword_source == "auto"
+    assert args.ai_agent is True
+    assert args.provider == "dataforseo"
+    assert args.country == "2840"
+    assert args.language == "en"
     assert args.dry_run is True
 
 

--- a/tests/test_config_env.py
+++ b/tests/test_config_env.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from site_audit.cli import build_parser
-from site_audit.config_env import apply_env_defaults, update_env_file
+from site_audit.config_env import apply_env_defaults, env_names, update_env_file
 from site_audit.settings_ui import _render_home, _render_reports_page, _schema
 
 
@@ -29,6 +29,13 @@ def test_env_defaults_apply_to_boolean_optional_run_options(monkeypatch) -> None
     apply_env_defaults(args, parser, ["run", "example.com"])
 
     assert args.strip_header_footer is False
+
+
+def test_env_names_normalize_hyphenated_commands() -> None:
+    assert env_names("serp-gap", "ai_agent") == [
+        "SITE_AUDIT_SERP_GAP_AI_AGENT",
+        "SITE_AUDIT_AI_AGENT",
+    ]
 
 
 def test_cli_options_override_env_defaults(monkeypatch) -> None:
@@ -72,8 +79,11 @@ def test_settings_schema_includes_cli_and_provider_credentials() -> None:
 
     assert "SITE_AUDIT_RUN_MAX_PAGES" in keys
     assert "SITE_AUDIT_RUN_GOOGLE_ADS_CUSTOMER_ID" in keys
+    assert "SITE_AUDIT_SERP_GAP_AI_AGENT" in keys
     assert "GOOGLE_ADS_REFRESH_TOKEN" in keys
     assert "AHREFS_API_KEY" in keys
+    assert "OPENROUTER_API_KEY" in keys
+    assert "OPENROUTER_MODEL" in keys
 
 
 def test_settings_schema_includes_field_explanations() -> None:
@@ -83,11 +93,13 @@ def test_settings_schema_includes_field_explanations() -> None:
     domain = by_key["SITE_AUDIT_RUN_DOMAIN"]["details"]
     seed = by_key["SITE_AUDIT_RUN_COMPETITIVE_AUTO_PRODUCT_SEED"]["details"]
     ads = by_key["GOOGLE_ADS_REFRESH_TOKEN"]["details"]
+    openrouter = by_key["OPENROUTER_API_KEY"]["details"]
     fallback = by_key["SITE_AUDIT_RUN_DUPLICATE_THRESHOLD"]["details"]
 
     assert "site to crawl" in domain["what"]
     assert "Comma-separated" in seed["format"]
     assert "without logging in" in ads["why"]
+    assert "AI-agent" in openrouter["why"]
     assert fallback["what"]
     assert fallback["example"]
 

--- a/tests/test_serp_gap.py
+++ b/tests/test_serp_gap.py
@@ -3,12 +3,14 @@ from pathlib import Path
 
 import numpy as np
 
+from site_audit.ai_agent import build_editor_brief_messages, parse_keyword_candidates
 from site_audit.serp_gap import (
     SerpGapConfig,
     _add_serp_url_rankings,
     _attach_action_points,
     _action_csv_rows,
     _action_points_for_analysis,
+    _ai_agent_state,
     _content_comparison,
     _content_order_path,
     _dedupe_semantic_row_texts,
@@ -162,6 +164,34 @@ def test_serp_gap_manual_keywords_can_target_homepage(tmp_path: Path) -> None:
         "call center software",
     ]
     assert all(row["source"] == "manual" for row in payload["selected_keywords"])
+
+
+def test_serp_gap_url_only_dry_run_uses_ai_keyword_fallback(tmp_path: Path) -> None:
+    _write_base_report(tmp_path)
+
+    payload = run(
+        SerpGapConfig(
+            domain="example.com",
+            projects_root=tmp_path,
+            urls=["https://www.example.com/"],
+            dry_run=True,
+        )
+    )
+
+    assert payload["status"] == "dry_run"
+    assert payload["ai_agent"]["status"] == "dry_run"
+    assert payload["selected_keywords"][0]["keyword"] == "Example Home"
+    assert payload["selected_keywords"][0]["source"] == "ai_agent_fallback"
+    assert "no API demand metric match" in payload["selected_keywords"][0]["metrics_source"]
+
+
+def test_serp_gap_ai_agent_state_reports_missing_openrouter_key(monkeypatch) -> None:
+    monkeypatch.setattr("site_audit.serp_gap.openrouter_api_key", lambda: "")
+
+    state = _ai_agent_state(SerpGapConfig(domain="example.com", dry_run=False, ai_agent=True))
+
+    assert state["status"] == "missing_openrouter_api_key"
+    assert "OPENROUTER_API_KEY" in state["notes"][0]
 
 
 def test_serp_gap_budget_cap_stops_before_paid_work(tmp_path: Path) -> None:
@@ -682,6 +712,70 @@ def test_serp_gap_todo_markdown_is_actionable_and_deduped() -> None:
     assert "Review paragraph 4 for intent drift or filler." not in markdown
     assert "P1 (0.50 best SERP paragraph match" in markdown
     assert "Do not copy competitor wording." in markdown
+
+
+def test_serp_gap_todo_markdown_embeds_ai_editor_brief_without_duplicate_lines() -> None:
+    payload = {
+        "status": "ok",
+        "domain": "example.com",
+        "summary": {"pages_analyzed": 1, "keywords_selected": 1, "action_points": 0},
+        "pages": [
+            {
+                "url": "https://example.com/support",
+                "title": "Support",
+                "ai_editor_brief": {
+                    "status": "ok",
+                    "provider": "openrouter",
+                    "model": "deepseek/deepseek-v4-pro",
+                    "cache_status": "miss",
+                    "markdown": "\n".join([
+                        "# AI Agent TODO",
+                        "## Evidence",
+                        "- Demand metrics absent; do not estimate search volume.",
+                        "- Demand metrics absent; do not estimate search volume.",
+                        "## Paragraph Decisions",
+                        "- P1: rewrite to answer the user intent directly.",
+                    ]),
+                },
+                "analyses": [],
+            }
+        ],
+    }
+
+    markdown = _todo_markdown(payload)
+
+    assert "### AI Agent TODO" in markdown
+    assert "provider: openrouter" in markdown
+    assert markdown.count("Demand metrics absent; do not estimate search volume.") == 1
+    assert "- P1: rewrite to answer the user intent directly." in markdown
+
+
+def test_ai_agent_keyword_parser_and_editor_prompt_are_specific() -> None:
+    keywords = parse_keyword_candidates(
+        '{"keywords":[{"keyword":"ai customer support paradox","intent":"matches article"},'
+        '{"keyword":"ai support handoff","priority":2}]}'
+    )
+    messages = build_editor_brief_messages({
+        "url": "https://example.com/blog/ai-support-paradox/",
+        "title": "AI Support Paradox",
+        "keywords": [{"keyword": "ai customer support paradox", "impressions": 0}],
+        "action_points": [
+            {
+                "priority": "high",
+                "type": "add_topic",
+                "keyword": "ai customer support paradox",
+                "topic": "human handoff",
+                "task_summary": "Add handoff section.",
+            }
+        ],
+        "analyses": [],
+    })
+
+    assert keywords == ["ai customer support paradox", "ai support handoff"]
+    prompt = "\n".join(message["content"] for message in messages)
+    assert "keep, rewrite, move, merge, or remove" in prompt
+    assert "Do not copy competitor wording" in prompt
+    assert "demand metrics absent" in prompt
 
 
 def test_serp_gap_enriches_manual_keywords_from_ahrefs_metrics() -> None:


### PR DESCRIPTION
## Summary
- Adds an OpenRouter-backed AI agent layer for serp-gap with optional Harnext SDK wrapper and direct OpenRouter fallback.
- Adds URL-only keyword inference, cached prompts/completions under projects/<domain>/cache/serp_gap/ai_agent/, and page-level AI editor TODO markdown.
- Adds an interactive terminal menu via site-audit serp-gap --menu with explained choices/toggles, plus OpenRouter/Harnext .env settings.
- Updates docs and fixes missing report-section anchors for paragraph relation visualizations.

Closes #69

## Notes
- Default OpenRouter model is deepseek/deepseek-v4-pro.
- .env remains ignored by git; interactive CLI setup can write OPENROUTER_API_KEY locally.
- Exact --url selection now analyzes only the explicit URL(s), matching the command description and URL-specific report directory behavior.

## Tests
- python3 -m py_compile site_audit/ai_agent.py site_audit/serp_gap.py site_audit/cli.py site_audit/config_env.py site_audit/settings_ui.py
- python3 -m pytest tests/test_serp_gap.py tests/test_cli.py tests/test_config_env.py tests/test_report_docs.py
- python3 -m pytest (fails locally only because this Python environment is missing umap: ModuleNotFoundError: No module named 'umap' in tests/test_compare_metrics.py)