### PR TITLE
Skip CPU rescue on whole-chunk embedding NaN, add model advisory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1220,6 +1220,11 @@ site-audit run <domain> [flags]
 | `--request-delay` | 0 | Seconds to sleep before each fetch. Slow down for rate-limited sites. |
 | `-v`, `--verbose` | off | DEBUG-level logging. |
 
+Embedding model note for Apple Silicon: `Alibaba-NLP/gte-multilingual-base`
+has been observed to develop in-process NaN corruption during very large
+audits with tens of thousands of pages. For large sites on that platform, use
+the default `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`.
+
 ```bash
 site-audit serve <domain> [--projects-root projects/] [--port 8765]
 ```

--- a/site_audit/embedder.py
+++ b/site_audit/embedder.py
@@ -165,6 +165,12 @@ class Embedder:
         segfaults once faiss has loaded libomp); (3) with ``zero_fill_bad``
         zero the surviving bad rows so a long audit degrades instead of
         dying — otherwise raise.
+
+        Step (2) is skipped and (3) applied directly if the *entire* chunk
+        is still non-finite after step (1), since whole-chunk failure
+        correlates with corrupted in-process model weights rather than a
+        transient error, and the CPU rung would otherwise burn hours
+        re-encoding rows that are never going to recover.
         """
         if not texts:
             return np.zeros((0, 0), dtype=np.float32)
@@ -188,6 +194,21 @@ class Embedder:
             bad = _non_finite_row_indices(arr)
             if bad.size == 0:
                 return arr
+            if bad.size == len(texts):
+                action = "zero-filling the chunk" if zero_fill_bad else "raising"
+                LOG.warning(
+                    "All %d/%d vectors in this chunk are non-finite after an "
+                    "accelerator reload; this usually means the model's "
+                    "in-process weights are corrupted (not a transient error); "
+                    "skipping the slow CPU-per-row rescue and %s",
+                    bad.size, len(texts), action,
+                )
+                if zero_fill_bad:
+                    arr[bad] = 0.0
+                    return arr
+                raise RuntimeError(
+                    f"Embedding model returned {bad.size}/{len(texts)} non-finite vectors"
+                )
             LOG.warning(
                 "%d vectors still non-finite after accelerator retry; "
                 "re-encoding those rows on CPU",

--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -60,7 +60,11 @@ class CpuFallbackEmbedder(Embedder):
     ) -> np.ndarray:
         if self._device == "cpu":
             return np.asarray([[1.0, 0.0] for _ in texts], dtype=np.float32)
-        return np.asarray([[np.nan, np.nan] for _ in texts], dtype=np.float32)
+        arr = np.ones((len(texts), 2), dtype=np.float32)
+        for idx, text in enumerate(texts):
+            if text == "bad":
+                arr[idx] = np.nan
+        return arr
 
 
 class FakeModel:
@@ -98,10 +102,10 @@ def test_encode_pages_persists_embedding_cache_in_chunks(monkeypatch) -> None:
 
 
 def test_encode_retries_non_finite_embeddings_on_cpu() -> None:
-    embeddings = CpuFallbackEmbedder().encode(["text"], batch_size=1)
+    embeddings = CpuFallbackEmbedder().encode(["ok", "bad"], batch_size=1)
 
     assert np.isfinite(embeddings).all()
-    assert embeddings.tolist() == [[1.0, 0.0]]
+    assert embeddings.tolist() == [[1.0, 1.0], [1.0, 0.0]]
 
 
 def test_embedder_caps_model_max_sequence_length() -> None:
@@ -212,6 +216,34 @@ def test_cpu_fallback_reencodes_only_still_bad_rows() -> None:
     assert emb.calls[2] == ("cpu", ["a", "c"])
 
 
+def test_whole_chunk_failure_zero_fills_without_cpu_fallback() -> None:
+    emb = ScriptedEmbedder([_nan_at([0, 1, 2]), _nan_at([0, 1, 2])])
+
+    result = emb.encode(["a", "b", "c"], zero_fill_bad=True)
+
+    assert np.isfinite(result).all()
+    assert not result.any()
+    assert [device for device, _ in emb.calls] == [None, None]
+
+
+def test_whole_chunk_failure_raises_without_cpu_fallback() -> None:
+    emb = ScriptedEmbedder([_nan_at([0, 1, 2]), _nan_at([0, 1, 2])])
+
+    with pytest.raises(RuntimeError, match="3/3 non-finite"):
+        emb.encode(["a", "b", "c"])
+
+    assert [device for device, _ in emb.calls] == [None, None]
+
+
+def test_chunk_size_one_failure_zero_fills_without_cpu_fallback() -> None:
+    emb = ScriptedEmbedder([_nan_at([0]), _nan_at([0])])
+
+    result = emb.encode(["a"], batch_size=1, zero_fill_bad=True)
+
+    assert result.tolist() == [[0.0, 0.0, 0.0]]
+    assert [device for device, _ in emb.calls] == [None, None]
+
+
 def test_raises_when_rows_stay_non_finite() -> None:
     emb = ScriptedEmbedder([_nan_at([1]), _nan_at([0]), _nan_at([0])])
 
@@ -230,7 +262,7 @@ def test_encode_reloads_model_before_each_retry() -> None:
 
     emb._ensure = tracking_ensure
 
-    result = emb.encode(["a"])
+    result = emb.encode(["a", "b"])
 
     assert np.isfinite(result).all()
     # initial load, accelerator reload, CPU reload
@@ -324,7 +356,7 @@ def test_encode_and_cache_skips_zero_rows_and_logs_identifiers(caplog) -> None:
 def test_encode_returns_to_accelerator_after_cpu_fallback() -> None:
     emb = ScriptedEmbedder([_nan_at([0]), _nan_at([0]), _finite, _finite])
 
-    first = emb.encode(["a"])
+    first = emb.encode(["a", "ok"])
     second = emb.encode(["b"])
 
     assert np.isfinite(first).all()
@@ -364,7 +396,7 @@ def test_reload_defeats_real_ensure_early_return(monkeypatch) -> None:
         def _clear_accelerator_cache(self) -> None:
             pass
 
-    result = RealEnsureEmbedder().encode(["a"])
+    result = RealEnsureEmbedder().encode(["a", "b"])
 
     assert np.isfinite(result).all()
     # initial load, accelerator reload, cpu reload — three constructions


### PR DESCRIPTION
Closes #298

## What

On the 51k-page etabletka.sk audit, one embedding chunk came back entirely non-finite even after the model reload added in #297, and the same rows stayed non-finite after a multi-hour single-threaded CPU rung — the CPU rung was pure wasted time for a whole-chunk failure, which correlates with in-process model corruption rather than a transient/fixable error.

- `Embedder.encode`: when the accelerator-reload retry still leaves the **entire** chunk non-finite (`bad.size == len(texts)`), skip the CPU rung and go straight to zero-fill/raise. Partial-chunk failures (some rows bad, not all) are unaffected — that's the case #297 was built for and it works there.
- README note: `gte-multilingual-base` has shown this corruption on large Apple Silicon audits; MiniLM (the default) is recommended for large sites.

Scope note: the issue's follow-up #2 (subprocess isolation / stage reordering) is intentionally NOT addressed here — it's a larger architectural change to consider separately.

## Review

Verified by execution: the accelerator reload always runs unconditionally first; only the second (CPU) rung is conditionally skipped; new tests assert zero CPU calls occurred (not just output correctness) for whole-chunk cases; the pre-existing partial-chunk CPU-rescue test is unweakened. Docstring updated to document the new short-circuit.

## Tests

`pytest -q`: 711 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)