### PR TITLE
Group action plan into per-URL cards with conflict suppression

### DIFF
--- a/docs/report-sections.md
+++ b/docs/report-sections.md
@@ -20,9 +20,11 @@ Action: review the low-similarity tail. Keep pages that serve a strategic purpos
 <a id="action-plan-block"></a>
 ## Action plan
 
-Aggregates findings from multiple analyses into a prioritized task list.
+Aggregates findings from multiple analyses into prioritized URL cards. Each card combines all active recommendations for the same primary page, sums any modeled click gains, and lists the underlying actions. Multi-URL merge/consolidation actions are filed under the canonical or best URL, with related URLs shown on the card. Coverage gaps for new pages appear as new-content cards keyed by query.
 
-Action: start here when you need execution priorities. Validate the suggested URL and issue type, then assign each item to content, technical SEO, internal linking, or product/UX.
+Actions that would conflict with a redirect or merge are suppressed and shown separately with the recommendation that caused suppression — including internal-link suggestions pointing at a page slated for removal. The card effort label is the heaviest member action's effort (quick/medium/deep); the summed effort score is exposed separately.
+
+Action: start here when you need execution priorities. Validate the suggested URL and issue type, assign the card to content, technical SEO, internal linking, or product/UX, then use the "All actions" list for the flat recommendation workflow.
 
 <a id="improvement-block"></a>
 ## GEO pages most in need of editing

--- a/site_audit/recommendations.py
+++ b/site_audit/recommendations.py
@@ -56,6 +56,9 @@ class Recommendation:
     traffic_opportunity: float = 0.0
     estimated_clicks_gain: float | None = None
     estimate_basis: str | None = None
+    suppressed: bool = False
+    suppressed_by: str | None = None
+    suppressed_reason: str = ""
 
 
 _PRI_RANK = {"high": 0, "medium": 1, "low": 2}
@@ -419,6 +422,41 @@ def _gain_label(gain: float | None) -> str:
     return f"≈ +{gain:.0f} clicks/period"
 
 
+def _item_row(r: Recommendation) -> dict:
+    return {
+        "id": r.id,
+        "category": r.category,
+        "type": r.type,
+        "priority": r.priority,
+        "priority_score": r.priority_score,
+        "impact": r.impact,
+        "confidence": r.confidence,
+        "effort_score": r.effort_score,
+        "risk": r.risk,
+        "owner": r.owner,
+        "cluster": r.cluster,
+        "traffic_opportunity": r.traffic_opportunity,
+        "estimated_clicks_gain": r.estimated_clicks_gain,
+        "estimate_basis": r.estimate_basis,
+        "gain_label": _gain_label(r.estimated_clicks_gain),
+        "title": r.title,
+        "instruction": r.instruction,
+        "targets": r.targets,
+        "evidence": r.evidence,
+        "effort": r.effort,
+        "score": r.score,
+    }
+
+
+def _suppressed_row(r: Recommendation) -> dict:
+    return {
+        **_item_row(r),
+        "suppressed": r.suppressed,
+        "suppressed_by": r.suppressed_by,
+        "suppressed_reason": r.suppressed_reason,
+    }
+
+
 def _priority_bucket(priority_score: float) -> str:
     if priority_score >= 60.0:
         return "high"
@@ -488,6 +526,170 @@ def _finalize(recs: list[Recommendation], *, linkgraph_payload: dict | None = No
         }
     recs.sort(key=lambda r: (-r.priority_score, _PRI_RANK.get(r.priority, 9), -r.impact, r.effort_score, r.id))
     return recs
