### PR TITLE
Reload model on non-finite embeddings and zero-fill unrecoverable rows

### DIFF
--- a/site_audit/embedder.py
+++ b/site_audit/embedder.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import logging
 import os
-from contextlib import ExitStack, contextmanager, nullcontext, redirect_stderr, redirect_stdout
+from contextlib import ExitStack, nullcontext, redirect_stderr, redirect_stdout
 from dataclasses import dataclass
 from io import StringIO
 from typing import Iterable, List
@@ -46,32 +46,6 @@ def _non_finite_row_indices(arr: np.ndarray) -> np.ndarray:
     if arr.size == 0:
         return np.zeros(0, dtype=np.int64)
     return np.flatnonzero(~np.isfinite(arr).all(axis=1))
-
-
-@contextmanager
-def _cpu_thread_boost():
-    """Temporarily raise torch's intra-op threads for a CPU fallback encode.
-
-    ``site_audit.__init__`` pins ``OMP_NUM_THREADS=1`` so faiss and torch can
-    share libomp, which makes CPU encoding of this model ~100x slower than the
-    hardware allows. ``torch.set_num_threads`` overrides the pin for torch
-    only, and the previous value is restored afterwards.
-    """
-    try:
-        import torch
-
-        previous = torch.get_num_threads()
-        torch.set_num_threads(max(1, (os.cpu_count() or 2) // 2))
-    except Exception:
-        yield
-        return
-    try:
-        yield
-    finally:
-        try:
-            torch.set_num_threads(previous)
-        except Exception:
-            pass
 
 
 def _embed_cache_save_every(default: int = DEFAULT_EMBED_CACHE_SAVE_EVERY) -> int:
@@ -173,7 +147,25 @@ class Embedder:
         )
         return np.asarray(embs, dtype=np.float32)
 
-    def encode(self, texts: list[str], batch_size: int = 32, show_progress: bool = False) -> np.ndarray:
+    def encode(
+        self,
+        texts: list[str],
+        batch_size: int = 32,
+        show_progress: bool = False,
+        *,
+        zero_fill_bad: bool = False,
+    ) -> np.ndarray:
+        """Encode texts, recovering from non-finite accelerator output.
+
+        Recovery ladder: (1) reload the model on the accelerator with a
+        cleared allocator cache and re-encode only the bad rows — MPS can
+        corrupt model state and then NaN every batch until reloaded;
+        (2) reload on CPU and re-encode only the bad rows (single-threaded:
+        raising torch's thread count under the OMP_NUM_THREADS=1 pin
+        segfaults once faiss has loaded libomp); (3) with ``zero_fill_bad``
+        zero the surviving bad rows so a long audit degrades instead of
+        dying — otherwise raise.
+        """
         if not texts:
             return np.zeros((0, 0), dtype=np.float32)
         self._ensure()
@@ -186,34 +178,45 @@ class Embedder:
         if bad.size == 0:
             return arr
         if self._device != "cpu":
-            # MPS returns NaN rows under allocator pressure instead of
-            # raising; freeing its cache and re-encoding just the bad rows
-            # usually recovers without leaving the accelerator.
             LOG.warning(
                 "Embedding model returned %d/%d non-finite vectors on %s; "
-                "clearing accelerator cache and retrying those rows",
+                "reloading the model and retrying those rows",
                 bad.size, len(texts), self._device or "auto",
             )
-            self._clear_accelerator_cache()
+            self._reload(self._device)
             self._reencode_rows(arr, texts, bad, batch_size=batch_size)
             bad = _non_finite_row_indices(arr)
             if bad.size == 0:
                 return arr
-            # Only the still-bad rows go to CPU — re-encoding the whole
-            # chunk there takes hours under the OMP_NUM_THREADS=1 pin.
             LOG.warning(
                 "%d vectors still non-finite after accelerator retry; "
                 "re-encoding those rows on CPU",
                 bad.size,
             )
-            self._model = None
-            self._ensure("cpu")
-            with _cpu_thread_boost():
-                self._reencode_rows(arr, texts, bad, batch_size=batch_size)
+            self._reload("cpu")
+            self._reencode_rows(arr, texts, bad, batch_size=batch_size)
             bad = _non_finite_row_indices(arr)
             if bad.size == 0:
                 return arr
-        raise RuntimeError("Embedding model returned non-finite vectors")
+        if zero_fill_bad:
+            LOG.warning(
+                "%d/%d vectors stayed non-finite on every device; zero-filling "
+                "them so the run can continue (affected texts embed as "
+                "unrelated to everything)",
+                bad.size, len(texts),
+            )
+            arr[bad] = 0.0
+            return arr
+        raise RuntimeError(
+            f"Embedding model returned {bad.size}/{len(texts)} non-finite vectors"
+        )
+
+    def _reload(self, device: str | None) -> None:
+        """Discard the loaded model and load a fresh copy on ``device``."""
+        self._model = None
+        self._device = None
+        self._clear_accelerator_cache()
+        self._ensure(device)
 
     def _reencode_rows(
         self,
@@ -241,6 +244,51 @@ class Embedder:
                 torch.cuda.empty_cache()
         except Exception:  # best-effort; the CPU fallback still applies
             pass
+
+    def encode_and_cache(
+        self,
+        texts: list[str],
+        urls: list[str],
+        hashes: list[str],
+        cache,
+        *,
+        batch_size: int = 32,
+        show_progress: bool = False,
+        identifiers: list[str] | None = None,
+    ) -> np.ndarray:
+        """Encode ``texts`` tolerantly and cache the rows that embedded.
+
+        Rows the model could not embed on any device come back as zero
+        vectors (the ``zero_fill_bad`` sentinel from :meth:`encode`); those
+        are never written to ``cache`` so a later run retries them, and
+        their ``identifiers`` (default: ``urls``) are logged. ``cache``
+        needs ``put(url, hash, embedding)`` — both ``EmbeddingCache`` and
+        ``ParagraphEmbeddingCache`` qualify. Calling ``cache.save()``
+        stays the caller's job.
+        """
+        embs = self.encode(
+            texts,
+            batch_size=batch_size,
+            show_progress=show_progress,
+            zero_fill_bad=True,
+        )
+        ids = identifiers if identifiers is not None else urls
+        skipped: list[str] = []
+        for k in range(len(texts)):
+            emb = embs[k]
+            if emb.size and not emb.any():
+                skipped.append(ids[k])
+                continue
+            cache.put(urls[k], hashes[k], emb)
+        if skipped:
+            LOG.warning(
+                "%d texts embedded as zero vectors (model returned "
+                "non-finite output for them on every device); left out of "
+                "the embedding cache so a later run retries: %s",
+                len(skipped),
+                ", ".join(skipped[:10]) + ("…" if len(skipped) > 10 else ""),
+            )
+        return embs
 
     def encode_pages(
         self,
@@ -279,15 +327,16 @@ class Embedder:
             for offset in range(0, len(misses_idx), save_every):
                 chunk_idx = misses_idx[offset : offset + save_every]
                 miss_texts = [inputs[i].text for i in chunk_idx]
-                new_embs = self.encode(
+                new_embs = self.encode_and_cache(
                     miss_texts,
+                    [inputs[i].url for i in chunk_idx],
+                    [hashes[i] for i in chunk_idx],
+                    cache,
                     batch_size=batch_size,
                     show_progress=True,
                 )
                 for k, i in enumerate(chunk_idx):
-                    emb = new_embs[k]
-                    embeddings[i] = emb
-                    cache.put(inputs[i].url, hashes[i], emb)
+                    embeddings[i] = new_embs[k]
                 cache.save()
                 LOG.info(
                     "Embedding cache persisted: %d / %d misses",

--- a/site_audit/pipeline.py
+++ b/site_audit/pipeline.py
@@ -1834,10 +1834,23 @@ def run(config: PipelineConfig) -> dict:
 
             if misses_idx:
                 miss_texts = [triples[k][2] for k in misses_idx]
-                new_embs = embedder.encode(miss_texts, batch_size=64, show_progress=True)
+                # encode_and_cache zero-fills rows that stay non-finite on
+                # every device (instead of raising and killing the audit)
+                # and keeps those rows out of the paragraph cache so a
+                # later run retries them.
+                new_embs = embedder.encode_and_cache(
+                    miss_texts,
+                    [pages[triples[k][0]].url for k in misses_idx],
+                    [hashes[k] for k in misses_idx],
+                    paragraph_cache,
+                    batch_size=64,
+                    show_progress=True,
+                    identifiers=[
+                        f"{pages[triples[k][0]].url} (paragraph {triples[k][1]})"
+                        for k in misses_idx
+                    ],
+                )
                 for slot, k in enumerate(misses_idx):
-                    page_i, _, _ = triples[k]
-                    paragraph_cache.put(pages[page_i].url, hashes[k], new_embs[slot])
                     cached_embs[k] = new_embs[slot]
                 paragraph_cache.save()
 

--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -1,3 +1,7 @@
+import logging
+import sys
+import types
+
 import numpy as np
 import pytest
 import torch
@@ -6,7 +10,6 @@ from site_audit.cache import EmbeddingCache, content_hash
 from site_audit.embedder import (
     EmbedInput,
     Embedder,
-    _cpu_thread_boost,
     _non_finite_row_indices,
     _reset_position_ids,
 )
@@ -34,7 +37,7 @@ class FakeEmbedder(Embedder):
     def __init__(self) -> None:
         super().__init__("fake-model")
 
-    def encode(self, texts: list[str], batch_size: int = 32, show_progress: bool = False) -> np.ndarray:
+    def encode(self, texts: list[str], batch_size: int = 32, show_progress: bool = False, **kwargs) -> np.ndarray:
         return np.asarray([[float(len(text)), float(i)] for i, text in enumerate(texts)], dtype=np.float32)
 
 
@@ -216,17 +219,158 @@ def test_raises_when_rows_stay_non_finite() -> None:
         emb.encode(["a", "b"])
 
 
-def test_cpu_thread_boost_sets_and_restores(monkeypatch) -> None:
-    seen: list[int] = []
-    monkeypatch.setattr(torch, "get_num_threads", lambda: 1)
-    monkeypatch.setattr(torch, "set_num_threads", lambda n: seen.append(n))
+def test_encode_reloads_model_before_each_retry() -> None:
+    emb = ScriptedEmbedder([_nan_at([0]), _nan_at([0]), _finite])
+    emb.ensure_calls = []
+    original_ensure = emb._ensure
 
-    with _cpu_thread_boost():
+    def tracking_ensure(device=None):
+        emb.ensure_calls.append(device)
+        original_ensure(device)
+
+    emb._ensure = tracking_ensure
+
+    result = emb.encode(["a"])
+
+    assert np.isfinite(result).all()
+    # initial load, accelerator reload, CPU reload
+    assert emb.ensure_calls == [None, None, "cpu"]
+
+
+def test_zero_fill_bad_rows_instead_of_raising() -> None:
+    emb = ScriptedEmbedder([_nan_at([1]), _nan_at([0]), _nan_at([0])])
+
+    result = emb.encode(["a", "b"], zero_fill_bad=True)
+
+    assert np.isfinite(result).all()
+    assert not result[1].any()
+    assert result[0].any()
+
+
+class PoisonEmbedder(Embedder):
+    """Embedder whose model NaNs the text \"poison\" on every device."""
+
+    def __init__(self) -> None:
+        super().__init__("fake-model")
+
+    def _ensure(self, device=None):
+        self._device = device
+        self._model = object()
+
+    def _clear_accelerator_cache(self):
         pass
 
-    assert len(seen) == 2
-    assert seen[0] >= 1
-    assert seen[1] == 1
+    def _encode_current_model(self, texts, *, batch_size, show_progress):
+        arr = np.ones((len(texts), 2), dtype=np.float32)
+        for k, text in enumerate(texts):
+            if text == "poison":
+                arr[k] = np.nan
+        return arr
+
+
+def test_encode_pages_never_caches_zero_filled_rows() -> None:
+    cache = FakeEmbeddingCache()
+    inputs = [
+        EmbedInput(url="https://example.com/ok", text="fine"),
+        EmbedInput(url="https://example.com/bad", text="poison"),
+    ]
+
+    embeddings = PoisonEmbedder().encode_pages(inputs, cache, use_cache=True, batch_size=2)
+
+    assert embeddings.shape == (2, 2)
+    assert embeddings[0].any()
+    assert not embeddings[1].any()
+    assert "https://example.com/ok" in cache.entries
+    assert "https://example.com/bad" not in cache.entries
+
+
+def test_encode_and_cache_skips_zero_rows_and_logs_identifiers(caplog) -> None:
+    """The shared helper works for (url, hash)-keyed caches (paragraphs)."""
+
+    class FakeParagraphCache:
+        def __init__(self) -> None:
+            self.entries: dict[tuple[str, str], np.ndarray] = {}
+
+        def put(self, url: str, hash_: str, embedding: np.ndarray) -> None:
+            self.entries[(url, hash_)] = embedding
+
+    cache = FakeParagraphCache()
+    texts = ["fine", "poison", "also fine"]
+    urls = ["https://example.com/a", "https://example.com/a", "https://example.com/b"]
+    hashes = ["h0", "h1", "h2"]
+    identifiers = [
+        "https://example.com/a (paragraph 0)",
+        "https://example.com/a (paragraph 1)",
+        "https://example.com/b (paragraph 0)",
+    ]
+
+    with caplog.at_level(logging.WARNING, logger="site_audit.embedder"):
+        embs = PoisonEmbedder().encode_and_cache(
+            texts, urls, hashes, cache, batch_size=2, identifiers=identifiers,
+        )
+
+    assert embs.shape == (3, 2)
+    assert embs[0].any() and embs[2].any()
+    assert not embs[1].any()
+    # Two paragraphs of the same URL cached independently; the poison row
+    # is absent so a later run retries it.
+    assert set(cache.entries) == {
+        ("https://example.com/a", "h0"),
+        ("https://example.com/b", "h2"),
+    }
+    assert "https://example.com/a (paragraph 1)" in caplog.text
+
+
+def test_encode_returns_to_accelerator_after_cpu_fallback() -> None:
+    emb = ScriptedEmbedder([_nan_at([0]), _nan_at([0]), _finite, _finite])
+
+    first = emb.encode(["a"])
+    second = emb.encode(["b"])
+
+    assert np.isfinite(first).all()
+    assert np.isfinite(second).all()
+    # ladder for call 1: accelerator, accelerator reload, cpu fallback;
+    # call 2 must not stay stranded on cpu.
+    assert [device for device, _ in emb.calls] == [None, None, "cpu", None]
+
+
+def test_reload_defeats_real_ensure_early_return(monkeypatch) -> None:
+    """With the real ``_ensure``/``_reload``, every retry rung constructs a
+    fresh model — the regression of the previous fix was retrying on a
+    stale (corrupted) model after only clearing the allocator cache."""
+    constructed_devices: list[str | None] = []
+
+    class FakeSentenceTransformer:
+        def __init__(self, model_name, trust_remote_code=False, device=None):
+            constructed_devices.append(device)
+            self.max_seq_length = 8192
+
+        def __getitem__(self, idx):
+            return types.SimpleNamespace(auto_model=types.SimpleNamespace())
+
+    fake_module = types.ModuleType("sentence_transformers")
+    fake_module.SentenceTransformer = FakeSentenceTransformer
+    monkeypatch.setitem(sys.modules, "sentence_transformers", fake_module)
+    monkeypatch.delenv("SITE_AUDIT_DEVICE", raising=False)
+
+    class RealEnsureEmbedder(Embedder):
+        def __init__(self) -> None:
+            super().__init__("stub-model")
+            self._script = [_nan_at([0]), _nan_at([0]), _finite]
+
+        def _encode_current_model(self, texts, *, batch_size, show_progress):
+            return np.asarray(self._script.pop(0)(texts), dtype=np.float32)
+
+        def _clear_accelerator_cache(self) -> None:
+            pass
+
+    result = RealEnsureEmbedder().encode(["a"])
+
+    assert np.isfinite(result).all()
+    # initial load, accelerator reload, cpu reload — three constructions
+    # prove _reload discards the model instead of hitting _ensure's
+    # early-return.
+    assert constructed_devices == [None, None, "cpu"]
 
 
 def test_embedding_cache_ignores_and_rejects_non_finite_vectors(tmp_path) -> None:


### PR DESCRIPTION
Closes #296

## Root cause (both proven by isolated repro)

- The 51k-page audit died mid-embedding: one chunk deterministically returns 2048/2048 NaN on MPS — corrupted model state, which `torch.mps.empty_cache()` + retry does not clear.
- The CPU fallback then also "failed": `torch.set_num_threads()` after faiss loads libomp under the repo's `OMP_NUM_THREADS=1` pin **segfaults (exit 139)** in isolation and manifests as NaN in-process. The thread boost from #291 was the bug.

## Fix

- Thread boost removed; the docstring records why single-threaded CPU is mandatory.
- Recovery ladder: full model **reload** on the accelerator + re-encode bad rows → reload on CPU + re-encode bad rows → with `zero_fill_bad` (used by both the page and paragraph bulk paths via a shared `encode_and_cache` helper) zero-fill survivors so the audit completes: zero rows are never cached (later runs retry), affected URLs/paragraphs logged, downstream math is safe (normalized vectors are never legitimately zero; similarity with a zero row is 0). Ad-hoc `encode()` callers (queries, headings) keep the raise.

## Review

Focused code-review pass, execution-verified: device state machine correct in all env configurations (CPU fallback never strands later chunks off the accelerator — pinned by regression tests including one driving the real `_ensure`/`_reload` against a stub SentenceTransformer), all 12 ad-hoc encode call sites keep the raise path, no thread-boost remnants. The reviewer's W1 (paragraph path had the same kill switch) implemented before merge.

## Tests

`pytest -q`: 708 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)