### PR TITLE
Recover non-finite embeddings per row instead of re-encoding chunks on CPU

### DIFF
--- a/site_audit/embedder.py
+++ b/site_audit/embedder.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import logging
 import os
-from contextlib import ExitStack, nullcontext, redirect_stderr, redirect_stdout
+from contextlib import ExitStack, contextmanager, nullcontext, redirect_stderr, redirect_stdout
 from dataclasses import dataclass
 from io import StringIO
 from typing import Iterable, List
@@ -40,6 +40,38 @@ def _quiet_model_load():
     stack.enter_context(redirect_stdout(StringIO()))
     stack.enter_context(redirect_stderr(StringIO()))
     return stack
+
+
+def _non_finite_row_indices(arr: np.ndarray) -> np.ndarray:
+    if arr.size == 0:
+        return np.zeros(0, dtype=np.int64)
+    return np.flatnonzero(~np.isfinite(arr).all(axis=1))
+
+
+@contextmanager
+def _cpu_thread_boost():
+    """Temporarily raise torch's intra-op threads for a CPU fallback encode.
+
+    ``site_audit.__init__`` pins ``OMP_NUM_THREADS=1`` so faiss and torch can
+    share libomp, which makes CPU encoding of this model ~100x slower than the
+    hardware allows. ``torch.set_num_threads`` overrides the pin for torch
+    only, and the previous value is restored afterwards.
+    """
+    try:
+        import torch
+
+        previous = torch.get_num_threads()
+        torch.set_num_threads(max(1, (os.cpu_count() or 2) // 2))
+    except Exception:
+        yield
+        return
+    try:
+        yield
+    finally:
+        try:
+            torch.set_num_threads(previous)
+        except Exception:
+            pass
 
 
 def _embed_cache_save_every(default: int = DEFAULT_EMBED_CACHE_SAVE_EVERY) -> int:
@@ -150,23 +182,65 @@ class Embedder:
             batch_size=batch_size,
             show_progress=show_progress,
         )
-        if np.isfinite(arr).all():
+        bad = _non_finite_row_indices(arr)
+        if bad.size == 0:
             return arr
         if self._device != "cpu":
+            # MPS returns NaN rows under allocator pressure instead of
+            # raising; freeing its cache and re-encoding just the bad rows
+            # usually recovers without leaving the accelerator.
             LOG.warning(
-                "Embedding model returned non-finite vectors on %s; retrying on CPU",
-                self._device or "auto",
+                "Embedding model returned %d/%d non-finite vectors on %s; "
+                "clearing accelerator cache and retrying those rows",
+                bad.size, len(texts), self._device or "auto",
+            )
+            self._clear_accelerator_cache()
+            self._reencode_rows(arr, texts, bad, batch_size=batch_size)
+            bad = _non_finite_row_indices(arr)
+            if bad.size == 0:
+                return arr
+            # Only the still-bad rows go to CPU — re-encoding the whole
+            # chunk there takes hours under the OMP_NUM_THREADS=1 pin.
+            LOG.warning(
+                "%d vectors still non-finite after accelerator retry; "
+                "re-encoding those rows on CPU",
+                bad.size,
             )
             self._model = None
             self._ensure("cpu")
-            arr = self._encode_current_model(
-                texts,
-                batch_size=batch_size,
-                show_progress=show_progress,
-            )
-            if np.isfinite(arr).all():
+            with _cpu_thread_boost():
+                self._reencode_rows(arr, texts, bad, batch_size=batch_size)
+            bad = _non_finite_row_indices(arr)
+            if bad.size == 0:
                 return arr
         raise RuntimeError("Embedding model returned non-finite vectors")
+
+    def _reencode_rows(
+        self,
+        arr: np.ndarray,
+        texts: list[str],
+        indices: np.ndarray,
+        *,
+        batch_size: int,
+    ) -> None:
+        retry = self._encode_current_model(
+            [texts[i] for i in indices],
+            batch_size=batch_size,
+            show_progress=False,
+        )
+        for k, i in enumerate(indices):
+            arr[i] = retry[k]
+
+    def _clear_accelerator_cache(self) -> None:
+        try:
+            import torch
+
+            if getattr(torch, "mps", None) is not None and torch.backends.mps.is_available():
+                torch.mps.empty_cache()
+            elif torch.cuda.is_available():
+                torch.cuda.empty_cache()
+        except Exception:  # best-effort; the CPU fallback still applies
+            pass
 
     def encode_pages(
         self,

--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -3,7 +3,13 @@ import pytest
 import torch
 
 from site_audit.cache import EmbeddingCache, content_hash
-from site_audit.embedder import EmbedInput, Embedder, _reset_position_ids
+from site_audit.embedder import (
+    EmbedInput,
+    Embedder,
+    _cpu_thread_boost,
+    _non_finite_row_indices,
+    _reset_position_ids,
+)
 
 
 class FakeEmbeddingCache:
@@ -128,6 +134,99 @@ def test_reset_position_ids_preserves_existing_buffer_rank() -> None:
 
     assert model.embeddings.position_ids.shape == (1, 8)
     assert model.embeddings.position_ids.tolist() == [list(range(8))]
+
+
+class ScriptedEmbedder(Embedder):
+    """Embedder whose model calls follow a scripted sequence of outputs."""
+
+    def __init__(self, script) -> None:
+        super().__init__("stub-model")
+        self._script = list(script)
+        self.calls: list[tuple[str | None, list[str]]] = []
+
+    def _ensure(self, device: str | None = None) -> None:
+        self._device = device
+        self._model = object()
+
+    def _clear_accelerator_cache(self) -> None:
+        pass
+
+    def _encode_current_model(self, texts, *, batch_size, show_progress):
+        self.calls.append((self._device, list(texts)))
+        return np.asarray(self._script.pop(0)(texts), dtype=np.float32)
+
+
+def _finite(texts):
+    return np.ones((len(texts), 3), dtype=np.float32)
+
+
+def _nan_at(bad_positions):
+    def fn(texts):
+        arr = np.ones((len(texts), 3), dtype=np.float32)
+        for pos in bad_positions:
+            arr[pos] = np.nan
+        return arr
+
+    return fn
+
+
+def test_non_finite_row_indices() -> None:
+    arr = np.ones((3, 2), dtype=np.float32)
+    arr[1, 0] = np.inf
+    assert _non_finite_row_indices(arr).tolist() == [1]
+    assert _non_finite_row_indices(np.zeros((0, 0), dtype=np.float32)).tolist() == []
+
+
+def test_encode_finite_passthrough_makes_one_call() -> None:
+    emb = ScriptedEmbedder([_finite])
+
+    result = emb.encode(["a", "b", "c"])
+
+    assert result.shape == (3, 3)
+    assert len(emb.calls) == 1
+
+
+def test_accelerator_retry_reencodes_only_bad_rows() -> None:
+    emb = ScriptedEmbedder([_nan_at([1]), _finite])
+
+    result = emb.encode(["a", "b", "c"])
+
+    assert np.isfinite(result).all()
+    assert len(emb.calls) == 2
+    # The retry stays on the accelerator (no device switch) and receives
+    # only the non-finite row's text.
+    assert emb.calls[1] == (None, ["b"])
+
+
+def test_cpu_fallback_reencodes_only_still_bad_rows() -> None:
+    emb = ScriptedEmbedder([_nan_at([0, 2]), _nan_at([0, 1]), _finite])
+
+    result = emb.encode(["a", "b", "c"])
+
+    assert np.isfinite(result).all()
+    assert len(emb.calls) == 3
+    assert emb.calls[1] == (None, ["a", "c"])
+    assert emb.calls[2] == ("cpu", ["a", "c"])
+
+
+def test_raises_when_rows_stay_non_finite() -> None:
+    emb = ScriptedEmbedder([_nan_at([1]), _nan_at([0]), _nan_at([0])])
+
+    with pytest.raises(RuntimeError, match="non-finite"):
+        emb.encode(["a", "b"])
+
+
+def test_cpu_thread_boost_sets_and_restores(monkeypatch) -> None:
+    seen: list[int] = []
+    monkeypatch.setattr(torch, "get_num_threads", lambda: 1)
+    monkeypatch.setattr(torch, "set_num_threads", lambda n: seen.append(n))
+
+    with _cpu_thread_boost():
+        pass
+
+    assert len(seen) == 2
+    assert seen[0] >= 1
+    assert seen[1] == 1
 
 
 def test_embedding_cache_ignores_and_rejects_non_finite_vectors(tmp_path) -> None:


### PR DESCRIPTION
Closes #290

Observed on a 51k-page audit: one page-embedding chunk returned NaN on MPS (allocator pressure at ~30 GB RSS despite the 512-token cap) and the fallback re-encoded all 2,048 texts on CPU — measured at ~120 s/batch under the `OMP_NUM_THREADS=1` pin, ≈2 hours for the chunk.

Now `Embedder.encode`:
1. identifies the non-finite **rows** (usually a handful),
2. clears the accelerator cache (`torch.mps.empty_cache()` / CUDA equivalent) and retries just those rows on the accelerator,
3. only if still bad, re-encodes just those rows on CPU with `torch.set_num_threads()` temporarily raised (restored after; the OMP pin stays in place for faiss),
4. still raises `RuntimeError` if anything remains non-finite, so poisoned vectors are never cached.

`pytest -q`: 623 passed. New tests cover row-scoped accelerator retry, row-scoped CPU fallback, the raise path, thread-boost set/restore, and the pre-existing full-fallback test still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)