### PR TITLE
serp-gap: fact-check drafted numbers, featured-snippet targeting, AI Overview capture

### DIFF
--- a/site_audit/agent_workspace.py
+++ b/site_audit/agent_workspace.py
@@ -24,7 +24,8 @@ def _slug(url: str) -> str:
     return slug[:90].strip("-") or "home"
 
 
-def _evidence_payload(page: dict) -> dict:
+def agent_evidence_payload(page: dict) -> dict:
+    """Evidence payload the agent sees: the page copy minus agent outputs and scatter data."""
     payload = copy.deepcopy(page)
     payload.pop("ai_editor_brief", None)
     payload.pop("ai_recommendation", None)
@@ -203,7 +204,7 @@ def write_agent_workspace(
         except FileNotFoundError:
             pass
     (workspace / "evidence.json").write_text(
-        json.dumps(_evidence_payload(page), ensure_ascii=False, indent=1),
+        json.dumps(agent_evidence_payload(page), ensure_ascii=False, indent=1),
         encoding="utf-8",
     )
     (workspace / "our_page.md").write_text(_our_page_markdown(page, own_ext), encoding="utf-8")

--- a/site_audit/ai_agent.py
+++ b/site_audit/ai_agent.py
@@ -860,6 +860,8 @@ def _editor_prompt_payload(page: dict) -> dict:
                     for row in (analysis.get("paa_coverage") or [])[:10]
                 ],
                 "related_searches": (analysis.get("serp_features") or {}).get("related_searches") or [],