+
+
+def _removal_targets(rec: Recommendation) -> list[str]:
+    if rec.id.startswith("dup-") and len(rec.targets) > 1:
+        return [rec.targets[1]]
+    if rec.id.startswith("cann-") and len(rec.targets) > 1:
+        return [target for target in rec.targets[1:] if target]
+    return []
+
+
+def _primary_target_keys(rec: Recommendation) -> set[str]:
+    if not rec.targets:
+        return set()
+    return _url_keys(rec.targets[0])
+
+
+def _improves_page(rec: Recommendation) -> bool:
+    return bool(rec.targets) and not rec.id.startswith("gap-") and rec.type != "coverage_gap"
+
+
+def _resolve_conflicts(recommendations: Iterable[Recommendation]) -> tuple[list[Recommendation], list[Recommendation]]:
+    recs = list(recommendations)
+    for rec in recs:
+        rec.suppressed = False
+        rec.suppressed_by = None
+        rec.suppressed_reason = ""
+
+    removal_by_url: dict[str, Recommendation] = {}
+    removal_recs = sorted(
+        (rec for rec in recs if _removal_targets(rec)),
+        key=lambda r: (-_safe_float(r.priority_score), r.id),
+    )
+    for rec in removal_recs:
+        for target in _removal_targets(rec):
+            for key in _url_keys(target):
+                removal_by_url.setdefault(key, rec)
+
+    kept: list[Recommendation] = []
+    suppressed: list[Recommendation] = []
+    for rec in recs:
+        if _removal_targets(rec):
+            kept.append(rec)
+            continue
+        if not _improves_page(rec):
+            kept.append(rec)
+            continue
+        suppressor: Recommendation | None = None
+        reason = ""
+        for key in sorted(_primary_target_keys(rec)):
+            if key in removal_by_url:
+                suppressor = removal_by_url[key]
+                reason = f"page is slated for redirect/merge by {suppressor.id}"
+                break
+        if suppressor is None and rec.id.startswith(("link-", "plink-")):
+            # Link recs edit targets[0] but point at targets[1]; a link into
+            # a page slated for removal is wasted work too.
+            for destination in rec.targets[1:]:
+                for key in sorted(_url_keys(destination)):
+                    if key in removal_by_url:
+                        suppressor = removal_by_url[key]
+                        reason = f"link destination is slated for redirect/merge by {suppressor.id}"
+                        break
+                if suppressor is not None:
+                    break
+        if suppressor is None:
+            kept.append(rec)
+            continue
+        rec.suppressed = True
+        rec.suppressed_by = suppressor.id
+        rec.suppressed_reason = reason
+        suppressed.append(rec)
+    return kept, suppressed
+
+
+def _card_title(members: list[Recommendation], url: str, query: str) -> str:
+    for rec in members:
+        evidence = rec.evidence or {}
+        for key in (
+            "page_title",
+            "current_title",
+            "title",
+            "target_title",
+            "source_title",
+            "best_title",
+            "canonical_title",
+        ):
+            value = str(evidence.get(key) or "").strip()
+            if value:
+                return value
+    if query:
+        return query
+    return url
+
+
+def _card_group(rec: Recommendation) -> tuple[str, str, str, list[str]]:
+    evidence = rec.evidence or {}
+    if rec.id.startswith("gap-") or rec.type == "coverage_gap":
+        query = str(evidence.get("query") or rec.title or "").strip()
+        return f"new-content:{query}", "", query, [target for target in rec.targets if target]
+    url = rec.targets[0] if rec.targets else ""
+    key = next(iter(sorted(_url_keys(url))), url) if url else f"site-wide:{rec.id}"
+    return key, url, "", [target for target in rec.targets[1:] if target]
+
+
+_EFFORT_RANK = {"quick": 0, "medium": 1, "deep": 2}
+
+
+def _effort_total_label(members: list[Recommendation]) -> str:
+    # The card label is the heaviest member's effort — summing scores would
+    # make three quick edits read as "deep". The summed score is exposed
+    # separately as effort_total_score.
+    ranked = [rec.effort for rec in members if rec.effort in _EFFORT_RANK]
+    if not ranked:
+        return "medium"
+    return max(ranked, key=lambda label: _EFFORT_RANK[label])
+
+
+def to_cards(recommendations: Iterable[Recommendation]) -> list[dict]:
+    groups: dict[str, dict] = {}
+    for rec in recommendations:
+        key, url, query, related = _card_group(rec)
+        group = groups.get(key)
+        if group is None:
+            group = {
+                "url": url,
+                "query": query,
+                "members": [],
+                "related_urls": [],
+            }
+            groups[key] = group
+        for related_url in related:
+            if related_url and related_url != group["url"] and related_url not in group["related_urls"]:
+                group["related_urls"].append(related_url)
+        group["members"].append(rec)
+
+    cards: list[dict] = []
+    for group in groups.values():
+        members = group["members"]
+        gains = [float(rec.estimated_clicks_gain) for rec in members if rec.estimated_clicks_gain is not None]
+        total_gain = round(sum(gains), 2) if gains else None
+        top_priority_score = max(float(rec.priority_score or 0.0) for rec in members)
+        top_priority = sorted({rec.priority for rec in members}, key=lambda p: _PRI_RANK.get(p, 9))[0]
+        effort_score_total = round(sum(float(rec.effort_score or 0.0) for rec in members), 1)
+        cards.append({
+            "url": group["url"],
+            "query": group["query"],
+            "title": _card_title(members, group["url"], group["query"]),
+            "related_urls": sorted(group["related_urls"]),
+            "total_estimated_clicks_gain": total_gain,
+            "top_priority": top_priority,
+            "top_priority_score": top_priority_score,
+            "categories": sorted({rec.category for rec in members}),
+            "recommendation_ids": [rec.id for rec in members],
+            "recommendations": [_item_row(rec) for rec in members],
+            "effort_total": _effort_total_label(members),
+            "effort_total_score": effort_score_total,
+        })
+    cards.sort(key=lambda card: (
+        _PRI_RANK.get(card["top_priority"], 9),
+        -(card["total_estimated_clicks_gain"] if card["total_estimated_clicks_gain"] is not None else -1.0),
+        -float(card["top_priority_score"] or 0.0),
+        card["url"] or f"new-content:{card.get('query', '')}",
+    ))
+    return cards
 
 
 def _pr_lookup(linkgraph_payload: dict | None) -> dict[str, float]:
@@ -964,7 +1166,15 @@ def synthesize(
     recs += _linking(linkgraph_payload, paragraph_links, pr)
     recs += _onpage(title_mismatch, anchor_analysis, ctr_anomalies, pr)
 
-    return _finalize(recs, linkgraph_payload=linkgraph_payload, search_payload=search_payload)[:max_total]
+    finalized = _finalize(recs, linkgraph_payload=linkgraph_payload, search_payload=search_payload)
+    kept, suppressed = _resolve_conflicts(finalized)
+    # Truncate AFTER resolving conflicts, and only report suppressions whose
+    # suppressor survived the cut — re-resolving on a truncated list would
+    # resurrect improve-recs for pages still slated for removal.
+    kept = kept[:max_total]
+    kept_ids = {rec.id for rec in kept}
+    suppressed = [rec for rec in suppressed if rec.suppressed_by in kept_ids]
+    return kept + suppressed
 
 
 def _ctr_anomaly_recommendations(payload: dict | list | None) -> list[dict]:
@@ -980,7 +1190,9 @@ def to_payload(recs: Iterable[Recommendation]) -> dict:
     when a CTR/position basis exists, else the legacy traffic index. The
     summary total sums those per-item values.
     """
-    items = list(recs)
+    recs_list = list(recs)
+    items = [r for r in recs_list if not r.suppressed]
+    suppressed = [r for r in recs_list if r.suppressed]
     by_category: dict[str, int] = {}
     by_priority: dict[str, int] = {"high": 0, "medium": 0, "low": 0}
     for r in items:
@@ -990,6 +1202,7 @@ def to_payload(recs: Iterable[Recommendation]) -> dict:
     types = sorted({r.type for r in items if r.type})
     clusters = sorted({r.cluster for r in items if r.cluster})
     avg = lambda attr: round(sum(float(getattr(r, attr, 0.0) or 0.0) for r in items) / max(len(items), 1), 1)
+    cards = to_cards(items)
     return {
         "total": len(items),
         "by_category": by_category,
@@ -1009,31 +1222,10 @@ def to_payload(recs: Iterable[Recommendation]) -> dict:
             "avg_risk": avg("risk"),
             "avg_priority_score": avg("priority_score"),
             "traffic_opportunity": round(sum(float(r.traffic_opportunity or 0.0) for r in items), 1),
+            "cards": len(cards),
+            "suppressed": len(suppressed),
         },
-        "items": [
-            {
-                "id": r.id,
-                "category": r.category,
-                "type": r.type,
-                "priority": r.priority,
-                "priority_score": r.priority_score,
-                "impact": r.impact,
-                "confidence": r.confidence,
-                "effort_score": r.effort_score,
-                "risk": r.risk,
-                "owner": r.owner,
-                "cluster": r.cluster,
-                "traffic_opportunity": r.traffic_opportunity,
-                "estimated_clicks_gain": r.estimated_clicks_gain,
-                "estimate_basis": r.estimate_basis,
-                "gain_label": _gain_label(r.estimated_clicks_gain),
-                "title": r.title,
-                "instruction": r.instruction,
-                "targets": r.targets,
-                "evidence": r.evidence,
-                "effort": r.effort,
-                "score": r.score,
-            }
-            for r in items
-        ],
+        "cards": cards,
+        "items": [_item_row(r) for r in items],
+        "suppressed": [_suppressed_row(r) for r in suppressed],
     }

--- a/tests/test_recommendation_cards.py
+++ b/tests/test_recommendation_cards.py
@@ -1,0 +1,287 @@
+from site_audit.recommendations import Recommendation, synthesize, to_payload
+
+
+def _finalized(*recs: Recommendation) -> dict:
+    return to_payload(recs)
+
+
+def test_duplicate_drop_target_suppresses_improve_recommendation() -> None:
+    payload = synthesize(
+        duplicates_rows=[
+            {
+                "similarity": 0.98,
+                "url_a": "https://example.com/canonical",
+                "url_b": "https://example.com/drop",
+            }
+        ],
+        answerability_payload=[
+            {"url": "https://example.com/drop", "score": 2.0, "flags": ["missing FAQ"]},
+            {"url": "https://example.com/canonical", "score": 2.0, "flags": ["missing FAQ"]},
+        ],
+        linkgraph_payload={
+            "top_authority_pages": [
+                {"url": "https://example.com/canonical", "pagerank": 0.02},
+                {"url": "https://example.com/drop", "pagerank": 0.01},
+            ]
+        },
+    )
+    report = to_payload(payload)
+
+    ids = {item["id"] for item in report["items"]}
+    suppressed = report["suppressed"]
+
+    assert "dup-0" in ids
+    assert any(item["targets"] == ["https://example.com/canonical"] for item in report["items"])
+    assert not any(item["targets"] == ["https://example.com/drop"] for item in report["items"])
+    assert len(suppressed) == 1
+    assert suppressed[0]["targets"] == ["https://example.com/drop"]
+    assert suppressed[0]["suppressed_by"] == "dup-0"
+    assert "dup-0" in suppressed[0]["suppressed_reason"]
+    assert report["summary"]["suppressed"] == 1
+
+
+def test_cannibalization_runner_up_suppresses_improve_but_best_url_remains() -> None:
+    report = to_payload(synthesize(
+        coverage_payload=[
+            {
+                "status": "cannibalized",
+                "query": "support automation",
+                "best_url": "https://example.com/best",
+                "best_similarity": 0.9,
+                "candidates_above_threshold": 3,
+                "runner_ups": [
+                    {"url": "https://example.com/runner"},
+                    {"url": "https://example.com/runner-two"},
+                ],
+            }
+        ],
+        title_mismatch=[
+            {"url": "https://example.com/best", "title_to_content": 0.2, "title": "Best"},
+            {"url": "https://example.com/runner", "title_to_content": 0.2, "title": "Runner"},
+        ],
+    ))
+
+    assert any(item["targets"] == ["https://example.com/best"] for item in report["items"])
+    assert not any(item["targets"] == ["https://example.com/runner"] for item in report["items"])
+    assert report["suppressed"][0]["targets"] == ["https://example.com/runner"]
+    assert report["suppressed"][0]["suppressed_by"] == "cann-0"
+
+
+def test_cards_group_url_recommendations_and_sum_modeled_gain() -> None:
+    report = _finalized(
+        Recommendation(
+            id="geo-0",
+            category="geo",
+            priority="medium",
+            title="Answerability",
+            instruction="Add FAQ.",
+            targets=["https://example.com/page"],
+            evidence={"current_title": "Page title"},
+            priority_score=40.0,
+            effort_score=55.0,
+            estimated_clicks_gain=10.0,
+        ),
+        Recommendation(
+            id="title-0",
+            category="onpage",
+            priority="high",
+            title="Rewrite title",
+            instruction="Rewrite.",
+            targets=["https://example.com/page"],
+            priority_score=70.0,
+            effort_score=25.0,
+            estimated_clicks_gain=5.0,
+        ),
+        Recommendation(
+            id="orphan-0",
+            category="linking",
+            priority="low",
+            title="Add links",
+            instruction="Add links.",
+            targets=["https://example.com/page"],
+            priority_score=20.0,
+            effort_score=25.0,
+        ),
+    )
+
+    card = report["cards"][0]
+
+    assert report["summary"]["cards"] == 1
+    assert card["url"] == "https://example.com/page"
+    assert card["title"] == "Page title"
+    assert card["total_estimated_clicks_gain"] == 15.0
+    assert card["top_priority"] == "high"
+    assert card["top_priority_score"] == 70.0
+    assert card["categories"] == ["geo", "linking", "onpage"]
+    assert card["recommendation_ids"] == ["geo-0", "title-0", "orphan-0"]
+    # Label reflects the heaviest member effort, not the summed score.
+    assert card["effort_total"] == "medium"
+
+
+def test_multi_target_recommendation_lands_on_canonical_card() -> None:
+    report = _finalized(
+        Recommendation(
+            id="dup-0",
+            category="content_debt",
+            priority="high",
+            title="Merge duplicate",
+            instruction="Redirect duplicate.",
+            targets=["https://example.com/canonical", "https://example.com/drop"],
+            priority_score=80.0,
+            effort_score=25.0,
+        )
+    )
+
+    card = report["cards"][0]
+
+    assert card["url"] == "https://example.com/canonical"
+    assert card["related_urls"] == ["https://example.com/drop"]
+    assert card["recommendation_ids"] == ["dup-0"]
+
+
+def test_coverage_gap_uses_new_content_pseudo_card() -> None:
+    report = to_payload(synthesize(
+        coverage_payload=[
+            {
+                "status": "gap",
+                "query": "support automation tools",
+                "source": "manual",
+                "best_similarity": 0.2,
+                "best_url": "https://example.com/neighbor",
+            }
+        ]
+    ))
+
+    card = report["cards"][0]
+
+    assert card["url"] == ""
+    assert card["query"] == "support automation tools"
+    assert card["related_urls"] == ["https://example.com/neighbor"]
+    assert card["recommendation_ids"] == ["gap-0"]
+
+
+def test_recommendation_payload_is_deterministic_with_cards_and_suppression() -> None:
+    kwargs = {
+        "duplicates_rows": [
+            {
+                "similarity": 0.98,
+                "url_a": "https://example.com/a",
+                "url_b": "https://example.com/b",
+            }
+        ],
+        "answerability_payload": [
+            {"url": "https://example.com/b", "score": 2.0, "flags": ["missing FAQ"]},
+            {"url": "https://example.com/a", "score": 2.0, "flags": ["missing FAQ"]},
+        ],
+        "linkgraph_payload": {
+            "top_authority_pages": [{"url": "https://example.com/a", "pagerank": 0.02}]
+        },
+    }
+
+    assert to_payload(synthesize(**kwargs)) == to_payload(synthesize(**kwargs))
+
+
+def test_items_shape_and_summary_counts_remain_kept_only() -> None:
+    report = to_payload(synthesize(
+        duplicates_rows=[
+            {
+                "similarity": 0.98,
+                "url_a": "https://example.com/a",
+                "url_b": "https://example.com/b",
+            }
+        ],
+        answerability_payload=[
+            {"url": "https://example.com/b", "score": 2.0, "flags": ["missing FAQ"]},
+        ],
+        linkgraph_payload={
+            "top_authority_pages": [{"url": "https://example.com/a", "pagerank": 0.02}]
+        },
+    ))
+
+    item = report["items"][0]
+
+    assert report["total"] == 1
+    assert report["by_category"] == {"content_debt": 1}
+    assert "suppressed" not in item
+    assert "suppressed_by" not in item
+    assert "suppressed_reason" not in item
+    assert set(item) == {
+        "id",
+        "category",
+        "type",
+        "priority",
+        "priority_score",
+        "impact",
+        "confidence",
+        "effort_score",
+        "risk",
+        "owner",
+        "cluster",
+        "traffic_opportunity",
+        "estimated_clicks_gain",
+        "estimate_basis",
+        "gain_label",
+        "title",
+        "instruction",
+        "targets",
+        "evidence",
+        "effort",
+        "score",
+    }
+
+
+def test_max_total_truncation_never_resurrects_suppressed_actions() -> None:
+    # More recommendations than max_total: improve-recs for redirect-slated
+    # pages must never reappear in items just because their suppressor was
+    # truncated out of the report.
+    duplicates = [
+        {"similarity": 0.99, "url_a": f"https://example.com/k{i}", "url_b": f"https://example.com/d{i}"}
+        for i in range(8)
+    ]
+    answerability = [
+        {"url": f"https://example.com/d{i}", "score": 1.0, "flags": ["no schema markup"], "title": f"Doomed {i}"}
+        for i in range(8)
+    ]
+
+    recs = synthesize(duplicates_rows=duplicates, answerability_payload=answerability, max_total=3)
+    report = to_payload(recs)
+
+    assert len(report["items"]) <= 3
+    removal_targets = {
+        item["targets"][1]
+        for item in report["items"]
+        if item["id"].startswith("dup-") and len(item["targets"]) > 1
+    }
+    improve_targets = {
+        item["targets"][0]
+        for item in report["items"]
+        if not item["id"].startswith("dup-") and item["targets"]
+    }
+    assert not removal_targets & improve_targets
+    item_ids = {item["id"] for item in report["items"]}
+    for row in report["suppressed"]:
+        assert row["suppressed_by"] in item_ids
+
+
+def test_link_recommendation_to_removal_target_is_suppressed() -> None:
+    report = to_payload(synthesize(
+        duplicates_rows=[
+            {"similarity": 0.99, "url_a": "https://example.com/keep", "url_b": "https://example.com/drop"},
+        ],
+        linkgraph_payload={
+            "recommendations": [
+                {
+                    "source_url": "https://example.com/other",
+                    "source_title": "Other",
+                    "target_url": "https://example.com/drop",
+                    "target_title": "Drop",
+                    "similarity": 0.9,
+                }
+            ]
+        },
+    ))
+
+    link_rows = [row for row in report["suppressed"] if row["id"].startswith("link-")]
+    assert len(link_rows) == 1
+    assert "link destination is slated for redirect/merge" in link_rows[0]["suppressed_reason"]
+    assert all(not item["id"].startswith("link-") for item in report["items"])

--- a/ui/index.html
+++ b/ui/index.html
@@ -2805,7 +2805,8 @@
     const block = document.getElementById('action-plan-block');
     const r = state.recommendations || {};
     const items = (r.items || []);
-    if (!items.length) { block.style.display = 'none'; return; }
+    const suppressed = (r.suppressed || []);
+    if (!items.length && !suppressed.length) { block.style.display = 'none'; return; }
     prepareActionPlanControls(items);
 
     const meta = document.getElementById('action-plan-meta');
@@ -2816,7 +2817,7 @@
       .filter(k => catCounts[k])
       .map(k => `${REC_CAT_LABELS[k]} ${catCounts[k]}`)
       .join(' · ');
-    meta.textContent = `${r.total} actions · high ${counts.high || 0} · medium ${counts.medium || 0} · low ${counts.low || 0} · avg priority ${Number(summary.avg_priority_score || 0).toFixed(1)} — ${catParts}`;
+    meta.textContent = `${r.total} actions · ${summary.cards || (r.cards || []).length || 0} cards · high ${counts.high || 0} · medium ${counts.medium || 0} · low ${counts.low || 0} · suppressed ${summary.suppressed || suppressed.length || 0} · avg priority ${Number(summary.avg_priority_score || 0).toFixed(1)} — ${catParts}`;
 
     document.querySelectorAll('.rec-pri-btn').forEach(b => {
       const on = b.dataset.recPri === state.recPriFilter;
@@ -2833,12 +2834,6 @@
 
     const filtered = filteredActionItems();
     drawActionPriorityMatrix(filtered);
-
-    if (!filtered.length) {
-      document.getElementById('audit-action-plan').innerHTML =
-        '<div class="text-gray-500 text-xs py-3">No actions match this filter.</div>';
-      return;
-    }
 
     const renderRec = rec => {
       const priClass = rec.priority === 'high' ? 'bg-red-100 text-red-800'
@@ -2882,7 +2877,7 @@
           <div class="flex items-start gap-2 flex-wrap">
             <span class="text-xs px-2 py-0.5 rounded font-medium ${priClass} whitespace-nowrap">${rec.priority}</span>
             <span class="text-xs px-2 py-0.5 rounded ${effortClass} whitespace-nowrap">${rec.effort}</span>
-            <span class="text-xs px-2 py-0.5 rounded bg-slate-100 text-slate-700 whitespace-nowrap">${REC_CAT_LABELS[rec.category] || rec.category}</span>
+            <span class="text-xs px-2 py-0.5 rounded bg-slate-100 text-slate-700 whitespace-nowrap">${escapeHtml(REC_CAT_LABELS[rec.category] || rec.category)}</span>
             ${rec.owner ? `<span class="text-xs px-2 py-0.5 rounded bg-gray-100 text-gray-700 whitespace-nowrap">${escapeHtml(rec.owner)}</span>` : ''}
             ${rec.cluster ? `<span class="text-xs px-2 py-0.5 rounded bg-gray-100 text-gray-700 whitespace-nowrap">${escapeHtml(truncateMiddle(rec.cluster, 32))}</span>` : ''}
             <span class="font-medium text-gray-900">${escapeHtml(rec.title)}</span>
@@ -2893,24 +2888,108 @@
           ${scoreLine}
         </div>`;
     };
+    const priorityRank = { high: 0, medium: 1, low: 2 };
+    const renderCard = (card, cardIndex) => {
+      const recs = card.recommendations || [];
+      const priClass = card.top_priority === 'high' ? 'bg-red-100 text-red-800'
+        : card.top_priority === 'medium' ? 'bg-orange-100 text-orange-800'
+        : 'bg-gray-100 text-gray-700';
+      const effortClass = card.effort_total === 'quick' ? 'bg-green-50 text-green-700'
+        : card.effort_total === 'deep' ? 'bg-purple-50 text-purple-700'
+        : 'bg-blue-50 text-blue-700';
+      const gainText = card.total_estimated_clicks_gain != null
+        ? `≈ +${Number(card.total_estimated_clicks_gain || 0).toFixed(0)} clicks/period`
+        : '—';
+      const cats = (card.categories || []).map(cat =>
+        `<span class="text-xs px-2 py-0.5 rounded bg-slate-100 text-slate-700 whitespace-nowrap">${escapeHtml(REC_CAT_LABELS[cat] || cat)}</span>`
+      ).join('');
+      const urlLine = card.url
+        ? `<a class="text-blue-600 hover:underline break-all" href="${escapeHtml(card.url)}" target="_blank" rel="noopener">${escapeHtml(card.url)}</a>`
+        : `<span class="text-gray-600">New content: ${escapeHtml(card.query || card.title || '')}</span>`;
+      const related = (card.related_urls || []).slice(0, 5).map(u =>
+        `<a class="text-blue-600 hover:underline break-all" href="${escapeHtml(u)}" target="_blank" rel="noopener">${escapeHtml(u)}</a>`
+      ).join(' · ');
+      return `
+        <details class="border border-gray-200 rounded-lg bg-white mb-3"${cardIndex < 3 ? ' open' : ''}>
+          <summary class="cursor-pointer list-none p-3 hover:bg-gray-50">
+            <div class="flex items-start justify-between gap-3 flex-wrap">
+              <div class="min-w-0">
+                <div class="font-semibold text-gray-900">${escapeHtml(card.title || card.url || card.query || 'Action group')}</div>
+                <div class="text-xs mt-1">${urlLine}</div>
+                ${related ? `<div class="text-xs text-gray-500 mt-1">Related: ${related}</div>` : ''}
+              </div>
+              <div class="flex items-center gap-2 flex-wrap justify-end text-xs">
+                <span class="px-2 py-0.5 rounded font-medium ${priClass} whitespace-nowrap">${escapeHtml(card.top_priority || '')}</span>
+                <span class="px-2 py-0.5 rounded ${effortClass} whitespace-nowrap">${escapeHtml(card.effort_total || '')}</span>
+                ${cats}
+                <span class="px-2 py-0.5 rounded bg-gray-100 text-gray-700 whitespace-nowrap">${escapeHtml(gainText)}</span>
+                <span class="px-2 py-0.5 rounded bg-gray-100 text-gray-700 whitespace-nowrap">${recs.length} actions</span>
+              </div>
+            </div>
+          </summary>
+          <div class="px-3 pb-1 border-t border-gray-100">${recs.map(renderRec).join('')}</div>
+        </details>`;
+    };
+    const renderSuppressed = rec => `
+      <div class="py-3 border-b border-gray-200 opacity-75">
+        <div class="flex items-start gap-2 flex-wrap">
+          <span class="text-xs px-2 py-0.5 rounded bg-gray-200 text-gray-700 whitespace-nowrap">suppressed</span>
+          <span class="text-xs px-2 py-0.5 rounded bg-slate-100 text-slate-700 whitespace-nowrap">${escapeHtml(REC_CAT_LABELS[rec.category] || rec.category)}</span>
+          <span class="font-medium text-gray-800">${escapeHtml(rec.title || '')}</span>
+        </div>
+        <div class="text-xs text-gray-500 mt-1">${escapeHtml(rec.suppressed_reason || '')}</div>
+        <div class="text-sm text-gray-600 mt-1.5">${escapeHtml(rec.instruction || '')}</div>
+      </div>`;
+
+    const visibleIds = new Set(filtered.map(rec => rec.id));
+    const filteredCards = (r.cards || []).map(card => {
+      const recs = (card.recommendations || []).filter(rec => visibleIds.has(rec.id));
+      if (!recs.length) return null;
+      const gains = recs.filter(rec => rec.estimated_clicks_gain != null).map(rec => Number(rec.estimated_clicks_gain || 0));
+      const priorities = recs.map(rec => rec.priority || 'low').sort((a, b) => (priorityRank[a] ?? 9) - (priorityRank[b] ?? 9));
+      return {
+        ...card,
+        recommendations: recs,
+        recommendation_ids: recs.map(rec => rec.id),
+        categories: Array.from(new Set(recs.map(rec => rec.category).filter(Boolean))).sort(),
+        total_estimated_clicks_gain: gains.length ? gains.reduce((a, b) => a + b, 0) : null,
+        top_priority: priorities[0] || card.top_priority,
+        top_priority_score: Math.max(...recs.map(rec => Number(rec.priority_score || 0))),
+      };
+    }).filter(Boolean);
+
     let html = '';
-    if (state.recGroup) {
+    if (!filtered.length) {
+      html = '<div class="text-gray-500 text-xs py-3">No active actions match this filter.</div>';
+    } else {
+      html = `<div class="text-xs text-gray-500 mb-2">${filteredCards.length}/${(r.cards || []).length} cards shown · ${filtered.length}/${items.length} actions shown</div>` +
+        filteredCards.map(renderCard).join('') +
+        '<h4 class="text-sm font-semibold text-gray-900 mt-5 mb-1">All actions</h4>';
+    }
+    if (state.recGroup && filtered.length) {
       const groups = new Map();
       filtered.forEach(rec => {
         const key = rec[state.recGroup] || 'Unassigned';
         if (!groups.has(key)) groups.set(key, []);
         groups.get(key).push(rec);
       });
-      html = Array.from(groups.entries()).map(([key, rows]) => `
+      html += Array.from(groups.entries()).map(([key, rows]) => `
         <div class="mt-4 first:mt-0">
           <div class="text-xs uppercase tracking-wide text-gray-500 font-semibold mb-1">${escapeHtml(String(key).replaceAll('_', ' '))} · ${rows.length}</div>
           ${rows.map(renderRec).join('')}
         </div>`).join('');
-    } else {
-      html = filtered.map(renderRec).join('');
+    } else if (filtered.length) {
+      html += filtered.map(renderRec).join('');
+    }
+    if (suppressed.length) {
+      html += `
+        <details class="mt-5 rounded-lg border border-gray-200 bg-gray-50">
+          <summary class="cursor-pointer p-3 text-sm font-semibold text-gray-700">${suppressed.length} suppressed actions</summary>
+          <div class="px-3 pb-1 border-t border-gray-200">${suppressed.map(renderSuppressed).join('')}</div>
+        </details>`;
     }
     document.getElementById('audit-action-plan').innerHTML =
-      `<div class="text-xs text-gray-500 mb-2">${filtered.length}/${items.length} actions shown</div>` + html;
+      html;
   }
 
   function drawActionPriorityMatrix(rows) {


### PR DESCRIPTION
Closes #270

## What

- `_resolve_conflicts`: duplicate drops and cannibalization runner-ups become removal targets; improve-recs whose primary target is slated for removal are suppressed with `suppressed_by`/reason, shown in a collapsed block instead of `items`. Internal-link recs pointing **at** a doomed page are suppressed too.
- `to_cards`: one card per URL aggregating member recommendations — summed modeled click gain (None-safe), top priority, categories, heaviest-member effort label; multi-target actions file under the canonical URL with `related_urls`; coverage gaps become new-content pseudo-cards keyed by query.
- UI: cards are the primary action-plan view (first 3 expanded), flat "All actions" list retained, suppressed block greyed at the end. Docs updated.

## Review fixes (code-review agent)

- **Critical**: `max_total` truncation could resurrect suppressed recs (to_payload re-resolved conflicts on the truncated list, un-suppressing improve-recs for pages still slated for 301). Conflicts now resolve exactly once; truncation keeps only suppressions whose suppressor survived; regression test with an over-budget fixture asserts no kept improve-rec targets a kept removal URL.
- Link-destination suppression added (the issue's headline conflict example).
- Suppressor attribution priority-ordered and self-contained; card titles scan all members; effort label = heaviest member (three quick edits no longer read "deep"); cards computed once; category labels HTML-escaped.

## Tests

`pytest -q`: 543 passed. Covers suppression direction (dup + cann), canonical survival, link-destination suppression, truncation regression, card grouping/gains/pseudo-cards, determinism, payload backward compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)