+                "answer_box": (analysis.get("serp_features") or {}).get("answer_box") or {},
+                "ai_overview": (analysis.get("serp_features") or {}).get("ai_overview"),
             },
             "topics": topics,
             "covered_topics": [

--- a/site_audit/draft_verification.py
+++ b/site_audit/draft_verification.py
@@ -9,6 +9,8 @@ see whether the recommendation actually closes the gap.
 
 from __future__ import annotations
 
+import re
+from dataclasses import asdict, dataclass
 from typing import Callable
 
 import numpy as np
@@ -16,6 +18,218 @@ import numpy as np
 # Keep in sync with build_serp_paragraph_gap() in competitive_analysis.py.
 COVERED_THRESHOLD = 0.78
 PARTIAL_THRESHOLD = 0.62
+
+
+@dataclass(frozen=True)
+class Claim:
+    """A numeric claim found in draft copy."""
+
+    text: str
+    number: str
+    normalized: str
+    kind: str
+    context: str
+    needs_data: bool = False
+
+
+_CURRENCY_CODES = "USD|EUR|GBP|CZK|PLN|HUF|CHF|CAD|AUD|NZD|SEK|NOK|DKK"
+_CURRENCY_SYMBOLS = r"$€£"
+_NUM_CORE = r"\d+(?:[,\s]\d{3})*(?:[.,]\d+)?|\d+(?:[.,]\d+)?"
+_NUMERIC_RE = re.compile(
+    rf"""
+    (?P<currency_prefix>(?:[{re.escape(_CURRENCY_SYMBOLS)}]|(?:{_CURRENCY_CODES})\b)\s*(?P<currency_prefix_num>{_NUM_CORE}))
+    |
+    (?P<currency_suffix>(?P<currency_suffix_num>{_NUM_CORE})\s*(?:[{re.escape(_CURRENCY_SYMBOLS)}]|\b(?:{_CURRENCY_CODES})\b))
+    |
+    (?P<percent>(?P<percent_num>{_NUM_CORE})\s*(?:%|\bpercent\b|\bpercentage\s+points?\b))
+    |
+    (?P<multiplier>(?P<multiplier_num>\d+(?:[.,]\d+)?)\s*x\b)
+    |
+    (?P<count>\b(?P<count_num>{_NUM_CORE})\b)
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+_ORDERED_LIST_RE = re.compile(r"(?m)^\s*\d+[.)]\s+\S")
+_BULLET_LIST_RE = re.compile(r"(?m)^\s*[-*+]\s+\S")
+_HEADING_COUNT_RE = re.compile(
+    r"^\s{0,3}#{1,6}\s+(?P<number>\d+)\s+(?P<noun>ways|tips|steps|reasons|items|examples|ideas|checks)\b",
+    re.IGNORECASE,
+)
+_LIST_POSITION_RE = re.compile(r"^\s*(?:#{1,6}\s*)?\d+[.)]\s+")
+_NEEDS_DATA_RE = re.compile(r"\[NEEDS DATA\]", re.IGNORECASE)
+_SENTENCE_BOUNDARY_RE = re.compile(r"[.!?\n]")
+_MONTHS = (
+    r"(?:january|february|march|april|may|june|july|august|september|october|november|december"
+    r"|jan|feb|mar|apr|jun|jul|aug|sept?|oct|nov|dec)"
+)
+_MONTH_BEFORE_DAY_RE = re.compile(rf"\b{_MONTHS}\.?\s+$", re.IGNORECASE)
+_DAY_BEFORE_MONTH_RE = re.compile(rf"^(?:st|nd|rd|th)?,?\s+(?:of\s+)?{_MONTHS}\b", re.IGNORECASE)
+
+
+def _numeric_context(text: str, start: int, end: int, radius: int = 70) -> str:
+    left = max(0, start - radius)
+    right = min(len(text), end + radius)
+    context = re.sub(r"\s+", " ", text[left:right]).strip()
+    return context
+
+
+def _sentence_for_span(text: str, start: int, end: int) -> str:
+    """Return the sentence containing ``text[start:end]`` (boundaries: . ! ? or newline)."""
+    left = 0
+    for boundary in _SENTENCE_BOUNDARY_RE.finditer(text, 0, start):
+        left = boundary.end()
+    boundary = _SENTENCE_BOUNDARY_RE.search(text, end)
+    right = boundary.start() if boundary else len(text)
+    return text[left:right]
+
+
+def _normalized_number(value: str) -> str:
+    cleaned = re.sub(r"(?<=\d)[,\s](?=\d{3}\b)", "", str(value or ""))
+    cleaned = cleaned.replace(",", ".")
+    cleaned = re.sub(r"[^0-9.]", "", cleaned)
+    if "." in cleaned:
+        cleaned = cleaned.rstrip("0").rstrip(".")
+    return cleaned
+
+
+def _claim_kind(match: re.Match[str]) -> tuple[str, str]:
+    if match.group("currency_prefix"):
+        return "currency", match.group("currency_prefix_num")
+    if match.group("currency_suffix"):
+        return "currency", match.group("currency_suffix_num")
+    if match.group("percent"):
+        return "percent", match.group("percent_num")
+    if match.group("multiplier"):
+        return "multiplier", match.group("multiplier_num")
+    return "count", match.group("count_num")
+
+
+def _line_for_offset(text: str, offset: int) -> str:
+    start = text.rfind("\n", 0, offset) + 1
+    end = text.find("\n", offset)
+    if end < 0:
+        end = len(text)
+    return text[start:end]
+
+
+def _is_heading_item_count(line: str, number: str, draft_markdown: str) -> bool:
+    match = _HEADING_COUNT_RE.search(line)
+    if not match or match.group("number") != number:
+        return False
+    expected = int(number)
+    list_items = len(_ORDERED_LIST_RE.findall(draft_markdown))
+    if list_items == expected:
+        return True
+    return len(_BULLET_LIST_RE.findall(draft_markdown)) == expected
+
+
+def _is_decimal_fragment(match: re.Match[str], text: str) -> bool:
+    """True when the match is the tail of a larger token split by ``[.,]`` (e.g. "4" in "v2.4")."""
+    start = match.start()
+    return start >= 2 and text[start - 1] in ".," and text[start - 2].isdigit()
+
+
+def _is_day_of_month(raw: str, match: re.Match[str], text: str) -> bool:
+    if not raw.isdigit() or not 1 <= int(raw) <= 31:
+        return False
+    if _MONTH_BEFORE_DAY_RE.search(text, 0, match.start()):
+        return True
+    return bool(_DAY_BEFORE_MONTH_RE.match(text[match.end():]))
+
+
+def _is_excluded_count(match: re.Match[str], text: str, normalized: str) -> bool:
+    line = _line_for_offset(text, match.start())
+    raw = match.group(0).strip()
+    if re.fullmatch(r"\d{4}", raw):
+        year = int(raw)
+        if 1990 <= year <= 2030:
+            return True
+    if _is_decimal_fragment(match, text):
+        return True
+    if _is_day_of_month(raw, match, text):
+        return True
+    if _LIST_POSITION_RE.match(line) and line.strip().startswith(raw):
+        return True
+    if _is_heading_item_count(line, raw, text):
+        return True
+    return not normalized
+
+
+def extract_numeric_claims(text: str) -> list[Claim]:
+    """Extract numeric claims from draft text with local context."""
+    draft = str(text or "")
+    claims: list[Claim] = []
+    seen: set[tuple[str, int, int]] = set()
+    for match in _NUMERIC_RE.finditer(draft):
+        kind, raw_number = _claim_kind(match)
+        normalized = _normalized_number(raw_number)
+        if kind == "count" and _is_excluded_count(match, draft, normalized):
+            continue
+        context = _numeric_context(draft, match.start(), match.end())
+        sentence = _sentence_for_span(draft, match.start(), match.end())
+        claim = Claim(
+            text=match.group(0).strip(),
+            number=raw_number.strip(),
+            normalized=normalized,
+            kind=kind,
+            context=context,
+            needs_data=bool(_NEEDS_DATA_RE.search(sentence)),
+        )
+        key = (claim.text, match.start(), match.end())
+        if key not in seen:
+            seen.add(key)
+            claims.append(claim)
+    return claims
+
+
+def _number_pattern(normalized: str) -> str:
+    if not normalized:
+        return r"(?!x)x"
+    if "." in normalized:
+        whole, decimal = normalized.split(".", 1)
+        return rf"{_integer_number_pattern(whole)}[\.,]{re.escape(decimal)}"
+    return _integer_number_pattern(normalized)
+
+
+def _integer_number_pattern(normalized: str) -> str:
+    digits = re.escape(normalized)
+    if len(normalized) > 3:
+        groups = []
+        rest = normalized
+        while rest:
+            groups.append(rest[-3:])
+            rest = rest[:-3]
+        grouped = r"[,\s]?".join(re.escape(group) for group in reversed(groups))
+        return rf"(?:{digits}|{grouped})"
+    return digits
+
+
+def _claim_verified(claim: Claim, evidence_text: str) -> bool:
+    number = _number_pattern(claim.normalized)
+    if claim.kind == "percent":
+        pattern = rf"(?<!\d){number}\s*(?:%|percent|percentage\s+points?)(?!\w)"
+    elif claim.kind == "multiplier":
+        pattern = rf"(?<!\d){number}\s*(?:x|times)(?!\w)"
+    elif claim.kind == "currency":
+        marker = rf"(?:[{re.escape(_CURRENCY_SYMBOLS)}]|\b(?:{_CURRENCY_CODES})\b)"
+        pattern = rf"(?:{marker}\s*{number}|{number}\s*{marker})"
+    else:
+        pattern = rf"(?<!\d){number}(?!\d)"
+    return bool(re.search(pattern, evidence_text, flags=re.IGNORECASE))
+
+
+def verify_numeric_claims(draft_markdown: str, evidence_texts: list[str]) -> dict:
+    """Verify draft numeric claims against supplied evidence text."""
+    evidence_text = "\n".join(str(text or "") for text in evidence_texts)
+    verified: list[dict] = []
+    unverified: list[dict] = []
+    for claim in extract_numeric_claims(draft_markdown):
+        payload = asdict(claim)
+        if claim.needs_data or _claim_verified(claim, evidence_text):
+            verified.append(payload)
+        else:
+            unverified.append(payload)
+    return {"verified": verified, "unverified": unverified}
 
 
 def assemble_recommended_blocks(own_paragraphs: list[str], recommendation: dict) -> list[dict]:

--- a/site_audit/fix_drafts.py
+++ b/site_audit/fix_drafts.py
@@ -15,13 +15,13 @@ from .ai_agent import (
     openrouter_api_key,
     openrouter_model,
 )
+from .draft_verification import verify_numeric_claims
 
 
 _DRAFTABLE_PREFIXES = ("title-", "ctr-", "geo-", "gap-")
 _TITLE_PREFIXES = ("title-", "ctr-")
 _SEPARATORS = (" | ", " — ", " - ", " – ", " :: ", " : ")
 _SENTENCE_RE = re.compile(r"(?<=[.!?])\s+")
-_DIGIT_RE = re.compile(r"\d{2,}")
 
 
 @dataclass
@@ -553,15 +553,16 @@ def _first_sentence(text: str) -> str:
 
 
 def _has_unseen_number(text: str, context_text: str) -> bool:
-    """Flag digit sequences (2+ digits) in ``text`` that never appear in the context.
+    """Flag numeric claims in ``text`` that are not grounded in the context.
 
-    Known, accepted limitations of this cheap check: single-digit inventions
-    ("Top 5") and digits split across tokens ("7 3") pass, and any 2+-digit
-    number present anywhere in the context JSON (e.g. word_count, evidence
-    volume/position) legitimizes those digits regardless of meaning.
+    Delegates to :func:`site_audit.draft_verification.verify_numeric_claims` so the
+    main report and the SERP-gap verification loop share one digit-grounding
+    checker (typed claims, fuzzy formatting variants, year/list/date exclusions,
+    [NEEDS DATA] exemption). Known, accepted limitation: any number present
+    anywhere in the context JSON (e.g. word_count, evidence volume/position)
+    legitimizes the same number in the draft regardless of meaning.
     """
-    context_numbers = set(_DIGIT_RE.findall(context_text or ""))
-    return any(number not in context_numbers for number in _DIGIT_RE.findall(text or ""))
+    return bool(verify_numeric_claims(text or "", [context_text or ""])["unverified"])
 
 
 def _object_dict(value: Any) -> dict:

--- a/site_audit/serp_gap.py
+++ b/site_audit/serp_gap.py
@@ -23,7 +23,7 @@ from urllib.parse import urlparse
 import numpy as np
 import requests
 
-from .agent_workspace import write_agent_workspace
+from .agent_workspace import agent_evidence_payload, write_agent_workspace
 from .ai_agent import (
     DEFAULT_OPENROUTER_MODEL,
     MissingOpenRouterKey,
@@ -45,7 +45,7 @@ from .ai_agent import (
 )
 from .analyzer import PageInfo, section_for_url
 from .cache import HttpCache, content_hash, domain_slug
-from .draft_verification import assemble_recommended_blocks, verify_recommendation
+from .draft_verification import assemble_recommended_blocks, verify_numeric_claims, verify_recommendation
 from .answerability import score_page
 from .competitive_analysis import (
     CompetitiveTarget,
@@ -485,7 +485,7 @@ def run(config: SerpGapConfig) -> dict:
                 own_paragraphs=own_paragraphs_for_page,
                 own_embeddings=own_embeddings_for_page,
             )
-            features = _serp_features(serp)
+            features = _serp_features(serp, config.domain)
             gap["serp_features"] = features
             gap["paa_coverage"] = _paa_coverage(features, own_paragraphs_for_page, own_embeddings_for_page, embedder)
             serp_rows = _serp_result_rows(serp)
@@ -1443,11 +1443,93 @@ def _serp_result_rows(payload: dict) -> list[dict]:
     return rows
 
 
-def _serp_features(payload: dict) -> dict:
-    """Extract People Also Ask, related searches, and answer box from a SERP payload."""
-    features: dict = {"people_also_ask": [], "related_searches": [], "answer_box": {}}
+def _word_count(text: str) -> int:
+    return len(re.findall(r"[A-Za-z0-9][A-Za-z0-9'-]*", str(text or "")))
+
+
+def _snippet_format(answer: str, source: dict | None = None) -> str:
+    source = source or {}
+    if source.get("table") or source.get("table_items") or source.get("tableRows"):
+        return "table"
+    if source.get("list") or source.get("items") or source.get("list_items"):
+        return "list"
+    lines = [line.strip() for line in str(answer or "").splitlines() if line.strip()]
+    if len(lines) >= 2 and all(re.match(r"^(?:[-*•]|\d+[.)])\s+", line) for line in lines[:3]):
+        return "list"
+    return "paragraph"
+
+
+def _answer_box_payload(title: str, answer: str, url: str, source: dict | None = None) -> dict:
+    return {
+        "title": str(title or "").strip(),
+        "answer": str(answer or "").strip(),
+        "url": str(url or "").strip(),
+        "format": _snippet_format(answer, source),
+        "word_count": _word_count(answer),
+    }
+
+
+def _domain_from_value(value: str) -> str:
+    raw = str(value or "").strip()
+    if not raw:
+        return ""
+    if "://" in raw:
+        return urlparse(raw).netloc.lower().removeprefix("www.")
+    if "." in raw and "/" not in raw:
+        return raw.lower().removeprefix("www.")
+    return ""
+
+
+def _collect_ai_overview_domains(node) -> list[str]:
+    domains: list[str] = []
+
+    def add_domain(value: str) -> None:
+        domain = _domain_from_value(value)
+        if domain and domain not in domains:
+            domains.append(domain)
+
+    def walk(value) -> None:
+        if len(domains) >= 10:
+            return
+        if isinstance(value, dict):
+            for key in ("url", "link", "source_url", "domain"):
+                add_domain(str(value.get(key) or ""))
+            for nested in value.values():
+                walk(nested)
+        elif isinstance(value, list):
+            for nested in value:
+                walk(nested)
+        elif isinstance(value, str):
+            for url in re.findall(r"https?://[^\s)>\"]+", value):
+                add_domain(url)
+
+    walk(node)
+    return domains[:10]
+
+
+def _ai_overview_payload(node, own_domain: str | None = None) -> dict | None:
+    if isinstance(node, list) and node:
+        node = {"items": node}
+    if not isinstance(node, dict):
+        return None
+    domains = _collect_ai_overview_domains(node)
+    own = _domain_from_value(own_domain or "")
+    cites_us: bool | None = None
+    if domains and own:
+        cites_us = any(domain == own or domain.endswith("." + own) for domain in domains)
+    return {
+        "present": True,
+        "cites_us": cites_us,
+        "cited_domains": domains[:10],
+    }
+
+
+def _serp_features(payload: dict, own_domain: str | None = None) -> dict:
+    """Extract People Also Ask, related searches, answer box, and AI Overview from SERP payloads."""
+    features: dict = {"people_also_ask": [], "related_searches": [], "answer_box": {}, "ai_overview": None}
     raw = payload.get("raw") or {}
     provider = (payload.get("meta") or {}).get("provider") or ""
+    own_domain = own_domain or (payload.get("meta") or {}).get("domain") or (payload.get("meta") or {}).get("own_domain")
     if provider == "serper" or "organic" in raw:
         for item in (raw.get("peopleAlsoAsk") or [])[:10]:
             if not isinstance(item, dict):
@@ -1469,11 +1551,17 @@ def _serp_features(payload: dict) -> dict:
         if isinstance(answer_box, dict):
             answer = str(answer_box.get("answer") or answer_box.get("snippet") or "").strip()
             if answer:
-                features["answer_box"] = {
-                    "title": str(answer_box.get("title") or "").strip(),
-                    "answer": answer,
-                    "url": str(answer_box.get("link") or "").strip(),
-                }
+                features["answer_box"] = _answer_box_payload(
+                    str(answer_box.get("title") or ""),
+                    answer,
+                    str(answer_box.get("link") or ""),
+                    answer_box,
+                )
+        for key in ("aiOverview", "ai_overview", "ai_overview_item"):
+            overview = _ai_overview_payload(raw.get(key), own_domain)
+            if overview is not None:
+                features["ai_overview"] = overview
+                break
         return features
     for item in _serp_items(payload):
         item_type = str(item.get("type") or "")
@@ -1506,11 +1594,9 @@ def _serp_features(payload: dict) -> dict:
         elif item_type == "featured_snippet" and not features["answer_box"]:
             answer = str(item.get("description") or "").strip()
             if answer:
-                features["answer_box"] = {
-                    "title": str(item.get("title") or "").strip(),
-                    "answer": answer,
-                    "url": str(item.get("url") or "").strip(),
-                }
+                features["answer_box"] = _answer_box_payload(str(item.get("title") or ""), answer, str(item.get("url") or ""), item)
+        elif item_type == "ai_overview" and features["ai_overview"] is None:
+            features["ai_overview"] = _ai_overview_payload(item, own_domain)
     return features
 
 
@@ -2030,11 +2116,15 @@ def _attach_winnability(page_results: list[dict], keyword_rows: list[dict], own_
 def _recommendation_header(analysis: dict) -> str:
     win = analysis.get("winnability") or {}
     band = win.get("band")
+    notes: list[str] = []
     if band == "unlikely":
-        return "Content changes alone are unlikely to reach page 1; build authority or target an easier variant first."
-    if band == "hard":
-        return "Hard SERP: proceed with content improvements, but expect link acquisition or authority gains to matter."
-    return ""
+        notes.append("Content changes alone are unlikely to reach page 1; build authority or target an easier variant first.")
+    elif band == "hard":
+        notes.append("Hard SERP: proceed with content improvements, but expect link acquisition or authority gains to matter.")
+    overview = (analysis.get("serp_features") or {}).get("ai_overview")
+    if isinstance(overview, dict) and overview.get("present") and overview.get("cited_domains") and overview.get("cites_us") is False:
+        notes.append("AI Overview is present but does not cite this domain; prioritize direct answers, sourceable facts, and snippet/PAA blocks.")
+    return " ".join(notes)
 
 
 def _enrich_serp_domain_ratings(
@@ -3522,6 +3612,77 @@ def _winnability_prerequisite_action(page: dict, analysis: dict, order: int) -> 
     }
 
 
+def _featured_snippet_action(page: dict, analysis: dict, order: int) -> dict | None:
+    keyword = str((analysis.get("keyword") or {}).get("keyword") or analysis.get("query") or "").strip()
+    answer_box = (analysis.get("serp_features") or {}).get("answer_box") or {}
+    holder_url = str(answer_box.get("url") or "").strip()
+    answer = str(answer_box.get("answer") or "").strip()
+    if not holder_url or not answer:
+        return None
+    own_host = urlparse(str(page.get("url") or "")).netloc
+    if own_host and _is_own_url(holder_url, own_host):
+        return None
+    demand = _keyword_demand(analysis)
+    snippet_format = str(answer_box.get("format") or _snippet_format(answer) or "paragraph")
+    word_count = _safe_int(answer_box.get("word_count")) or _word_count(answer)
+    if snippet_format == "list":
+        format_instruction = "Match the current list structure with concise, parallel list items immediately under the H2."
+    elif snippet_format == "table":
+        format_instruction = "Match the current table structure with a compact comparison table immediately under the H2."
+    else:
+        format_instruction = "Place a 40-55-word direct-answer paragraph immediately under the H2."
+    instruction = (
+        f"Win the featured snippet for '{keyword}'. Current holder: {holder_url}. "
+        f"Current snippet is a {snippet_format} with {word_count} words: \"{answer[:240]}\". "
+        f"Add an H2 phrased as the query ('{keyword}') and {format_instruction}"
+    )
+    acceptance = [
+        f"The page contains an H2 phrased as the query: '{keyword}'.",
+        f"The block immediately after that H2 uses the same snippet format ({snippet_format}).",
+        "Paragraph snippets are 40-55 words; list/table snippets are concise and scannable.",
+        "The answer is original, directly answers the query, and uses only sourceable facts.",
+    ]
+    return {
+        "id": f"win_featured_snippet_{order}",
+        "order": order,
+        "type": "win_featured_snippet",
+        "priority": "high",
+        "action": "Win the featured snippet",
+        "task_summary": f"Create a snippet-ready answer block for '{keyword}'.",
+        "target_url": page.get("url", ""),
+        "keyword": keyword,
+        "topic": "featured snippet",
+        "instruction": instruction,
+        "rationale": "A competitor owns the answer box for this target keyword; matching the answer format gives the page a concrete snippet target.",
+        "placement": f"Immediately under an H2 phrased as '{keyword}'.",
+        "acceptance_criteria": acceptance,
+        "content_brief": {
+            "recommended_heading": keyword,
+            "recommended_format": snippet_format,
+            "placement": f"Immediately under an H2 phrased as '{keyword}'.",
+            "paragraph_plan": [format_instruction, "Use the current holder only as intent/format evidence; write original copy."],
+            "acceptance_criteria": acceptance,
+            "ai_agent_prompt": (
+                f"Add a featured-snippet candidate to {page.get('url', '')} for '{keyword}'. "
+                f"Current holder {holder_url} uses {snippet_format} format and {word_count} words. {format_instruction}"
+            ),
+        },
+        "ai_agent_prompt": (
+            f"Add a featured-snippet candidate to {page.get('url', '')} for '{keyword}'. "
+            f"Current holder {holder_url} uses {snippet_format} format and {word_count} words. {format_instruction}"
+        ),
+        "impact_score": round((65 + demand["score"] * 12) * _analysis_winnability_factor(analysis), 3),
+        "evidence": {
+            "holder_url": holder_url,
+            "snippet_text": answer,
+            "snippet_format": snippet_format,
+            "snippet_word_count": word_count,
+            "keyword_impressions": demand["impressions"],
+            "keyword_volume": demand["volume"],
+        },
+    }
+
+
 def _recommended_outline(analysis: dict) -> list[dict]:
     path = analysis.get("content_order_path") or {}
     rows: list[dict] = []
@@ -3565,6 +3726,10 @@ def _action_points_for_analysis(page: dict, analysis: dict) -> list[dict]:
         order += 1
     if (analysis.get("winnability") or {}).get("band") == "unlikely":
         leading_actions.append(_winnability_prerequisite_action(page, analysis, order))
+        order += 1
+    snippet_action = _featured_snippet_action(page, analysis, order)
+    if snippet_action:
+        actions.append(snippet_action)
         order += 1
     for topic in (analysis.get("missing_topics") or [])[:8]:
         actions.append(_topic_action("add_topic", page, analysis, topic, order))
@@ -3895,6 +4060,10 @@ def _recommended_article_markdown(
         unresolved = summary.get("unresolved_critical") or []
         if unresolved:
             lines.append(f"- **Still uncovered critical/high topics:** {'; '.join(str(x) for x in unresolved[:10])}")
+    unverified = _unverified_number_labels(verification or {})
+    if unverified:
+        lines.append(f"- **Unverified numeric claims:** {'; '.join(unverified[:10])}")
+    if summary or unverified:
         lines.append("")
     for section in new_sections:
         heading = str(section.get("heading") or "").strip()
@@ -3915,21 +4084,118 @@ def _recommended_article_markdown(
     return "\n".join(line for line in lines if line is not None).strip() + "\n"
 
 
+def _recommendation_numeric_text(blocks: list[dict], recommendation: dict) -> str:
+    parts: list[str] = []
+    for key in ("title", "h1", "meta_description"):
+        row = recommendation.get(key) or {}
+        if isinstance(row, dict):
+            value = str(row.get("recommended") or "").strip()
+            if value:
+                parts.append(value)
+    for block in blocks:
+        text = str(block.get("text") or "").strip()
+        if text:
+            parts.append(text)
+    return "\n\n".join(parts)
+
+
+def _numeric_evidence_texts(page: dict, own_paragraphs: list[str] | None = None) -> list[str]:
+    """Every text the agent may legitimately source numbers from.
+
+    Mirrors what the agent actually sees: the full own-page paragraphs (own_content
+    stores truncated copies) plus the same evidence payload written to the agent
+    workspace / chat prompt, so numbers from untouched kept content or any evidence
+    field never get flagged as invented.
+    """
+    texts: list[str] = [str(paragraph or "") for paragraph in own_paragraphs or []]
+    texts.append(json.dumps(agent_evidence_payload(page), ensure_ascii=False, sort_keys=True))
+    for row in (page.get("own_content") or {}).get("paragraphs") or []:
+        if isinstance(row, dict):
+            texts.append(str(row.get("text") or ""))
+    texts.extend(str(item or "") for item in page.get("keywords") or [])
+    for analysis in page.get("analyses") or []:
+        texts.append(json.dumps(analysis.get("keyword") or {}, ensure_ascii=False, sort_keys=True))
+        features = analysis.get("serp_features") or {}
+        texts.append(json.dumps(features, ensure_ascii=False, sort_keys=True))
+        for topic in analysis.get("topics") or []:
+            for example in topic.get("examples") or []:
+                texts.append(str(example.get("paragraph") or ""))
+                texts.append(str(example.get("url") or ""))
+        for row in ((analysis.get("paragraph_match_heatmap") or {}).get("rows") or []):
+            for cell in row.get("cells") or []:
+                texts.append(str(cell.get("paragraph") or ""))
+        for row in analysis.get("structural_patterns") or []:
+            texts.append(json.dumps(row, ensure_ascii=False, sort_keys=True))
+        for row in analysis.get("competitor_pages") or []:
+            texts.append(json.dumps(row, ensure_ascii=False, sort_keys=True))
+    return [text for text in texts if str(text or "").strip()]
+
+
+def _unverified_number_labels(verification: dict) -> list[str]:
+    labels: list[str] = []
+    for claim in verification.get("unverified_numbers") or []:
+        text = str(claim.get("text") or claim.get("number") or "").strip()
+        context = str(claim.get("context") or "").strip()
+        if not text:
+            continue
+        labels.append(f"{text} ({context[:140]})" if context else text)
+    return labels
+
+
+def _verification_repair_prompt(verification: dict, mode: str = "workspace") -> str:
+    if mode == "chat":
+        coverage_fix = "Add or strengthen sections in your recommendation to cover them."
+        closing = " Output the corrected brief and the full recommendation JSON block again."
+    else:
+        coverage_fix = "Update recommendation.json (add or strengthen sections) to cover them."
+        closing = " Modify recommendation.json and brief.md only."
+    instructions: list[str] = []
+    unresolved = (verification.get("summary") or {}).get("unresolved_critical") or []
+    if unresolved:
+        instructions.append(
+            "Verification: these critical/high SERP topics are still not covered by your recommendation: "
+            + "; ".join(str(label) for label in unresolved[:10])
+            + ". "
+            + coverage_fix
+        )
+    unverified = _unverified_number_labels(verification)
+    if unverified:
+        instructions.append(
+            "Replace or source these numbers: "
+            + "; ".join(unverified[:12])
+            + ". Use only numbers present in the Evidence JSON or mark the claim [NEEDS DATA]."
+        )
+    if not instructions:
+        return ""
+    return " ".join(instructions) + closing
+
+
 def _verification_for(
     page: dict,
     recommendation: dict,
     own_paragraphs: list[str],
     embedder: Embedder | None,
 ) -> dict:
-    if embedder is None or not recommendation:
+    if not recommendation:
         return {}
     try:
         blocks = assemble_recommended_blocks(own_paragraphs, recommendation)
-        return verify_recommendation(
-            blocks,
-            page.get("analyses") or [],
-            embed_fn=lambda texts: embedder.encode(texts, batch_size=64).astype(np.float32),
+        verification = (
+            verify_recommendation(
+                blocks,
+                page.get("analyses") or [],
+                embed_fn=lambda texts: embedder.encode(texts, batch_size=64).astype(np.float32),
+            )
+            if embedder is not None
+            else {"topics": [], "paa": [], "summary": {}}
         )
+        numeric = verify_numeric_claims(
+            _recommendation_numeric_text(blocks, recommendation),
+            _numeric_evidence_texts(page, own_paragraphs),
+        )
+        verification["numeric_claims"] = numeric
+        verification["unverified_numbers"] = numeric.get("unverified") or []
+        return verification
     except Exception as exc:
         return {"status": "error", "message": str(exc)}
 
@@ -3988,23 +4254,17 @@ def _attach_workspace_brief(
         verification_repair_attempted = False
         if not errors:
             verification = _verification_for(page, recommendation, own_paragraphs, embedder)
-            unresolved = (verification.get("summary") or {}).get("unresolved_critical") or []
-            if unresolved:
+            repair_prompt = _verification_repair_prompt(verification)
+            if repair_prompt:
                 verification_repair_attempted = True
-                repair_prompt = (
-                    "Verification: these critical/high SERP topics are still not covered by your recommendation: "
-                    + "; ".join(str(label) for label in unresolved[:10])
-                    + ". Update recommendation.json (add or strengthen sections) to cover them. "
-                    "Modify recommendation.json and brief.md only."
-                )
-                completion = _session(repair_prompt, max_turns=max(6, config.ai_agent_max_turns // 2))
-                candidate = (completion.raw or {}).get("recommendation") or {}
-                candidate_errors = validate_recommendation(candidate, paragraph_count)
-                if not candidate_errors:
+                repair_completion = _session(repair_prompt, max_turns=max(6, config.ai_agent_max_turns // 2))
+                candidate = (repair_completion.raw or {}).get("recommendation") or {}
+                if not validate_recommendation(candidate, paragraph_count):
+                    completion = repair_completion
                     recommendation = candidate
                     verification = _verification_for(page, recommendation, own_paragraphs, embedder)
-                else:
-                    errors = candidate_errors
+                # An invalid repair candidate is discarded: keep the original valid
+                # recommendation and its verification instead of failing the page.
         return {
             "brief": completion.text,
             "recommendation": recommendation,
@@ -4084,6 +4344,42 @@ def _attach_chat_brief(
     brief_markdown = completion.text
     if recommendation:
         brief_markdown = re.sub(r"```json\s*\{.*?\}\s*```", "", brief_markdown, flags=re.DOTALL | re.IGNORECASE).strip()
+    verification = {}
+    verification_repair_attempted = False
+    if not errors:
+        verification = _verification_for(page, recommendation, own_paragraphs or [], embedder)
+        repair_prompt = _verification_repair_prompt(verification, mode="chat")
+        if repair_prompt:
+            verification_repair_attempted = True
+            repair_messages = messages + [
+                {"role": "assistant", "content": completion.text},
+                {"role": "user", "content": repair_prompt},
+            ]
+            repair_completion = cached_completion(
+                cache_dir,
+                kind=f"editor-brief-repair-{_url_report_slug(page.get('url', ''))}",
+                messages=repair_messages,
+                client=client,
+                model=config.ai_agent_model,
+                refresh=config.ai_agent_refresh,
+                temperature=0.2,
+                timeout=180,
+            )
+            if repair_completion.cache_status == "hit":
+                state["cache_hits"] += 1
+            candidate = parse_recommendation(repair_completion.text)
+            if candidate and not validate_recommendation(candidate, paragraph_count):
+                completion = repair_completion
+                recommendation = candidate
+                brief_markdown = re.sub(
+                    r"```json\s*\{.*?\}\s*```",
+                    "",
+                    repair_completion.text,
+                    flags=re.DOTALL | re.IGNORECASE,
+                ).strip()
+                verification = _verification_for(page, recommendation, own_paragraphs or [], embedder)
+            # An invalid repair candidate is discarded: keep the original valid
+            # recommendation and its verification instead of failing the page.
     page["ai_editor_brief"] = {
         "status": "ok",
         "provider": completion.provider,
@@ -4092,16 +4388,13 @@ def _attach_chat_brief(
         "fallback_from": completion.fallback_from,
         "markdown": _clean_ai_markdown(brief_markdown),
     }
-    verification = {}
-    if not errors:
-        verification = _verification_for(page, recommendation, own_paragraphs or [], embedder)
     page["ai_recommendation"] = {
         "status": "ok" if not errors else "invalid_recommendation",
         "errors": errors,
         "data": recommendation,
         "repair_attempted": False,
         "verification": verification,
-        "verification_repair_attempted": False,
+        "verification_repair_attempted": verification_repair_attempted,
         "workspace": "",
         "article_markdown": (
             _recommended_article_markdown(page, recommendation, own_paragraphs or [], verification)
@@ -4599,6 +4892,9 @@ def _append_ai_editor_brief_markdown(lines: list[str], seen: set[str], brief: di
         unresolved = verification_summary.get("unresolved_critical") or []
         if unresolved:
             _append_unique(lines, seen, f"- Still uncovered critical/high topics: {'; '.join(unresolved[:10])}")
+    unverified = _unverified_number_labels((recommendation or {}).get("verification") or {})
+    if unverified:
+        _append_unique(lines, seen, f"- Unverified numeric claims: {'; '.join(unverified[:10])}")
     status = brief.get("status", "")
     if status == "ok" and brief.get("markdown"):
         meta = [
@@ -6133,9 +6429,10 @@ function topicCoverageHeatmap(a){const matrix=a.topic_coverage_matrix||{};const 
 function paragraphMatchHeatmap(a){const heat=a.paragraph_match_heatmap||{};const columns=heat.columns||[];const rows=heat.rows||[];if(!columns.length||!rows.length)return '<div class="empty">No paragraph match heatmap available.</div>';const header=`<div class="heatmap-head"><div>${esc(ownDomain)} paragraph</div>${columns.map(col=>`<div title="${esc(col.url||'')}">${esc(col.domain||'Page').slice(0,22)}${col.rank?`<br>#${esc(col.rank)}`:''}</div>`).join('')}</div>`;const body=rows.map(row=>`<div class="paragraph-row"><div class="paragraph-topic"><strong>P${n(Number(row.paragraph_index||0)+1)} · ${esc(row.status||'')} · impact ${Number(row.max_rank_impact||0).toFixed(2)}</strong><span title="${esc(row.paragraph||'')}">${esc(row.paragraph||'')}</span></div>${(row.cells||[]).map((cell,index)=>{const col=columns[index]||{};const status=cell.status||'no_match';const sim=Number(cell.similarity||0);const impact=Number(cell.rank_impact||0);const label=sim?sim.toFixed(2):'-';const title=[`P${Number(row.paragraph_index||0)+1}`,col.domain||col.url||'',`SERP rank ${cell.rank||col.rank||''}`,`similarity ${label}`,`rank impact proxy ${impact.toFixed(3)}`,cell.paragraph||''].filter(Boolean).join(' · ');return `<div class="heatmap-cell ${esc(status)}" title="${esc(title)}">${esc(label)}<br><span class="mini">impact ${impact.toFixed(2)}</span></div>`;}).join('')}</div>`).join('');return `<div class="paragraph-heatmap-wrap"><div class="paragraph-heatmap" style="--paragraph-cols:${columns.length}">${header}${body}</div></div><div class="heatmap-legend"><span><i style="background:#eefbf4;border:1px solid #a5dabb"></i>strong paragraph match</span><span><i style="background:#eef4ff;border:1px solid #b9cdfc"></i>partial match</span><span><i style="background:#fff1f3;border:1px solid #f4b4be"></i>weak match</span><span>Impact = semantic match x top-10 SERP rank weight.</span></div>`;}
 function semanticScatterSection(a){const points=a.scatter?.points||[];return `<div class="panel" style="margin-top:14px"><h4>Semantic Scatterplot</h4><div class="panel-body">${sectionNote('Vector space for keyword, target page, competitor titles, headings, and paragraphs. Use filters to isolate entity types and domains.')} ${scatterSvg(points)}</div></div>`;}
 function visualComparisonSection(a){const hasComparison=a.content_comparison||a.topic_coverage_matrix||a.paragraph_match_heatmap||a.content_order_path;if(!hasComparison)return '';return `<div class="panel content-comparison" style="margin-top:14px"><h4>Why These Edits Matter</h4><div class="panel-body">${sectionNote('Top ranking page differences show why the recommended edits matter: compare topic coverage, paragraph depth, heading structure, content order, and which SERP pages cover each missing or partial topic.')} ${visualReasonList(a)}<div class="visual-grid"><div class="visual-card"><h5>SERP rank vs content coverage</h5>${contentComparisonRows(a)}</div><div class="visual-card"><h5>Top ranking page differences</h5>${contentDeltaBoxes(a)}</div></div><div class="visual-card coverage-heatmap-card" style="margin-top:14px"><h5>Topic coverage heatmap</h5>${topicCoverageHeatmap(a)}</div><div class="visual-card paragraph-match-card" style="margin-top:14px"><h5>Paragraph match heatmap</h5>${paragraphMatchHeatmap(a)}</div><div class="visual-card content-path-card" style="margin-top:14px"><h5>Content order semantic path</h5>${contentOrderPathSection(a)}</div></div></div>`;}
-function keywordChartsSection(a){return `${intentWinnabilityPanel(a)}${semanticScatterSection(a)}${visualComparisonSection(a)}`;}
+function keywordChartsSection(a){return `${intentWinnabilityPanel(a)}${serpFeaturesPanel(a)}${semanticScatterSection(a)}${visualComparisonSection(a)}`;}
 function keywordId(pageIndex, keywordIndex){return `keyword-${pageIndex}-${keywordIndex}`;}
 function overviewSection(){const points=data.overview_scatter?.points||[];const rankings=data.serp_url_rankings||[];const serpEvidence=`<div class="panel"><h4>Top-10 URLs Across Selected Keywords</h4><div class="panel-body">${sectionNote('Repeated winners show which URLs and intents Google currently rewards for the selected keywords.')} ${serpUrlGraph(rankings)}${serpRankingChart(rankings)}${urlDemandMetricsSection(rankings)}${serpRankingList(rankings)}${domainRatingAttribution()}</div></div>${keywordMetricsSection()}`;const semanticEvidence=`${keywordParagraphRidgelineSection(points)}<div class="panel" style="margin-top:14px"><h4>All Keywords, URLs, and Content</h4><div class="panel-body">${sectionNote('Vector-space chart for keywords, URLs, titles, headings, and paragraphs across the selected SERP set.')} ${scatterSvg(points)}</div></div>${keywordFrequencySection(points)}<div class="panel" style="margin-top:14px"><h4>Topic Traffic Impact</h4><div class="panel-body">${sectionNote('Directional demand by aggregate semantic cluster. Use it to decide which topic groups deserve editing effort first.')} ${clusterImpactChart(points)}</div></div><div class="panel" style="margin-top:14px"><h4>Aggregate Semantic Clusters</h4><div class="panel-body">${sectionNote('Broad topic groups across selected keywords and processed URLs.')} ${clusterCards(points)}</div></div>`;return `<section class="page-section" id="overview-section"><div class="page-head"><h2>SERP Content Task Board</h2><div class="mini">Charts first, then tasks: validate SERP and vector-space evidence before editing.</div></div><div class="keyword-card">${serpEvidence}${semanticEvidence}${aiAgentStatusSection()}${contentBriefsSection()}${aggregateActionsSection()}${paragraphRulesSection()}</div></section>`;}
+function serpFeaturesPanel(a){const f=a.serp_features||{};const overview=f.ai_overview;const answer=f.answer_box||{};const rows=[];if(answer.answer)rows.push(`<div class="why-item"><b>Featured snippet:</b> ${esc(answer.format||'paragraph')} · ${n(answer.word_count||0)} words · ${urlLink(answer.url||'')}<div class="mini">${esc(answer.answer||'')}</div></div>`);if(overview&&overview.present){const cites=overview.cited_domains||[];const citesLabel=overview.cites_us===true?esc(ownDomain)+' cited':(overview.cites_us===false?esc(ownDomain)+' not cited':'citation status unknown');rows.push(`<div class="why-item"><b>AI Overview:</b> present · ${citesLabel}${cites.length?`<div class="mini">Cited domains: ${cites.map(d=>esc(d)).join(' · ')}</div>`:''}</div>`);}return rows.length?collapsiblePanel('SERP Features',`${sectionNote('Answer-box and AI Overview evidence available from the SERP provider for this keyword.')}<div class="why-list">${rows.join('')}</div>`,{meta:`${n(rows.length)} feature${rows.length===1?'':'s'}`}):'';}
 function keywordCard(a, pageIndex, keywordIndex){const s=a.summary||{};const reviewRows=(a.off_intent_paragraphs&&a.off_intent_paragraphs.length)?a.off_intent_paragraphs:a.own_paragraphs_to_review;const semanticEvidence=`<div class="tables"><div class="panel"><h4>Competitor SERP</h4><div class="panel-body">${sectionNote('Ranking pages fetched for this keyword after ignored hosts are skipped.')} ${competitorList(a.competitor_pages)}</div></div></div>`;const actionRows=a.action_points||[];const actionsPanel=collapsiblePanel('Keyword Content Actions',`${sectionNote('Edit these after reviewing the charts. Each task describes paragraph structure, placement, and completion criteria.')} ${actionList(actionRows,10)}`,{meta:`${n(actionRows.length)} task${actionRows.length===1?'':'s'}`});const structRows=(a.structural_patterns||[]).filter(r=>(r.competitors||0)>=1);const outlineRows=a.recommended_outline||[];const outlinePanel=outlineRows.length?collapsiblePanel('Recommended Section Order',`${sectionNote('Section themes ordered by where ranking competitors place them. "add" rows are themes the page does not cover yet.')}<ol style="margin:0;padding-left:20px">${outlineRows.map(r=>`<li style="margin-bottom:6px" title="${esc(r.sample_text||'')}"><span class="chip ${r.status==='have'?'covered':'missing'}">${esc(r.status)}</span> ${esc(r.label||'')} <span class="mini">— seen on ${n(r.competitor_pages||0)} competitor page(s)</span></li>`).join('')}</ol>`,{meta:`${n(outlineRows.filter(r=>r.status==='add').length)} to add`}):'';const paaRows=a.paa_coverage||[];const paaCovered=paaRows.filter(r=>r.status==='covered').length;const relatedQueries=(a.serp_features&&a.serp_features.related_searches)||[];const paaPanel=paaRows.length?collapsiblePanel('People Also Ask Coverage',`${sectionNote('Questions Google shows for this keyword, scored against this page\'s paragraphs. Missing questions are direct content opportunities.')}<table><thead><tr><th>Question</th><th>Status</th><th>Best similarity</th><th>Closest paragraph</th></tr></thead><tbody>${paaRows.map(r=>`<tr><td>${esc(r.question)}</td><td><span class="chip ${esc(r.status)}">${esc(r.status)}</span></td><td>${esc(String(r.best_similarity??''))}</td><td>${esc(r.best_paragraph||'')}</td></tr>`).join('')}</tbody></table>${relatedQueries.length?`<div class="mini" style="margin-top:8px">Related searches: ${relatedQueries.map(q=>esc(q)).join(' · ')}</div>`:''}`,{meta:`${n(paaCovered)}/${n(paaRows.length)} covered`}):'';const structPanel=structRows.length?collapsiblePanel('Structural / GEO Gaps',`${sectionNote('Page-structure signals where ranking competitors beat this page: schema, question headings, statistics, citations, tables, depth.')}<table><thead><tr><th>Signal</th><th>Competitors</th><th>Ours</th><th>Theirs (max)</th><th>Advice</th></tr></thead><tbody>${structRows.map(r=>`<tr><td>${esc(r.signal)}</td><td>${n(r.competitors)}</td><td>${esc(String(r.ours))}</td><td>${esc(String(r.max_theirs))}</td><td>${esc(r.advice)}</td></tr>`).join('')}</tbody></table>`,{meta:`${n(structRows.length)} signal${structRows.length===1?'':'s'}`}):'';const topicPanel=collapsiblePanel('Topic Relations',`${sectionNote('Missing and partial topics are the source evidence for the content tasks above.')} ${topicChart(a.topics)}<table><thead><tr><th>Coverage</th><th>Priority</th><th>Topic and Example</th><th>Seen</th><th>${esc(ownDomain)} sim</th><th>Example URL</th></tr></thead><tbody>${topicRows(a.topics,18)}</tbody></table>`,{meta:`${n((a.topics||[]).length)} topics`,style:''});const reviewPanel=collapsiblePanel(`${ownDomain} Paragraphs To Review`,`${sectionNote('Review candidates for intent drift, thinness, or filler. Keep useful facts, but rewrite, move, merge, or remove weak paragraphs.')} ${reviewList(reviewRows)}`,{meta:`${n((reviewRows||[]).length)} paragraph${(reviewRows||[]).length===1?'':'s'}`,style:''});return `<div class="keyword-card" id="${keywordId(pageIndex, keywordIndex)}"><div class="keyword-head"><div><h3>${esc(a.query || a.keyword?.keyword || '')}</h3><div class="mini">Status ${esc(a.status)} · Competitors ${esc(a.competitors||a.competitor_pages?.length||0)} · Scatter points ${esc(a.scatter?.shown||0)}</div></div><div class="chips"><span class="chip missing">Missing ${n(s.missing||0)}</span><span class="chip partial">Partial ${n(s.partial||0)}</span><span class="chip covered">Covered ${n(s.covered||0)}</span></div></div>${keywordChartsSection(a)}${actionsPanel}${structPanel}${paaPanel}${outlinePanel}<div class="two-col" style="margin-top:14px">${topicPanel}${reviewPanel}</div>${diagnosticDetails('Raw semantic evidence for this keyword',semanticEvidence,false)}</div>`;}
 function decisionChipClass(decision){if(decision==='keep')return 'covered';if(decision==='rewrite')return 'partial';return 'missing';}
 function recommendationSection(page){const rec=page.ai_recommendation||{};if(!rec.status)return '';if(rec.status!=='ok'&&rec.status!=='invalid_recommendation'){return '';}
@@ -6143,6 +6440,7 @@ const d=rec.data||{};const parts=[];
 if(rec.status==='invalid_recommendation'&&(rec.errors||[]).length){parts.push(`<div class="mini" style="color:var(--missing);margin-bottom:8px">Recommendation failed validation: ${rec.errors.slice(0,6).map(e=>esc(e)).join('; ')}</div>`);}
 const verif=rec.verification||{};const vs=verif.summary||{};
 if((verif.topics||[]).length){const unresolved=vs.unresolved_critical||[];parts.push(`<div style="margin-bottom:10px"><div class="chips" style="margin-bottom:6px"><span class="chip ${vs.missing_after>0?'missing':'covered'}">Missing ${n(vs.missing_before)} → ${n(vs.missing_after)}</span><span class="chip ${vs.partial_after>0?'partial':'covered'}">Partial ${n(vs.partial_before)} → ${n(vs.partial_after)}</span><span class="chip ${vs.paa_missing_after>0?'missing':'covered'}">PAA missing ${n(vs.paa_missing_before)} → ${n(vs.paa_missing_after)}</span></div>${unresolved.length?`<div class="mini" style="color:var(--missing)">Still uncovered critical/high topics: ${unresolved.map(t=>esc(t)).join('; ')}</div>`:''}<details><summary class="mini">Coverage check details</summary><table><thead><tr><th>Keyword</th><th>Topic</th><th>Priority</th><th>Before → After</th><th>Best similarity</th></tr></thead><tbody>${verif.topics.map(r=>`<tr><td>${esc(r.keyword||'')}</td><td>${esc(r.label||'')}</td><td>${esc(r.priority||'')}</td><td><span class="chip ${esc(r.before)}">${esc(r.before)}</span> → <span class="chip ${esc(r.after)}">${esc(r.after)}</span></td><td>${esc(String(r.best_similarity??''))}</td></tr>`).join('')}</tbody></table></details></div>`);}
+const unverifiedNums=verif.unverified_numbers||[];if(unverifiedNums.length){parts.push(`<div class="mini" style="color:var(--missing);margin-bottom:10px"><b>Unverified numeric claims:</b> ${unverifiedNums.map(c=>`${esc(c.text||c.number||'')} (${esc(String(c.context||'').slice(0,140))})`).join('; ')}</div>`);}
 const titleRec=d.title||{};const h1Rec=d.h1||{};const metaRec=d.meta_description||{};const assessment=d.page_assessment||{};
 const headParts=[];
 if(assessment.reason)headParts.push(`<div class="mini" style="margin-bottom:6px">Target page check: <b>${assessment.is_right_target_page===false?'wrong target page':'right target page'}</b> — ${esc(assessment.reason||'')}</div>`);

--- a/tests/test_draft_verification.py
+++ b/tests/test_draft_verification.py
@@ -2,6 +2,8 @@ import numpy as np
 
 from site_audit.draft_verification import (
     assemble_recommended_blocks,
+    extract_numeric_claims,
+    verify_numeric_claims,
     verify_recommendation,
 )
 
@@ -110,3 +112,75 @@ def test_verify_handles_missing_centroids_and_empty_blocks() -> None:
     assert result["topics"] == []
     assert result["paa"] == []
     assert result["summary"]["missing_before"] == 0
+
+
+def test_extract_numeric_claims_handles_common_numbers_and_exclusions() -> None:
+    text = """
+# 3 ways to improve support
+1. Start with triage.
+2. Route urgent work.
+3. Review weekly.
+
+Results improved by 73%, the plan costs $1,200, and routing is 3x faster.
+The 2024 report is background only.
+"""
+    claims = extract_numeric_claims(text)
+
+    assert [claim.text for claim in claims] == ["73%", "$1,200", "3x"]
+    assert [claim.kind for claim in claims] == ["percent", "currency", "multiplier"]
+    assert [claim.normalized for claim in claims] == ["73", "1200", "3"]
+
+
+def test_verify_numeric_claims_matches_evidence_variants_and_needs_data() -> None:
+    draft = "Conversion rose 73%. Setup costs 1200 USD. Routing is 3x faster. Churn fell 19% [NEEDS DATA]."
+    result = verify_numeric_claims(draft, ["The study says 73 percent. Pricing is $1,200. Routing improved 3 x."])
+
+    assert [claim["text"] for claim in result["verified"]] == ["73%", "1200 USD", "3x", "19%"]
+    assert result["unverified"] == []
+
+
+def test_verify_numeric_claims_flags_absent_numbers() -> None:
+    result = verify_numeric_claims("Customers save 73% after launch.", ["Customers save time after launch."])
+
+    assert [claim["text"] for claim in result["unverified"]] == ["73%"]
+
+
+def test_verification_repair_prompt_and_payload_list_unverified_numbers() -> None:
+    from site_audit.serp_gap import _verification_for, _verification_repair_prompt
+
+    page = {
+        "own_content": {"paragraphs": [{"text": "Existing evidence mentions setup qualitatively."}]},
+        "analyses": [],
+    }
+    recommendation = {
+        "paragraph_decisions": [{"index": 0, "decision": "rewrite", "rewrite": "Setup saves teams 73% of review time."}],
+        "new_sections": [],
+    }
+
+    verification = _verification_for(page, recommendation, ["Original paragraph."], embedder=None)
+    prompt = _verification_repair_prompt(verification)
+
+    assert verification["unverified_numbers"][0]["text"] == "73%"
+    assert "Replace or source these numbers" in prompt
+    assert "73%" in prompt
+
+
+def test_needs_data_exemption_is_scoped_to_the_claims_own_sentence() -> None:
+    draft = (
+        "Support costs fell 40% [NEEDS DATA]. "
+        "Meanwhile revenue grew 55% across teams this quarter."
+    )
+    result = verify_numeric_claims(draft, ["No numbers in the evidence."])
+
+    assert [claim["text"] for claim in result["verified"]] == ["40%"]
+    assert [claim["text"] for claim in result["unverified"]] == ["55%"]
+
+
+def test_extract_numeric_claims_excludes_dates_and_version_fragments() -> None:
+    text = (
+        "Released on January 15, 2026 as v2.4. "
+        "The update shipped on 3 March and improved routing for 87 teams."
+    )
+    claims = extract_numeric_claims(text)
+
+    assert [claim.text for claim in claims] == ["87"]

--- a/tests/test_serp_gap.py
+++ b/tests/test_serp_gap.py
@@ -1585,14 +1585,15 @@ def test_serp_features_parses_serper_payload() -> None:
         {"question": "How much does X cost?", "snippet": "s", "url": "https://a", "title": "t"}
     ]
     assert features["related_searches"] == ["x pricing"]
-    assert features["answer_box"] == {"title": "t", "answer": "a", "url": "https://b"}
+    assert features["answer_box"] == {"title": "t", "answer": "a", "url": "https://b", "format": "paragraph", "word_count": 1}
+    assert features["ai_overview"] is None
 
 
 def test_serp_features_handles_missing_blocks() -> None:
     from site_audit.serp_gap import _serp_features
 
     features = _serp_features({"meta": {"provider": "serper"}, "raw": {}})
-    assert features == {"people_also_ask": [], "related_searches": [], "answer_box": {}}
+    assert features == {"people_also_ask": [], "related_searches": [], "answer_box": {}, "ai_overview": None}
 
 
 def test_serp_features_parses_dataforseo_payload() -> None:
@@ -1615,6 +1616,57 @@ def test_serp_features_parses_dataforseo_payload() -> None:
     assert features["people_also_ask"][0]["snippet"] == "d"
     assert features["related_searches"] == ["x alternatives"]
     assert features["answer_box"]["answer"] == "fd"
+    assert features["answer_box"]["format"] == "paragraph"
+
+
+def test_serp_features_parses_serper_ai_overview() -> None:
+    from site_audit.serp_gap import _serp_features
+
+    payload = {
+        "meta": {"provider": "serper", "status": "ok", "domain": "ours.example"},
+        "raw": {
+            "organic": [],
+            "aiOverview": {
+                "text": "Overview answer.",
+                "sources": [
+                    {"link": "https://ours.example/guide"},
+                    {"link": "https://competitor.example/post"},
+                ],
+            },
+        },
+    }
+
+    features = _serp_features(payload)
+
+    assert features["ai_overview"] == {
+        "present": True,
+        "cites_us": True,
+        "cited_domains": ["ours.example", "competitor.example"],
+    }
+
+
+def test_serp_features_parses_dataforseo_ai_overview() -> None:
+    from site_audit.serp_gap import _serp_features
+
+    payload = {
+        "meta": {"provider": "dataforseo", "status": "ok"},
+        "raw": {
+            "tasks": [{"result": [{"items": [
+                {
+                    "type": "ai_overview",
+                    "items": [{"url": "https://source-a.example/a"}, {"url": "https://source-b.example/b"}],
+                },
+            ]}]}],
+        },
+    }
+
+    features = _serp_features(payload, own_domain="ours.example")
+
+    assert features["ai_overview"] == {
+        "present": True,
+        "cites_us": False,
+        "cited_domains": ["source-a.example", "source-b.example"],
+    }
 
 
 def test_paa_coverage_classifies_thresholds() -> None:
@@ -1805,6 +1857,50 @@ def test_structural_and_paa_actions_emitted() -> None:
     assert paa["priority"] == "high"
 
 
+def test_featured_snippet_action_emitted_for_competitor_holder() -> None:
+    from site_audit.serp_gap import _action_points_for_analysis
+
+    page = {"url": "https://ours.example/p", "title": "T", "h1": "H"}
+    analysis = _analysis_base("what is a widget tool")
+    analysis["serp_features"] = {
+        "answer_box": {
+            "answer": "A widget tool helps teams sort widget tasks and route the next action.",
+            "url": "https://competitor.example/snippet",
+            "format": "paragraph",
+            "word_count": 12,
+        }
+    }
+
+    actions = _action_points_for_analysis(page, analysis)
+    action = next(row for row in actions if row["type"] == "win_featured_snippet")
+
+    assert "https://competitor.example/snippet" in action["instruction"]
+    assert "paragraph with 12 words" in action["instruction"]
+    assert "40-55-word direct-answer paragraph" in action["instruction"]
+    assert action["placement"] == "Immediately under an H2 phrased as 'what is a widget tool'."
+    assert any("same snippet format (paragraph)" in row for row in action["acceptance_criteria"])
+    assert action["evidence"]["snippet_format"] == "paragraph"
+
+
+def test_featured_snippet_action_skips_own_holder() -> None:
+    from site_audit.serp_gap import _action_points_for_analysis
+
+    page = {"url": "https://ours.example/p", "title": "T", "h1": "H"}
+    analysis = _analysis_base("what is a widget tool")
+    analysis["serp_features"] = {
+        "answer_box": {
+            "answer": "A widget tool helps teams sort widget tasks.",
+            "url": "https://ours.example/snippet",
+            "format": "paragraph",
+            "word_count": 8,
+        }
+    }
+
+    actions = _action_points_for_analysis(page, analysis)
+
+    assert all(row["type"] != "win_featured_snippet" for row in actions)
+
+
 def test_action_dedupe_across_keywords() -> None:
     from site_audit.serp_gap import _attach_action_points
 
@@ -1986,3 +2082,196 @@ def test_recommended_article_markdown_assembles_full_page() -> None:
     assert "**Title change:** keyword alignment" in md
     # removed paragraphs do not appear
     assert "Weak text." not in md
+
+
+def test_numeric_verification_ignores_numbers_in_untouched_kept_paragraphs() -> None:
+    from site_audit.serp_gap import _verification_for
+
+    tail = "Our team resolved 4817 tickets last quarter."
+    long_paragraph = ("This paragraph explains our support workflow in detail. " * 9) + tail
+    assert len(long_paragraph) > 500 and tail[:-1] in long_paragraph[500:]
+    page = {
+        # own_content stores paragraphs truncated to 500 chars, like run() does
+        "own_content": {"paragraphs": [{"index": 0, "word_count": len(long_paragraph.split()), "text": long_paragraph[:500]}]},
+        "analyses": [],
+    }
+    recommendation = {"paragraph_decisions": [{"index": 0, "decision": "keep"}], "new_sections": []}
+
+    verification = _verification_for(page, recommendation, [long_paragraph], embedder=None)
+
+    assert verification["unverified_numbers"] == []
+
+
+def _chat_recommendation_text(section_draft: str) -> str:
+    rec = {
+        "page_assessment": {"is_right_target_page": True, "reason": "ok"},
+        "title": {"recommended": "Widget tools guide"},
+        "meta_description": {"recommended": "All about widget tools."},
+        "h1": {"recommended": "Widget tools"},
+        "outline": [{"heading": "Why widgets", "status": "new"}],
+        "paragraph_decisions": [{"index": 0, "decision": "keep"}],
+        "new_sections": [{"heading": "Why widgets", "draft": section_draft, "placement_after_paragraph": 0}],
+        "structured_data": [],
+        "internal_links": [],
+    }
+    return "Brief text here.\n```json\n" + json.dumps(rec) + "\n```"
+
+
+def _chat_page() -> dict:
+    return {
+        "url": "https://ours.example/p",
+        "title": "T",
+        "h1": "H",
+        "keywords": ["widget tools"],
+        "own_content": {"paragraphs": [{"index": 0, "word_count": 4, "text": "Widgets help teams work."}]},
+        "analyses": [],
+    }
+
+
+class _ScriptedChatClient:
+    provider = "fake"
+
+    def __init__(self, texts: list[str]) -> None:
+        self.texts = texts
+        self.calls: list[list[dict]] = []
+
+    def complete(self, messages, *, model, temperature=0.2, timeout=120) -> AgentCompletion:
+        self.calls.append(messages)
+        return AgentCompletion(text=self.texts[min(len(self.calls), len(self.texts)) - 1], provider="fake", model=model)
+
+
+def _run_chat_brief(tmp_path: Path, client: _ScriptedChatClient) -> dict:
+    from types import SimpleNamespace
+
+    from site_audit.serp_gap import _attach_chat_brief
+
+    page = _chat_page()
+    config = SimpleNamespace(ai_agent_model="m", ai_agent_refresh=True, ai_agent_max_turns=12)
+    _attach_chat_brief(
+        page,
+        tmp_path,
+        config,
+        {"cache_hits": 0, "editor_briefs": 0},
+        client=client,
+        paragraph_count=1,
+        own_paragraphs=["Widgets help teams work."],
+        embedder=None,
+    )
+    return page
+
+
+def test_chat_brief_numeric_repair_turn_carries_draft_and_rechecks(tmp_path: Path) -> None:
+    client = _ScriptedChatClient([
+        _chat_recommendation_text("Teams report 73% faster resolution with widgets."),
+        _chat_recommendation_text("Teams report faster resolution with widgets [NEEDS DATA]."),
+    ])
+
+    page = _run_chat_brief(tmp_path, client)
+
+    assert len(client.calls) == 2
+    roles = [message["role"] for message in client.calls[1]]
+    assert roles == ["system", "user", "assistant", "user"]
+    assistant = [m for m in client.calls[1] if m["role"] == "assistant"]
+    assert "73%" in assistant[0]["content"]
+    repair_prompt = client.calls[1][-1]["content"]
+    assert "Replace or source these numbers" in repair_prompt
+    assert "73%" in repair_prompt
+    assert "Output the corrected brief and the full recommendation JSON block again." in repair_prompt
+    assert "recommendation.json" not in repair_prompt
+    rec = page["ai_recommendation"]
+    assert rec["status"] == "ok"
+    assert rec["verification_repair_attempted"] is True
+    assert rec["verification"]["unverified_numbers"] == []
+
+
+def test_chat_brief_keeps_valid_recommendation_when_repair_candidate_is_invalid(tmp_path: Path) -> None:
+    client = _ScriptedChatClient([
+        _chat_recommendation_text("Teams report 73% faster resolution with widgets."),
+        "Sorry, I cannot modify files.",
+    ])
+
+    page = _run_chat_brief(tmp_path, client)
+
+    rec = page["ai_recommendation"]
+    assert rec["status"] == "ok"
+    assert rec["data"]["title"]["recommended"] == "Widget tools guide"
+    assert [claim["text"] for claim in rec["verification"]["unverified_numbers"]] == ["73%"]
+    assert "Unverified numeric claims" in rec["article_markdown"]
+    assert "73%" in rec["article_markdown"]
+
+
+def test_recommended_article_markdown_lists_unverified_numbers_without_summary() -> None:
+    from site_audit.serp_gap import _recommended_article_markdown
+
+    page = {"url": "https://ours.example/p", "title": "T", "h1": "H"}
+    rec = {
+        "title": {"recommended": "T2"},
+        "h1": {"recommended": "H2"},
+        "paragraph_decisions": [{"index": 0, "decision": "keep"}],
+        "new_sections": [],
+    }
+    verification = {
+        "summary": {},
+        "unverified_numbers": [{"text": "73%", "context": "Teams report 73% faster resolution."}],
+    }
+
+    md = _recommended_article_markdown(page, rec, ["Widgets help teams work."], verification)
+
+    assert "**Unverified numeric claims:** 73%" in md
+
+
+def test_recommendation_header_notes_ai_overview_only_with_known_citations() -> None:
+    from site_audit.serp_gap import _recommendation_header
+
+    cited = {"serp_features": {"ai_overview": {"present": True, "cites_us": False, "cited_domains": ["competitor.example"]}}}
+    unknown = {"serp_features": {"ai_overview": {"present": True, "cites_us": None, "cited_domains": []}}}
+    citing_us = {"serp_features": {"ai_overview": {"present": True, "cites_us": True, "cited_domains": ["ours.example"]}}}
+
+    assert "AI Overview is present but does not cite this domain" in _recommendation_header(cited)
+    assert _recommendation_header(unknown) == ""
+    assert _recommendation_header(citing_us) == ""
+
+
+def test_featured_snippet_action_deduped_across_keywords() -> None:
+    page = {"url": "https://ours.example/p", "title": "T", "h1": "H"}
+    for keyword, impressions in (("what is a widget tool", 100), ("widget tool definition", 900)):
+        analysis = _analysis_base(keyword)
+        analysis["keyword"]["impressions"] = impressions
+        analysis["serp_features"] = {
+            "answer_box": {
+                "answer": "A widget tool helps teams sort widget tasks.",
+                "url": "https://competitor.example/snippet",
+                "format": "paragraph",
+                "word_count": 8,
+            }
+        }
+        page.setdefault("analyses", []).append(analysis)
+
+    _attach_action_points([page])
+    snippet_actions = [row for row in page["action_points"] if row["type"] == "win_featured_snippet"]
+
+    assert len(snippet_actions) == 1
+    assert snippet_actions[0]["keyword"] == "widget tool definition"
+
+
+def test_serp_features_ai_overview_without_sources_reports_unknown_citation() -> None:
+    from site_audit.serp_gap import _serp_features
+
+    payload = {"meta": {"provider": "serper"}, "raw": {"organic": [], "aiOverview": {"text": "Overview answer."}}}
+
+    features = _serp_features(payload, "ours.example")
+
+    assert features["ai_overview"] == {"present": True, "cites_us": None, "cited_domains": []}
+
+
+def test_serp_features_parses_list_shaped_ai_overview() -> None:
+    from site_audit.serp_gap import _serp_features
+
+    payload = {
+        "meta": {"provider": "serper"},
+        "raw": {"organic": [], "aiOverview": [{"text": "block", "link": "https://competitor.example/post"}]},
+    }
+
+    features = _serp_features(payload, "ours.example")
+
+    assert features["ai_overview"] == {"present": True, "cites_us": False, "cited_domains": ["competitor.example"]}


### PR DESCRIPTION
Closes #278

## What

- **Deterministic numeric fact-check** in the verification loop: typed claim extraction (percent/currency/count/multiplier with year, list-position, day-of-month, and version-fragment exclusions and fuzzy normalization — "73%" ↔ "73 percent", "$1,200" ↔ "1200 USD", "3x" ↔ "3 times"), verified against the same evidence corpus the agent sees (full own paragraphs + agent evidence payload). Unverified claims trigger a repair turn on BOTH agent paths (chat path now includes the assistant draft and chat-appropriate wording), are re-checked, and any leftovers appear in the report payload and the article's rationale. `[NEEDS DATA]` exemption scoped to its own sentence. `fix_drafts` now delegates to the same shared checker.
- **`win_featured_snippet` action** when a competitor holds the answer box (own-domain check, www/subdomain safe): instruction carries holder URL, snippet text, format and length, the 40–55-word direct-answer requirement, and format-referencing acceptance criteria; deduped per page; context flows into the agent evidence payload.
- **AI Overview capture** from both provider shapes (defensive, absent → null, list-shaped blocks coerced): per-keyword presence, `cites_us` (true/false/null when sources unknown), cited domains capped at 10; gap-header note only when cited domains exist and none are ours.
- Failed repair candidates no longer flip a valid recommendation to invalid — the original recommendation and verification are kept (both paths).

## Review

Code-review agent (execution-verified probes): three must-fixes found and applied — evidence-corpus truncation flagging untouched site content as invented, chat repair turn missing the assistant draft with workspace-only wording, and the [NEEDS DATA] exemption leaking to neighboring sentences.

## Tests

`pytest -q`: 694 passed (+18 across implementation and review pins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)